### PR TITLE
feat: Sprint 4 — AI quality, validation, and park discovery

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -646,6 +646,8 @@ model DataSource {
   crawlStatus      CrawlStatus   @default(PENDING)
   crawlError       String?       @db.Text
   robotsOverride   Boolean       @default(false)
+  approveCount     Int           @default(0)
+  rejectCount      Int           @default(0)
 
   park              Park                    @relation(fields: [parkId], references: [id], onDelete: Cascade)
   fieldExtractions  FieldExtraction[]
@@ -724,4 +726,45 @@ model ResearchSessionSource {
   dataSource DataSource      @relation(fields: [dataSourceId], references: [id], onDelete: Cascade)
 
   @@unique([sessionId, dataSourceId])
+}
+
+// ── Domain Reliability (OP-78) ────────────────────────────────────────────
+
+model DomainReliability {
+  id                 String   @id @default(cuid())
+  domainPattern      String   @unique  // e.g. "riderplanet-usa.com", ".gov"
+  defaultReliability Int      @default(50)
+  isBlocked          Boolean  @default(false)
+  notes              String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+// ── Park Discovery (OP-85) ────────────────────────────────────────────────
+
+enum ParkCandidateStatus {
+  PENDING
+  ACCEPTED
+  REJECTED
+}
+
+model ParkCandidate {
+  id              String               @id @default(cuid())
+  name            String
+  state           String
+  city            String?
+  estimatedLat    Float?
+  estimatedLng    Float?
+  sourceUrl       String?
+  status          ParkCandidateStatus  @default(PENDING)
+  rejectedReason  String?
+  seededParkId    String?              // Set when ACCEPTED → Park created
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([name, state])
+  @@index([status])
+  @@index([state])
 }

--- a/src/app/admin/ai-research/conflicts/page.tsx
+++ b/src/app/admin/ai-research/conflicts/page.tsx
@@ -1,0 +1,35 @@
+// TODO OP-84: Field Conflict Resolution UI
+// When multiple sources disagree on a field value, surface conflicts
+// in review queue with side-by-side source comparison.
+
+export default function ConflictsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">
+          Field Conflicts
+        </h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Review and resolve conflicting field values from multiple sources.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
+        <div className="text-gray-400 text-4xl mb-4">
+          {"{ }"}
+        </div>
+        <h2 className="text-lg font-semibold text-gray-700">
+          Coming Soon — OP-84
+        </h2>
+        <p className="mt-2 text-sm text-gray-500 max-w-md mx-auto">
+          Field Conflict Resolution UI. When multiple sources disagree on a
+          field value, this page will show side-by-side comparisons with source
+          reliability context and smart resolution suggestions.
+        </p>
+        <p className="mt-4 text-xs text-gray-400">
+          Depends on OP-83 (Multi-Source Cross-Validation)
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/ai-research/discovery/page.tsx
+++ b/src/app/admin/ai-research/discovery/page.tsx
@@ -1,0 +1,142 @@
+import { prisma } from "@/lib/prisma";
+import { ParkDiscoveryTable } from "@/components/admin/ParkDiscoveryTable";
+import type { ParkCandidateStatus, ParkCandidateSummary } from "@/lib/types";
+
+export default async function ParkDiscoveryPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string; state?: string }>;
+}) {
+  const params = await searchParams;
+  const statusFilter = params.status || "PENDING";
+
+  const where: { status?: ParkCandidateStatus; state?: string } = {};
+  if (statusFilter && statusFilter !== "ALL") {
+    where.status = statusFilter as ParkCandidateStatus;
+  }
+  if (params.state) {
+    where.state = params.state.toUpperCase();
+  }
+
+  const [candidates, totalAll, totalPending, totalAccepted, totalRejected] =
+    await Promise.all([
+      prisma.parkCandidate.findMany({
+        where,
+        orderBy: [{ state: "asc" }, { name: "asc" }],
+      }),
+      prisma.parkCandidate.count(),
+      prisma.parkCandidate.count({ where: { status: "PENDING" } }),
+      prisma.parkCandidate.count({ where: { status: "ACCEPTED" } }),
+      prisma.parkCandidate.count({ where: { status: "REJECTED" } }),
+    ]);
+
+  const summaries: ParkCandidateSummary[] = candidates.map((c) => ({
+    id: c.id,
+    name: c.name,
+    state: c.state,
+    city: c.city,
+    estimatedLat: c.estimatedLat,
+    estimatedLng: c.estimatedLng,
+    sourceUrl: c.sourceUrl,
+    status: c.status as ParkCandidateStatus,
+    rejectedReason: c.rejectedReason,
+    seededParkId: c.seededParkId,
+    createdAt: c.createdAt.toISOString(),
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Park Discovery</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Review AI-discovered park candidates and seed them into the database.
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-4 gap-4">
+        <StatCard label="Total Candidates" value={totalAll} />
+        <StatCard label="Pending" value={totalPending} color="gray" />
+        <StatCard label="Accepted" value={totalAccepted} color="green" />
+        <StatCard label="Rejected" value={totalRejected} color="red" />
+      </div>
+
+      {/* Status Filter */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-gray-700">Filter:</span>
+        <StatusFilterLink
+          href="/admin/ai-research/discovery"
+          label="All"
+          active={statusFilter === "ALL"}
+        />
+        <StatusFilterLink
+          href="/admin/ai-research/discovery?status=PENDING"
+          label="Pending"
+          active={statusFilter === "PENDING"}
+        />
+        <StatusFilterLink
+          href="/admin/ai-research/discovery?status=ACCEPTED"
+          label="Accepted"
+          active={statusFilter === "ACCEPTED"}
+        />
+        <StatusFilterLink
+          href="/admin/ai-research/discovery?status=REJECTED"
+          label="Rejected"
+          active={statusFilter === "REJECTED"}
+        />
+      </div>
+
+      <ParkDiscoveryTable candidates={summaries} />
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color?: "gray" | "green" | "red";
+}) {
+  const colorStyles = {
+    gray: "text-gray-900",
+    green: "text-green-700",
+    red: "text-red-700",
+  };
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <p className="text-xs font-medium text-gray-500 uppercase">{label}</p>
+      <p
+        className={`text-2xl font-bold mt-1 ${color ? colorStyles[color] : "text-gray-900"}`}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function StatusFilterLink({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
+  return (
+    <a
+      href={href}
+      className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+        active
+          ? "bg-gray-900 text-white"
+          : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+      }`}
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/app/admin/ai-research/page.tsx
+++ b/src/app/admin/ai-research/page.tsx
@@ -1,10 +1,12 @@
 import { prisma } from "@/lib/prisma";
+import { getDomainAccuracyStats } from "@/lib/ai/feedback-loop";
 import Link from "next/link";
 import {
   BrainCircuit,
   DollarSign,
   FileSearch,
   AlertCircle,
+  BarChart3,
 } from "lucide-react";
 
 export default async function AIResearchPage() {
@@ -18,6 +20,7 @@ export default async function AIResearchPage() {
     totalSessions,
     costResult,
     recentSessions,
+    domainAccuracy,
   ] = await Promise.all([
     prisma.park.count(),
     prisma.park.count({ where: { researchStatus: "NEEDS_RESEARCH" } }),
@@ -32,6 +35,7 @@ export default async function AIResearchPage() {
       orderBy: { createdAt: "desc" },
       take: 10,
     }),
+    getDomainAccuracyStats(),
   ]);
 
   const totalCost = costResult._sum.estimatedCostUSD ?? 0;
@@ -104,6 +108,55 @@ export default async function AIResearchPage() {
             <p className="mt-1 text-2xl font-bold text-blue-900">{maintenance}</p>
           </div>
         </div>
+      </div>
+
+      {/* Domain Accuracy */}
+      <div className="rounded-lg border border-gray-200 bg-white p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <BarChart3 className="w-5 h-5 text-gray-500" />
+          <h2 className="text-lg font-semibold text-gray-900">Domain Accuracy</h2>
+        </div>
+        {domainAccuracy.length === 0 ? (
+          <p className="text-gray-500 text-sm">No extraction reviews yet. Approve or reject extractions to see accuracy data.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead>
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Domain</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Approves</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Rejects</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Accuracy %</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Sources</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {domainAccuracy.map((d) => {
+                  const pct = Math.round(d.accuracy * 100);
+                  const colorClass =
+                    pct >= 70
+                      ? "text-green-700"
+                      : pct >= 40
+                        ? "text-yellow-700"
+                        : "text-red-700";
+                  return (
+                    <tr key={d.domain} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{d.domain}</td>
+                      <td className="px-4 py-3 text-sm text-gray-900">{d.totalApproves}</td>
+                      <td className="px-4 py-3 text-sm text-gray-900">{d.totalRejects}</td>
+                      <td className="px-4 py-3">
+                        <span className={`text-sm font-medium ${colorClass}`}>
+                          {pct}%
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-900">{d.sourceCount}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       {/* Recent Sessions */}

--- a/src/app/admin/ai-research/sources/page.tsx
+++ b/src/app/admin/ai-research/sources/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
-import type { DataSourceSummary } from "@/lib/types";
+import type { DataSourceSummary, DomainReliabilitySummary } from "@/lib/types";
 import { SourceManagementTable } from "@/components/admin/SourceManagementTable";
+import { DomainReliabilityTable } from "@/components/admin/DomainReliabilityTable";
 
 export default async function SourcesPage({
   searchParams,
@@ -8,6 +9,20 @@ export default async function SourcesPage({
   searchParams: Promise<{ parkId?: string }>;
 }) {
   const { parkId } = await searchParams;
+
+  // Fetch domain reliability entries for the top section
+  const domainEntries = await prisma.domainReliability.findMany({
+    orderBy: { defaultReliability: "desc" },
+  });
+
+  const domainSummaries: DomainReliabilitySummary[] = domainEntries.map((d) => ({
+    id: d.id,
+    domainPattern: d.domainPattern,
+    defaultReliability: d.defaultReliability,
+    isBlocked: d.isBlocked,
+    notes: d.notes,
+    createdAt: d.createdAt.toISOString(),
+  }));
 
   // If no parkId, show park list for selection
   if (!parkId) {
@@ -27,6 +42,12 @@ export default async function SourcesPage({
     return (
       <div className="space-y-6">
         <h1 className="text-2xl font-bold text-gray-900">Data Sources</h1>
+
+        {/* Domain Reliability Section */}
+        <DomainReliabilityTable domains={domainSummaries} />
+
+        <hr className="border-gray-200" />
+
         <p className="text-sm text-gray-500">Select a park to manage its data sources.</p>
         <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
@@ -91,6 +112,8 @@ export default async function SourcesPage({
     contentChanged: s.contentChanged,
     crawlStatus: s.crawlStatus,
     crawlError: s.crawlError,
+    approveCount: s.approveCount,
+    rejectCount: s.rejectCount,
     createdAt: s.createdAt.toISOString(),
   }));
 
@@ -100,6 +123,12 @@ export default async function SourcesPage({
         <a href="/admin/ai-research/sources" className="text-sm text-blue-600 hover:text-blue-800">&larr; All Parks</a>
         <h1 className="text-2xl font-bold text-gray-900 mt-2">Sources: {park.name}</h1>
       </div>
+
+      {/* Domain Reliability Section */}
+      <DomainReliabilityTable domains={domainSummaries} />
+
+      <hr className="border-gray-200" />
+
       <SourceManagementTable sources={summaries} parkId={parkId} />
     </div>
   );

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -14,6 +14,7 @@ import {
   MapPin,
   MessageSquare,
   PlusCircle,
+  Search,
   Settings,
   Upload,
   Users,
@@ -159,6 +160,13 @@ export default async function AdminLayout({
             >
               <Globe className="w-4 h-4" />
               <span className="font-medium text-sm">Sources</span>
+            </Link>
+            <Link
+              href="/admin/ai-research/discovery"
+              className="flex items-center gap-3 px-4 py-3 text-gray-700 rounded-lg hover:bg-gray-100 transition-colors pl-8"
+            >
+              <Search className="w-4 h-4" />
+              <span className="font-medium text-sm">Park Discovery</span>
             </Link>
             <Link
               href="/admin/users"

--- a/src/app/api/admin/ai-research/dashboard/route.ts
+++ b/src/app/api/admin/ai-research/dashboard/route.ts
@@ -56,6 +56,9 @@ export async function GET() {
     completedAt: s.completedAt?.toISOString() ?? null,
   }));
 
+  const { getDomainAccuracyStats } = await import("@/lib/ai/feedback-loop");
+  const domainAccuracy = await getDomainAccuracyStats();
+
   const dashboard: AIResearchDashboard = {
     totalParks,
     parksByResearchStatus,
@@ -63,6 +66,7 @@ export async function GET() {
     totalSessions,
     totalCostUSD: costResult._sum.estimatedCostUSD ?? 0,
     recentSessions,
+    domainAccuracy,
   };
 
   return NextResponse.json(dashboard);

--- a/src/app/api/admin/ai-research/discovery/candidates/route.ts
+++ b/src/app/api/admin/ai-research/discovery/candidates/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-helpers";
+import { prisma } from "@/lib/prisma";
+import { researchPark } from "@/lib/ai/research-pipeline";
+import type { ParkCandidateStatus, ParkCandidateSummary } from "@/lib/types";
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+async function ensureUniqueSlug(baseSlug: string): Promise<string> {
+  let slug = baseSlug;
+  let counter = 1;
+  while (true) {
+    const existing = await prisma.park.findUnique({ where: { slug } });
+    if (!existing) return slug;
+    counter++;
+    slug = `${baseSlug}-${counter}`;
+  }
+}
+
+// GET — List ParkCandidate records
+export async function GET(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get("status") || "PENDING";
+  const state = searchParams.get("state");
+
+  const where: { status?: ParkCandidateStatus; state?: string } = {};
+  if (status && status !== "ALL") {
+    where.status = status as ParkCandidateStatus;
+  }
+  if (state) {
+    where.state = state.toUpperCase();
+  }
+
+  const [candidates, total] = await Promise.all([
+    prisma.parkCandidate.findMany({
+      where,
+      orderBy: [{ state: "asc" }, { name: "asc" }],
+    }),
+    prisma.parkCandidate.count({ where }),
+  ]);
+
+  const summaries: ParkCandidateSummary[] = candidates.map((c) => ({
+    id: c.id,
+    name: c.name,
+    state: c.state,
+    city: c.city,
+    estimatedLat: c.estimatedLat,
+    estimatedLng: c.estimatedLng,
+    sourceUrl: c.sourceUrl,
+    status: c.status as ParkCandidateStatus,
+    rejectedReason: c.rejectedReason,
+    seededParkId: c.seededParkId,
+    createdAt: c.createdAt.toISOString(),
+  }));
+
+  return NextResponse.json({ candidates: summaries, total });
+}
+
+// PATCH — Accept or reject a candidate
+export async function PATCH(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  let body: { candidateId?: string; action?: string; rejectedReason?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { candidateId, action, rejectedReason } = body;
+
+  if (!candidateId || !action) {
+    return NextResponse.json(
+      { error: "candidateId and action are required" },
+      { status: 400 }
+    );
+  }
+
+  if (action !== "accept" && action !== "reject") {
+    return NextResponse.json(
+      { error: "action must be 'accept' or 'reject'" },
+      { status: 400 }
+    );
+  }
+
+  const candidate = await prisma.parkCandidate.findUnique({
+    where: { id: candidateId },
+  });
+
+  if (!candidate) {
+    return NextResponse.json(
+      { error: "Candidate not found" },
+      { status: 404 }
+    );
+  }
+
+  if (candidate.status !== "PENDING") {
+    return NextResponse.json(
+      { error: `Candidate is already ${candidate.status}` },
+      { status: 400 }
+    );
+  }
+
+  if (action === "reject") {
+    await prisma.parkCandidate.update({
+      where: { id: candidateId },
+      data: {
+        status: "REJECTED",
+        rejectedReason: rejectedReason || null,
+      },
+    });
+    return NextResponse.json({ success: true });
+  }
+
+  // action === "accept"
+  try {
+    const slug = await ensureUniqueSlug(generateSlug(candidate.name));
+
+    const result = await prisma.$transaction(async (tx) => {
+      const park = await tx.park.create({
+        data: {
+          name: candidate.name,
+          slug,
+          status: "APPROVED",
+          researchStatus: "NEEDS_RESEARCH",
+          latitude: candidate.estimatedLat,
+          longitude: candidate.estimatedLng,
+        },
+      });
+
+      await tx.address.create({
+        data: {
+          parkId: park.id,
+          state: candidate.state,
+          city: candidate.city,
+        },
+      });
+
+      await tx.parkCandidate.update({
+        where: { id: candidateId },
+        data: {
+          status: "ACCEPTED",
+          seededParkId: park.id,
+        },
+      });
+
+      return { parkId: park.id, parkSlug: park.slug };
+    });
+
+    // Fire-and-forget: trigger research on the new park
+    researchPark(result.parkId, "NEW_PARK_SEEDED").catch((err) => {
+      console.error(
+        `[discovery] Failed to start research for park ${result.parkId}:`,
+        err
+      );
+    });
+
+    return NextResponse.json({
+      success: true,
+      parkId: result.parkId,
+      parkSlug: result.parkSlug,
+    });
+  } catch (error) {
+    console.error("[discovery] Error accepting candidate:", error);
+    return NextResponse.json(
+      { error: "Failed to accept candidate" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/ai-research/discovery/route.ts
+++ b/src/app/api/admin/ai-research/discovery/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-helpers";
+import { discoverParksInState } from "@/lib/ai/park-discovery";
+import { estimateCost } from "@/lib/ai/config";
+
+export async function POST(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  let body: { state?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const { state } = body;
+
+  if (!state || typeof state !== "string" || state.length !== 2) {
+    return NextResponse.json(
+      { error: "state must be a two-letter abbreviation" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { candidates, inputTokens, outputTokens } =
+      await discoverParksInState(state.toUpperCase());
+
+    return NextResponse.json({
+      success: true,
+      candidatesFound: candidates.length,
+      inputTokens,
+      outputTokens,
+      estimatedCost: estimateCost(inputTokens, outputTokens),
+    });
+  } catch (error) {
+    console.error("[discovery] Error discovering parks:", error);
+    return NextResponse.json(
+      { error: "Discovery failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/ai-research/domains/route.ts
+++ b/src/app/api/admin/ai-research/domains/route.ts
@@ -1,0 +1,172 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-helpers";
+import { prisma } from "@/lib/prisma";
+import type { DomainReliabilitySummary } from "@/lib/types";
+
+export async function GET() {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  const domains = await prisma.domainReliability.findMany({
+    orderBy: { defaultReliability: "desc" },
+  });
+
+  const results: DomainReliabilitySummary[] = domains.map((d) => ({
+    id: d.id,
+    domainPattern: d.domainPattern,
+    defaultReliability: d.defaultReliability,
+    isBlocked: d.isBlocked,
+    notes: d.notes,
+    createdAt: d.createdAt.toISOString(),
+  }));
+
+  return NextResponse.json({ domains: results });
+}
+
+export async function POST(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  const body = await request.json();
+  const { domainPattern, defaultReliability, isBlocked, notes } = body;
+
+  if (!domainPattern || typeof domainPattern !== "string" || !domainPattern.trim()) {
+    return NextResponse.json(
+      { error: "domainPattern is required" },
+      { status: 400 }
+    );
+  }
+
+  if (
+    defaultReliability === undefined ||
+    typeof defaultReliability !== "number" ||
+    defaultReliability < 0 ||
+    defaultReliability > 100
+  ) {
+    return NextResponse.json(
+      { error: "defaultReliability must be a number between 0 and 100" },
+      { status: 400 }
+    );
+  }
+
+  // Check for duplicates
+  const existing = await prisma.domainReliability.findUnique({
+    where: { domainPattern: domainPattern.trim() },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "Domain pattern already exists" },
+      { status: 409 }
+    );
+  }
+
+  const domain = await prisma.domainReliability.create({
+    data: {
+      domainPattern: domainPattern.trim(),
+      defaultReliability,
+      isBlocked: isBlocked ?? false,
+      notes: notes || null,
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+    domain: {
+      id: domain.id,
+      domainPattern: domain.domainPattern,
+      defaultReliability: domain.defaultReliability,
+      isBlocked: domain.isBlocked,
+      notes: domain.notes,
+      createdAt: domain.createdAt.toISOString(),
+    } satisfies DomainReliabilitySummary,
+  });
+}
+
+export async function PATCH(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  const body = await request.json();
+  const { id, defaultReliability, isBlocked, notes } = body;
+
+  if (!id) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  const existing = await prisma.domainReliability.findUnique({
+    where: { id },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Domain entry not found" },
+      { status: 404 }
+    );
+  }
+
+  const updateData: Record<string, unknown> = {};
+
+  if (defaultReliability !== undefined) {
+    if (
+      typeof defaultReliability !== "number" ||
+      defaultReliability < 0 ||
+      defaultReliability > 100
+    ) {
+      return NextResponse.json(
+        { error: "defaultReliability must be between 0 and 100" },
+        { status: 400 }
+      );
+    }
+    updateData.defaultReliability = defaultReliability;
+  }
+
+  if (isBlocked !== undefined) {
+    updateData.isBlocked = Boolean(isBlocked);
+  }
+
+  if (notes !== undefined) {
+    updateData.notes = notes || null;
+  }
+
+  const updated = await prisma.domainReliability.update({
+    where: { id },
+    data: updateData,
+  });
+
+  return NextResponse.json({
+    success: true,
+    domain: {
+      id: updated.id,
+      domainPattern: updated.domainPattern,
+      defaultReliability: updated.defaultReliability,
+      isBlocked: updated.isBlocked,
+      notes: updated.notes,
+      createdAt: updated.createdAt.toISOString(),
+    } satisfies DomainReliabilitySummary,
+  });
+}
+
+export async function DELETE(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  const body = await request.json();
+  const { id } = body;
+
+  if (!id) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  const existing = await prisma.domainReliability.findUnique({
+    where: { id },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Domain entry not found" },
+      { status: 404 }
+    );
+  }
+
+  await prisma.domainReliability.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/ai-research/extractions/[id]/approve/route.ts
+++ b/src/app/api/admin/ai-research/extractions/[id]/approve/route.ts
@@ -187,5 +187,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     }
   });
 
+  // OP-79: Record feedback for accuracy tracking
+  if (extraction.dataSourceId) {
+    const { recordFeedback } = await import("@/lib/ai/feedback-loop");
+    recordFeedback(extraction.dataSourceId, "approve").catch(() => {});
+  }
+
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/admin/ai-research/extractions/[id]/reject/route.ts
+++ b/src/app/api/admin/ai-research/extractions/[id]/reject/route.ts
@@ -10,7 +10,10 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   const { id } = await params;
 
-  const extraction = await prisma.fieldExtraction.findUnique({ where: { id } });
+  const extraction = await prisma.fieldExtraction.findUnique({
+    where: { id },
+    select: { id: true, status: true, dataSourceId: true },
+  });
   if (!extraction) {
     return NextResponse.json({ error: "Extraction not found" }, { status: 404 });
   }
@@ -26,6 +29,12 @@ export async function POST(_request: Request, { params }: RouteParams) {
       verifiedBy: adminResult.user.id,
     },
   });
+
+  // OP-79: Record feedback for accuracy tracking
+  if (extraction.dataSourceId) {
+    const { recordFeedback } = await import("@/lib/ai/feedback-loop");
+    recordFeedback(extraction.dataSourceId, "reject").catch(() => {});
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/admin/ai-research/sources/route.ts
+++ b/src/app/api/admin/ai-research/sources/route.ts
@@ -33,6 +33,8 @@ export async function GET(request: Request) {
     contentChanged: s.contentChanged,
     crawlStatus: s.crawlStatus,
     crawlError: s.crawlError,
+    approveCount: s.approveCount,
+    rejectCount: s.rejectCount,
     createdAt: s.createdAt.toISOString(),
   }));
 

--- a/src/components/admin/DomainReliabilityTable.tsx
+++ b/src/components/admin/DomainReliabilityTable.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Pencil, Trash2, Check, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { DomainReliabilitySummary } from "@/lib/types";
+
+type Props = {
+  domains: DomainReliabilitySummary[];
+};
+
+export function DomainReliabilityTable({ domains }: Props) {
+  const router = useRouter();
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // Add form state
+  const [newPattern, setNewPattern] = useState("");
+  const [newReliability, setNewReliability] = useState(50);
+  const [newBlocked, setNewBlocked] = useState(false);
+  const [newNotes, setNewNotes] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  // Edit form state
+  const [editReliability, setEditReliability] = useState(50);
+  const [editBlocked, setEditBlocked] = useState(false);
+  const [editNotes, setEditNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newPattern.trim()) return;
+
+    setAdding(true);
+    try {
+      const response = await fetch("/api/admin/ai-research/domains", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          domainPattern: newPattern.trim(),
+          defaultReliability: newReliability,
+          isBlocked: newBlocked,
+          notes: newNotes.trim() || null,
+        }),
+      });
+      if (response.ok) {
+        setNewPattern("");
+        setNewReliability(50);
+        setNewBlocked(false);
+        setNewNotes("");
+        setShowAddForm(false);
+        router.refresh();
+      } else {
+        const data = await response.json();
+        alert(data.error || "Failed to add domain");
+      }
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const startEdit = (domain: DomainReliabilitySummary) => {
+    setEditingId(domain.id);
+    setEditReliability(domain.defaultReliability);
+    setEditBlocked(domain.isBlocked);
+    setEditNotes(domain.notes || "");
+  };
+
+  const handleSave = async (id: string) => {
+    setSaving(true);
+    try {
+      const response = await fetch("/api/admin/ai-research/domains", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id,
+          defaultReliability: editReliability,
+          isBlocked: editBlocked,
+          notes: editNotes.trim() || null,
+        }),
+      });
+      if (response.ok) {
+        setEditingId(null);
+        router.refresh();
+      } else {
+        const data = await response.json();
+        alert(data.error || "Failed to update domain");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string, pattern: string) => {
+    if (!confirm(`Delete domain entry "${pattern}"?`)) return;
+
+    try {
+      const response = await fetch("/api/admin/ai-research/domains", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      });
+      if (response.ok) {
+        router.refresh();
+      } else {
+        const data = await response.json();
+        alert(data.error || "Failed to delete domain");
+      }
+    } catch {
+      alert("Network error");
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Domain Reliability
+          </h2>
+          <p className="text-xs text-gray-500">
+            Default reliability scores assigned to new sources based on their
+            domain. Suffix patterns (e.g. .gov) match all subdomains.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => setShowAddForm(!showAddForm)}
+        >
+          <Plus className="w-4 h-4 mr-1" />
+          Add Domain
+        </Button>
+      </div>
+
+      {/* Add form */}
+      {showAddForm && (
+        <form
+          onSubmit={handleAdd}
+          className="rounded-lg border border-gray-200 bg-white p-4 space-y-3"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Domain Pattern
+              </label>
+              <input
+                type="text"
+                value={newPattern}
+                onChange={(e) => setNewPattern(e.target.value)}
+                placeholder=".gov or example.com"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Reliability (0-100)
+              </label>
+              <input
+                type="number"
+                value={newReliability}
+                onChange={(e) => setNewReliability(Number(e.target.value))}
+                min={0}
+                max={100}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Notes
+              </label>
+              <input
+                type="text"
+                value={newNotes}
+                onChange={(e) => setNewNotes(e.target.value)}
+                placeholder="Optional description"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex items-end gap-3">
+              <label className="flex items-center gap-2 text-sm text-gray-700 pb-2">
+                <input
+                  type="checkbox"
+                  checked={newBlocked}
+                  onChange={(e) => setNewBlocked(e.target.checked)}
+                  className="rounded border-gray-300"
+                />
+                Blocked
+              </label>
+              <Button type="submit" size="sm" disabled={adding}>
+                Add
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowAddForm(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </form>
+      )}
+
+      {/* Table */}
+      {domains.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+          <p className="text-gray-500 text-sm">
+            No domain reliability entries yet. Add one above.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Domain Pattern
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Reliability
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Notes
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {domains.map((domain) => (
+                <tr key={domain.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm font-mono text-gray-900">
+                    {domain.domainPattern}
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingId === domain.id ? (
+                      <input
+                        type="number"
+                        value={editReliability}
+                        onChange={(e) =>
+                          setEditReliability(Number(e.target.value))
+                        }
+                        min={0}
+                        max={100}
+                        className="w-20 rounded-md border border-gray-300 px-2 py-1 text-sm"
+                      />
+                    ) : (
+                      <span
+                        className={`text-sm font-medium ${
+                          domain.defaultReliability >= 70
+                            ? "text-green-700"
+                            : domain.defaultReliability >= 40
+                              ? "text-yellow-700"
+                              : "text-red-700"
+                        }`}
+                      >
+                        {domain.defaultReliability}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingId === domain.id ? (
+                      <label className="flex items-center gap-2 text-sm text-gray-700">
+                        <input
+                          type="checkbox"
+                          checked={editBlocked}
+                          onChange={(e) => setEditBlocked(e.target.checked)}
+                          className="rounded border-gray-300"
+                        />
+                        Blocked
+                      </label>
+                    ) : domain.isBlocked ? (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-red-100 text-red-800 border-red-200">
+                        Blocked
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-green-100 text-green-800 border-green-200">
+                        Active
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingId === domain.id ? (
+                      <input
+                        type="text"
+                        value={editNotes}
+                        onChange={(e) => setEditNotes(e.target.value)}
+                        className="w-full rounded-md border border-gray-300 px-2 py-1 text-sm"
+                      />
+                    ) : (
+                      <span className="text-sm text-gray-500">
+                        {domain.notes || "--"}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-1">
+                      {editingId === domain.id ? (
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => handleSave(domain.id)}
+                            disabled={saving}
+                            title="Save"
+                            className="text-green-600 hover:text-green-700 hover:bg-green-50"
+                          >
+                            <Check className="w-4 h-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => setEditingId(null)}
+                            title="Cancel"
+                            className="text-gray-400 hover:text-gray-600 hover:bg-gray-50"
+                          >
+                            <X className="w-4 h-4" />
+                          </Button>
+                        </>
+                      ) : (
+                        <>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() => startEdit(domain)}
+                            title="Edit"
+                            className="text-gray-400 hover:text-blue-600 hover:bg-blue-50"
+                          >
+                            <Pencil className="w-4 h-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() =>
+                              handleDelete(domain.id, domain.domainPattern)
+                            }
+                            title="Delete"
+                            className="text-gray-400 hover:text-red-600 hover:bg-red-50"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/ParkDiscoveryTable.tsx
+++ b/src/components/admin/ParkDiscoveryTable.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  CheckCircle,
+  XCircle,
+  ExternalLink,
+  Loader2,
+  Search,
+  CheckCheck,
+  XOctagon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ParkCandidateSummary } from "@/lib/types";
+import Link from "next/link";
+
+const US_STATES = [
+  { value: "AL", label: "Alabama" },
+  { value: "AK", label: "Alaska" },
+  { value: "AZ", label: "Arizona" },
+  { value: "AR", label: "Arkansas" },
+  { value: "CA", label: "California" },
+  { value: "CO", label: "Colorado" },
+  { value: "CT", label: "Connecticut" },
+  { value: "DE", label: "Delaware" },
+  { value: "FL", label: "Florida" },
+  { value: "GA", label: "Georgia" },
+  { value: "HI", label: "Hawaii" },
+  { value: "ID", label: "Idaho" },
+  { value: "IL", label: "Illinois" },
+  { value: "IN", label: "Indiana" },
+  { value: "IA", label: "Iowa" },
+  { value: "KS", label: "Kansas" },
+  { value: "KY", label: "Kentucky" },
+  { value: "LA", label: "Louisiana" },
+  { value: "ME", label: "Maine" },
+  { value: "MD", label: "Maryland" },
+  { value: "MA", label: "Massachusetts" },
+  { value: "MI", label: "Michigan" },
+  { value: "MN", label: "Minnesota" },
+  { value: "MS", label: "Mississippi" },
+  { value: "MO", label: "Missouri" },
+  { value: "MT", label: "Montana" },
+  { value: "NE", label: "Nebraska" },
+  { value: "NV", label: "Nevada" },
+  { value: "NH", label: "New Hampshire" },
+  { value: "NJ", label: "New Jersey" },
+  { value: "NM", label: "New Mexico" },
+  { value: "NY", label: "New York" },
+  { value: "NC", label: "North Carolina" },
+  { value: "ND", label: "North Dakota" },
+  { value: "OH", label: "Ohio" },
+  { value: "OK", label: "Oklahoma" },
+  { value: "OR", label: "Oregon" },
+  { value: "PA", label: "Pennsylvania" },
+  { value: "RI", label: "Rhode Island" },
+  { value: "SC", label: "South Carolina" },
+  { value: "SD", label: "South Dakota" },
+  { value: "TN", label: "Tennessee" },
+  { value: "TX", label: "Texas" },
+  { value: "UT", label: "Utah" },
+  { value: "VT", label: "Vermont" },
+  { value: "VA", label: "Virginia" },
+  { value: "WA", label: "Washington" },
+  { value: "WV", label: "West Virginia" },
+  { value: "WI", label: "Wisconsin" },
+  { value: "WY", label: "Wyoming" },
+];
+
+type Props = {
+  candidates: ParkCandidateSummary[];
+};
+
+export function ParkDiscoveryTable({ candidates }: Props) {
+  const router = useRouter();
+  const [processingId, setProcessingId] = useState<string | null>(null);
+  const [processingBulk, setProcessingBulk] = useState<string | null>(null);
+  const [rejectReasons, setRejectReasons] = useState<Record<string, string>>(
+    {}
+  );
+  const [showRejectInput, setShowRejectInput] = useState<string | null>(null);
+
+  // Discover parks state
+  const [discoverState, setDiscoverState] = useState("");
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverResult, setDiscoverResult] = useState<string | null>(null);
+
+  const pendingCandidates = candidates.filter((c) => c.status === "PENDING");
+
+  const handleAccept = async (candidateId: string) => {
+    setProcessingId(candidateId);
+    try {
+      const response = await fetch(
+        "/api/admin/ai-research/discovery/candidates",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ candidateId, action: "accept" }),
+        }
+      );
+      if (response.ok) {
+        router.refresh();
+      } else {
+        const data = await response.json();
+        alert(data.error || "Failed to accept candidate");
+      }
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleReject = async (candidateId: string) => {
+    setProcessingId(candidateId);
+    try {
+      const response = await fetch(
+        "/api/admin/ai-research/discovery/candidates",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            candidateId,
+            action: "reject",
+            rejectedReason: rejectReasons[candidateId] || undefined,
+          }),
+        }
+      );
+      if (response.ok) {
+        setShowRejectInput(null);
+        setRejectReasons((prev) => {
+          const next = { ...prev };
+          delete next[candidateId];
+          return next;
+        });
+        router.refresh();
+      } else {
+        const data = await response.json();
+        alert(data.error || "Failed to reject candidate");
+      }
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const handleBulkAccept = async () => {
+    if (pendingCandidates.length === 0) return;
+    setProcessingBulk("accept");
+    try {
+      for (const candidate of pendingCandidates) {
+        const response = await fetch(
+          "/api/admin/ai-research/discovery/candidates",
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ candidateId: candidate.id, action: "accept" }),
+          }
+        );
+        if (!response.ok) {
+          const data = await response.json();
+          alert(
+            `Failed to accept "${candidate.name}": ${data.error || "Unknown error"}`
+          );
+          break;
+        }
+      }
+      router.refresh();
+    } finally {
+      setProcessingBulk(null);
+    }
+  };
+
+  const handleBulkReject = async () => {
+    if (pendingCandidates.length === 0) return;
+    setProcessingBulk("reject");
+    try {
+      for (const candidate of pendingCandidates) {
+        await fetch("/api/admin/ai-research/discovery/candidates", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ candidateId: candidate.id, action: "reject" }),
+        });
+      }
+      router.refresh();
+    } finally {
+      setProcessingBulk(null);
+    }
+  };
+
+  const handleDiscover = async () => {
+    if (!discoverState) return;
+    setDiscovering(true);
+    setDiscoverResult(null);
+    try {
+      const response = await fetch("/api/admin/ai-research/discovery", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ state: discoverState }),
+      });
+      const data = await response.json();
+      if (response.ok) {
+        setDiscoverResult(
+          `Found ${data.candidatesFound} candidate(s) in ${discoverState}.`
+        );
+        router.refresh();
+      } else {
+        setDiscoverResult(`Error: ${data.error || "Discovery failed"}`);
+      }
+    } catch (err) {
+      setDiscoverResult(
+        `Error: ${err instanceof Error ? err.message : "Network error"}`
+      );
+    } finally {
+      setDiscovering(false);
+    }
+  };
+
+  const isProcessing = processingId !== null || processingBulk !== null;
+
+  return (
+    <div className="space-y-4">
+      {/* Discover Parks */}
+      <div className="rounded-lg border border-gray-200 bg-white p-4">
+        <p className="text-sm font-medium text-gray-900 mb-2">
+          Discover Parks
+        </p>
+        <div className="flex items-end gap-3">
+          <div className="flex-1 max-w-xs">
+            <label className="block text-xs text-gray-500 mb-1">State</label>
+            <select
+              value={discoverState}
+              onChange={(e) => setDiscoverState(e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="">Select a state...</option>
+              {US_STATES.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label} ({s.value})
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button
+            onClick={handleDiscover}
+            disabled={discovering || !discoverState}
+            size="sm"
+          >
+            {discovering ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                Searching...
+              </>
+            ) : (
+              <>
+                <Search className="w-4 h-4 mr-1" />
+                Search
+              </>
+            )}
+          </Button>
+        </div>
+        {discoverResult && (
+          <div
+            className={`mt-3 rounded-lg border px-4 py-3 text-sm ${
+              discoverResult.startsWith("Error")
+                ? "bg-red-50 border-red-200 text-red-800"
+                : "bg-green-50 border-green-200 text-green-800"
+            }`}
+          >
+            {discoverResult}
+          </div>
+        )}
+      </div>
+
+      {/* Bulk Actions */}
+      {pendingCandidates.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBulkAccept}
+            disabled={isProcessing}
+            className="text-green-700 border-green-300 hover:bg-green-50"
+          >
+            {processingBulk === "accept" ? (
+              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+            ) : (
+              <CheckCheck className="w-4 h-4 mr-1" />
+            )}
+            Accept All Pending ({pendingCandidates.length})
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBulkReject}
+            disabled={isProcessing}
+            className="text-red-700 border-red-300 hover:bg-red-50"
+          >
+            {processingBulk === "reject" ? (
+              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+            ) : (
+              <XOctagon className="w-4 h-4 mr-1" />
+            )}
+            Reject All Pending ({pendingCandidates.length})
+          </Button>
+        </div>
+      )}
+
+      {/* Candidates Table */}
+      {candidates.length === 0 ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-8 text-center">
+          <p className="text-gray-500 text-sm">
+            No candidates found. Use the search above to discover parks in a
+            state.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  State
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  City
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Coordinates
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Source
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {candidates.map((candidate) => (
+                <tr key={candidate.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                    {candidate.name}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {candidate.state}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {candidate.city || "\u2014"}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {candidate.estimatedLat && candidate.estimatedLng
+                      ? `${candidate.estimatedLat.toFixed(4)}, ${candidate.estimatedLng.toFixed(4)}`
+                      : "\u2014"}
+                  </td>
+                  <td className="px-4 py-3">
+                    {candidate.sourceUrl ? (
+                      <a
+                        href={candidate.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 max-w-[200px] truncate"
+                      >
+                        <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                        Link
+                      </a>
+                    ) : (
+                      <span className="text-sm text-gray-400">{"\u2014"}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge
+                      status={candidate.status}
+                      seededParkId={candidate.seededParkId}
+                      rejectedReason={candidate.rejectedReason}
+                    />
+                  </td>
+                  <td className="px-4 py-3">
+                    {candidate.status === "PENDING" ? (
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => handleAccept(candidate.id)}
+                          disabled={isProcessing}
+                          title="Accept — create park"
+                          className="text-green-600 hover:text-green-700 hover:bg-green-50"
+                        >
+                          {processingId === candidate.id ? (
+                            <Loader2 className="w-5 h-5 animate-spin" />
+                          ) : (
+                            <CheckCircle className="w-5 h-5" />
+                          )}
+                        </Button>
+                        {showRejectInput === candidate.id ? (
+                          <div className="flex items-center gap-1">
+                            <input
+                              type="text"
+                              placeholder="Reason (optional)"
+                              value={rejectReasons[candidate.id] || ""}
+                              onChange={(e) =>
+                                setRejectReasons((prev) => ({
+                                  ...prev,
+                                  [candidate.id]: e.target.value,
+                                }))
+                              }
+                              className="w-32 rounded-md border border-gray-300 px-2 py-1 text-xs focus:border-red-500 focus:ring-1 focus:ring-red-500"
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter")
+                                  handleReject(candidate.id);
+                                if (e.key === "Escape")
+                                  setShowRejectInput(null);
+                              }}
+                            />
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleReject(candidate.id)}
+                              disabled={isProcessing}
+                              title="Confirm reject"
+                              className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                            >
+                              <XCircle className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() =>
+                              setShowRejectInput(candidate.id)
+                            }
+                            disabled={isProcessing}
+                            title="Reject"
+                            className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                          >
+                            <XCircle className="w-5 h-5" />
+                          </Button>
+                        )}
+                      </div>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  seededParkId,
+  rejectedReason,
+}: {
+  status: string;
+  seededParkId: string | null;
+  rejectedReason: string | null;
+}) {
+  const styles: Record<string, string> = {
+    PENDING: "bg-gray-100 text-gray-800 border-gray-200",
+    ACCEPTED: "bg-green-100 text-green-800 border-green-200",
+    REJECTED: "bg-red-100 text-red-800 border-red-200",
+  };
+
+  if (status === "ACCEPTED" && seededParkId) {
+    return (
+      <Link
+        href={`/admin/parks/${seededParkId}`}
+        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${styles.ACCEPTED} hover:bg-green-200 transition-colors`}
+      >
+        Seeded
+      </Link>
+    );
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${styles[status] || styles.PENDING}`}
+      title={status === "REJECTED" && rejectedReason ? rejectedReason : undefined}
+    >
+      {status}
+    </span>
+  );
+}

--- a/src/components/admin/SourceManagementTable.tsx
+++ b/src/components/admin/SourceManagementTable.tsx
@@ -192,6 +192,12 @@ export function SourceManagementTable({ sources, parkId }: Props) {
                         Official
                       </span>
                     )}
+                    {source.approveCount + source.rejectCount > 0 &&
+                      source.approveCount / (source.approveCount + source.rejectCount) < 0.2 && (
+                      <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">
+                        Low Accuracy
+                      </span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500 capitalize">{source.type}</td>
                   <td className="px-4 py-3 text-sm text-gray-500">

--- a/src/lib/ai/bulk-research.ts
+++ b/src/lib/ai/bulk-research.ts
@@ -1,0 +1,41 @@
+// TODO OP-80: Bulk Park Research
+// Admin UI to trigger research for multiple parks at once.
+// Progress tracking, cost estimation before launch, abort capability, rate limiting.
+
+import type { ResearchTrigger } from "@/lib/types";
+
+export type BulkResearchOptions = {
+  parkIds: string[];
+  trigger: ResearchTrigger;
+  maxConcurrent?: number;
+  dailyBudgetUSD?: number;
+};
+
+export type BulkResearchProgress = {
+  total: number;
+  completed: number;
+  failed: number;
+  estimatedCostUSD: number;
+  status: "pending" | "running" | "completed" | "aborted";
+};
+
+/**
+ * Run research on multiple parks with rate limiting and progress tracking.
+ * TODO OP-80: Implement batch orchestration with concurrency control,
+ * cost estimation, abort capability, and progress reporting.
+ */
+export async function runBulkResearch(
+  _options: BulkResearchOptions,
+): Promise<BulkResearchProgress> {
+  throw new Error("OP-80: Bulk research not yet implemented");
+}
+
+/**
+ * Estimate the cost of researching a set of parks before launching.
+ * TODO OP-80: Query source counts, estimate token usage per park.
+ */
+export async function estimateBulkResearchCost(
+  _parkIds: string[],
+): Promise<{ estimatedCostUSD: number; parkCount: number; sourceCount: number }> {
+  throw new Error("OP-80: Cost estimation not yet implemented");
+}

--- a/src/lib/ai/cross-validation.ts
+++ b/src/lib/ai/cross-validation.ts
@@ -1,0 +1,39 @@
+// TODO OP-83: Multi-Source Cross-Validation
+// Compare field values across multiple sources. Agreement from 2+ reliable
+// sources raises confidence. Disagreements flagged as conflicts for OP-84.
+
+export type CrossValidationResult = {
+  fieldName: string;
+  agreedValue: string | null;
+  agreementCount: number;
+  totalSources: number;
+  isConflict: boolean;
+  conflictingValues?: Array<{
+    value: string;
+    sourceId: string;
+    sourceUrl: string;
+    reliability: number;
+  }>;
+};
+
+/**
+ * Compare extracted values for a field across multiple sources.
+ * TODO OP-83: Implement agreement scoring and conflict detection.
+ * Should feed into source reliability scoring (OP-78).
+ */
+export async function crossValidateField(
+  _parkId: string,
+  _fieldName: string,
+): Promise<CrossValidationResult> {
+  throw new Error("OP-83: Cross-validation not yet implemented");
+}
+
+/**
+ * Run cross-validation for all pending fields on a park.
+ * TODO OP-83: Batch cross-validation after a research session completes.
+ */
+export async function crossValidatePark(
+  _parkId: string,
+): Promise<CrossValidationResult[]> {
+  throw new Error("OP-83: Cross-validation not yet implemented");
+}

--- a/src/lib/ai/discovery-schemas.ts
+++ b/src/lib/ai/discovery-schemas.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const parkCandidateSchema = z.object({
+  parks: z.array(
+    z.object({
+      name: z.string().describe("Official park name"),
+      city: z.string().optional().describe("City or town"),
+      state: z.string().describe("Two-letter state abbreviation"),
+      estimatedLat: z
+        .number()
+        .optional()
+        .describe("Approximate latitude if mentioned"),
+      estimatedLng: z
+        .number()
+        .optional()
+        .describe("Approximate longitude if mentioned"),
+      sourceUrl: z
+        .string()
+        .optional()
+        .describe("URL where this park was found"),
+    })
+  ),
+});
+
+export type DiscoveredParkCandidate = z.infer<
+  typeof parkCandidateSchema
+>["parks"][number];

--- a/src/lib/ai/domain-reliability.ts
+++ b/src/lib/ai/domain-reliability.ts
@@ -1,0 +1,67 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Look up domain-level reliability for a URL.
+ * Match rules: exact domain match first, then suffix match (e.g. ".gov").
+ * Returns null if no matching domain entry exists.
+ */
+export async function getDomainReliability(
+  url: string
+): Promise<{ reliability: number; isBlocked: boolean } | null> {
+  let hostname: string;
+  try {
+    const parsed = new URL(url);
+    hostname = parsed.hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return null;
+  }
+
+  // Fetch all domain entries — table is small, so this is fine
+  const domains = await prisma.domainReliability.findMany();
+
+  // Pass 1: exact match (e.g. "riderplanet-usa.com")
+  for (const domain of domains) {
+    const pattern = domain.domainPattern.toLowerCase();
+    if (pattern === hostname) {
+      return {
+        reliability: domain.defaultReliability,
+        isBlocked: domain.isBlocked,
+      };
+    }
+  }
+
+  // Pass 2: suffix match (e.g. ".gov" matches "blm.gov")
+  // Pick the longest matching suffix for specificity
+  let bestMatch: (typeof domains)[number] | null = null;
+  for (const domain of domains) {
+    const pattern = domain.domainPattern.toLowerCase();
+    if (pattern.startsWith(".") && hostname.endsWith(pattern)) {
+      if (!bestMatch || pattern.length > bestMatch.domainPattern.length) {
+        bestMatch = domain;
+      }
+    }
+  }
+
+  if (bestMatch) {
+    return {
+      reliability: bestMatch.defaultReliability,
+      isBlocked: bestMatch.isBlocked,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Get the default reliability score for a source URL.
+ * Returns the domain-level default if found, 50 otherwise.
+ * Blocked domains return 0.
+ */
+export async function getDefaultReliabilityForSource(
+  url: string
+): Promise<number> {
+  const result = await getDomainReliability(url);
+  if (!result) return 50;
+  if (result.isBlocked) return 0;
+  return result.reliability;
+}

--- a/src/lib/ai/extraction-validator.ts
+++ b/src/lib/ai/extraction-validator.ts
@@ -1,0 +1,123 @@
+import { STATE_BOUNDING_BOXES } from "./state-bounding-boxes";
+
+export type ValidationResult = {
+  valid: boolean;
+  reason?: string;
+};
+
+const PRICE_FIELDS = new Set([
+  "dayPassUSD",
+  "vehicleEntryFeeUSD",
+  "riderFeeUSD",
+  "membershipFeeUSD",
+]);
+
+const PHONE_FIELDS = new Set(["phone", "campingPhone"]);
+
+const URL_FIELDS = new Set(["website", "campingWebsite"]);
+
+/**
+ * Validate a single extracted field value.
+ * Returns { valid: true } if the value is acceptable,
+ * or { valid: false, reason: "..." } if it should be dropped.
+ */
+export function validateExtraction(
+  fieldName: string,
+  value: unknown,
+  parkState: string | null,
+): ValidationResult {
+  // --- Latitude ---
+  if (fieldName === "latitude") {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      return { valid: false, reason: "latitude must be a number" };
+    }
+    if (value < -90 || value > 90) {
+      return { valid: false, reason: `latitude ${value} outside valid range (-90 to 90)` };
+    }
+    if (parkState) {
+      const bbox = STATE_BOUNDING_BOXES[parkState.toUpperCase()];
+      if (bbox && (value < bbox.minLat || value > bbox.maxLat)) {
+        return {
+          valid: false,
+          reason: `latitude ${value} outside ${parkState} bounding box (${bbox.minLat}–${bbox.maxLat})`,
+        };
+      }
+    }
+    return { valid: true };
+  }
+
+  // --- Longitude ---
+  if (fieldName === "longitude") {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      return { valid: false, reason: "longitude must be a number" };
+    }
+    if (value < -180 || value > 180) {
+      return { valid: false, reason: `longitude ${value} outside valid range (-180 to 180)` };
+    }
+    if (parkState) {
+      const bbox = STATE_BOUNDING_BOXES[parkState.toUpperCase()];
+      if (bbox && (value < bbox.minLng || value > bbox.maxLng)) {
+        return {
+          valid: false,
+          reason: `longitude ${value} outside ${parkState} bounding box (${bbox.minLng}–${bbox.maxLng})`,
+        };
+      }
+    }
+    return { valid: true };
+  }
+
+  // --- Price fields ---
+  if (PRICE_FIELDS.has(fieldName)) {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      return { valid: false, reason: `${fieldName} must be a number` };
+    }
+    if (value < 0 || value > 500) {
+      return { valid: false, reason: `${fieldName} ${value} outside valid range ($0–$500)` };
+    }
+    return { valid: true };
+  }
+
+  // --- Phone fields ---
+  if (PHONE_FIELDS.has(fieldName)) {
+    if (typeof value !== "string") {
+      return { valid: false, reason: `${fieldName} must be a string` };
+    }
+    const digitsOnly = value.replace(/\D/g, "");
+    if (digitsOnly.length < 10) {
+      return {
+        valid: false,
+        reason: `${fieldName} has only ${digitsOnly.length} digits (minimum 10)`,
+      };
+    }
+    return { valid: true };
+  }
+
+  // --- URL fields ---
+  if (URL_FIELDS.has(fieldName)) {
+    if (typeof value !== "string") {
+      return { valid: false, reason: `${fieldName} must be a string` };
+    }
+    try {
+      new URL(value);
+    } catch {
+      return { valid: false, reason: `${fieldName} is not a valid URL` };
+    }
+    return { valid: true };
+  }
+
+  // --- Email ---
+  if (fieldName === "contactEmail") {
+    if (typeof value !== "string") {
+      return { valid: false, reason: "contactEmail must be a string" };
+    }
+    // Basic email check: has @ with a dot somewhere after it
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(value)) {
+      return { valid: false, reason: `contactEmail "${value}" is not a valid email address` };
+    }
+    return { valid: true };
+  }
+
+  // --- All other fields: no additional validation ---
+  return { valid: true };
+}

--- a/src/lib/ai/feedback-loop.ts
+++ b/src/lib/ai/feedback-loop.ts
@@ -1,0 +1,92 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Update the accuracy metrics for a DataSource after an approve/reject action.
+ * Also aggregates accuracy at the domain level into DomainReliability.
+ */
+export async function recordFeedback(
+  dataSourceId: string,
+  action: "approve" | "reject"
+): Promise<void> {
+  // 1. Increment the appropriate counter on the DataSource
+  const updated = await prisma.dataSource.update({
+    where: { id: dataSourceId },
+    data:
+      action === "approve"
+        ? { approveCount: { increment: 1 } }
+        : { rejectCount: { increment: 1 } },
+  });
+
+  // Domain-level accuracy is computed at display time via getDomainAccuracyStats().
+  // We don't auto-update DomainReliability — admin decides based on the dashboard.
+  void updated;
+}
+
+/**
+ * Query all DataSources, group by hostname, compute accuracy per domain.
+ * Return top 20 by total reviews descending.
+ */
+export async function getDomainAccuracyStats(): Promise<
+  Array<{
+    domain: string;
+    totalApproves: number;
+    totalRejects: number;
+    accuracy: number;
+    sourceCount: number;
+  }>
+> {
+  const sources = await prisma.dataSource.findMany({
+    select: { url: true, approveCount: true, rejectCount: true },
+  });
+
+  // Group by hostname
+  const domainMap = new Map<
+    string,
+    { totalApproves: number; totalRejects: number; sourceCount: number }
+  >();
+
+  for (const s of sources) {
+    let hostname: string;
+    try {
+      const parsed = new URL(s.url);
+      hostname = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    } catch {
+      continue; // skip invalid URLs
+    }
+
+    const existing = domainMap.get(hostname);
+    if (existing) {
+      existing.totalApproves += s.approveCount;
+      existing.totalRejects += s.rejectCount;
+      existing.sourceCount += 1;
+    } else {
+      domainMap.set(hostname, {
+        totalApproves: s.approveCount,
+        totalRejects: s.rejectCount,
+        sourceCount: 1,
+      });
+    }
+  }
+
+  // Convert to array, compute accuracy, sort by total reviews descending, take top 20
+  const results = Array.from(domainMap.entries())
+    .map(([domain, stats]) => {
+      const total = stats.totalApproves + stats.totalRejects;
+      return {
+        domain,
+        totalApproves: stats.totalApproves,
+        totalRejects: stats.totalRejects,
+        accuracy: total > 0 ? stats.totalApproves / total : 0,
+        sourceCount: stats.sourceCount,
+      };
+    })
+    .filter((r) => r.totalApproves + r.totalRejects > 0)
+    .sort((a, b) => {
+      const totalA = a.totalApproves + a.totalRejects;
+      const totalB = b.totalApproves + b.totalRejects;
+      return totalB - totalA;
+    })
+    .slice(0, 20);
+
+  return results;
+}

--- a/src/lib/ai/park-discovery.ts
+++ b/src/lib/ai/park-discovery.ts
@@ -1,0 +1,238 @@
+import { generateObject } from "ai";
+import { EXTRACTION_MODEL } from "./config";
+import { parkCandidateSchema } from "./discovery-schemas";
+import type { DiscoveredParkCandidate } from "./discovery-schemas";
+import { prisma } from "@/lib/prisma";
+
+// ── Levenshtein distance (standard DP) ───────────────────────────────────────
+
+export function levenshteinDistance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+
+  // Edge cases
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  // Use a single-row DP approach for space efficiency
+  const prev = new Array<number>(n + 1);
+  const curr = new Array<number>(n + 1);
+
+  for (let j = 0; j <= n; j++) prev[j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        prev[j] + 1, // deletion
+        curr[j - 1] + 1, // insertion
+        prev[j - 1] + cost // substitution
+      );
+    }
+    // Swap rows
+    for (let j = 0; j <= n; j++) prev[j] = curr[j];
+  }
+
+  return prev[n];
+}
+
+// ── Name normalization ───────────────────────────────────────────────────────
+
+const STRIP_SUFFIXES =
+  /\b(off[\s-]?road|offroad|ohv|atv|utv|sxs|park|area|riding|trails?|recreation|recreational)\b/gi;
+
+export function normalizeParkName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(STRIP_SUFFIXES, "")
+    .replace(/[^a-z0-9]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ── Fuzzy dedup check ────────────────────────────────────────────────────────
+
+function isFuzzyDuplicate(
+  candidateName: string,
+  existingName: string
+): boolean {
+  const a = normalizeParkName(candidateName);
+  const b = normalizeParkName(existingName);
+
+  if (a === b) return true;
+
+  const distance = levenshteinDistance(a, b);
+  const maxLen = Math.max(a.length, b.length);
+
+  // Threshold: <= 3 for names under 20 chars, <= 5 for longer
+  const threshold = maxLen < 20 ? 3 : 5;
+  return distance <= threshold;
+}
+
+// ── SerpApi search (matches source-discovery.ts pattern) ─────────────────────
+
+type SearchResult = {
+  title: string;
+  snippet: string;
+  link: string;
+};
+
+async function searchSerpApi(
+  query: string,
+  apiKey: string
+): Promise<SearchResult[]> {
+  const params = new URLSearchParams({
+    api_key: apiKey,
+    engine: "google",
+    q: query,
+    num: "10",
+  });
+
+  try {
+    const response = await fetch(
+      `https://serpapi.com/search.json?${params}`,
+      { signal: AbortSignal.timeout(10_000) }
+    );
+
+    if (!response.ok) return [];
+
+    const data = await response.json();
+    const results = data.organic_results || [];
+
+    return results.map(
+      (item: { link: string; title: string; snippet?: string }) => ({
+        title: item.title || "",
+        snippet: item.snippet || "",
+        link: item.link,
+      })
+    );
+  } catch {
+    return [];
+  }
+}
+
+// ── Main discovery function ──────────────────────────────────────────────────
+
+export async function discoverParksInState(state: string): Promise<{
+  candidates: Array<{
+    name: string;
+    state: string;
+    city: string | null;
+    estimatedLat: number | null;
+    estimatedLng: number | null;
+    sourceUrl: string | null;
+  }>;
+  inputTokens: number;
+  outputTokens: number;
+}> {
+  const apiKey = process.env.SERPAPI_API_KEY;
+  if (!apiKey) {
+    throw new Error("SERPAPI_API_KEY is not configured");
+  }
+
+  // 1. Run 3 searches in parallel
+  const queries = [
+    `"off-road parks in ${state}"`,
+    `"OHV riding areas ${state}"`,
+    `"ATV trails ${state} open to public"`,
+  ];
+
+  const searchResults = await Promise.all(
+    queries.map((q) => searchSerpApi(q, apiKey))
+  );
+
+  const allResults = searchResults.flat();
+
+  if (allResults.length === 0) {
+    return { candidates: [], inputTokens: 0, outputTokens: 0 };
+  }
+
+  // 2. Build snippet text for LLM extraction
+  const snippetText = allResults
+    .map(
+      (r, i) =>
+        `[${i + 1}] ${r.title}\n${r.snippet}\nSource: ${r.link}`
+    )
+    .join("\n\n");
+
+  const systemPrompt =
+    "You are identifying distinct off-road/OHV parks from web search results. Extract every unique park mentioned. Only include parks that appear to be real, named off-road riding areas (not private land, not individual trails within a park, not stores/dealers). Deduplicate — if the same park appears in multiple results, include it only once.";
+
+  const userPrompt = `Extract all distinct off-road/OHV parks found in these search results for ${state}:\n\n${snippetText}`;
+
+  const result = await generateObject({
+    model: EXTRACTION_MODEL,
+    schema: parkCandidateSchema,
+    system: systemPrompt,
+    prompt: userPrompt,
+  });
+
+  const extracted: DiscoveredParkCandidate[] = result.object.parks;
+  const inputTokens = result.usage?.inputTokens ?? 0;
+  const outputTokens = result.usage?.outputTokens ?? 0;
+
+  // 3. Fuzzy dedup against existing parks and candidates
+  const [existingParks, existingCandidates] = await Promise.all([
+    prisma.park.findMany({
+      where: { address: { state } },
+      select: { name: true },
+    }),
+    prisma.parkCandidate.findMany({
+      where: { state },
+      select: { name: true },
+    }),
+  ]);
+
+  const existingNames = [
+    ...existingParks.map((p) => p.name),
+    ...existingCandidates.map((c) => c.name),
+  ];
+
+  const dedupedCandidates: Array<{
+    name: string;
+    state: string;
+    city: string | null;
+    estimatedLat: number | null;
+    estimatedLng: number | null;
+    sourceUrl: string | null;
+  }> = [];
+
+  for (const candidate of extracted) {
+    const isDuplicate = existingNames.some((existing) =>
+      isFuzzyDuplicate(candidate.name, existing)
+    );
+
+    if (isDuplicate) continue;
+
+    // Also check against already-accepted candidates in this batch
+    const isBatchDuplicate = dedupedCandidates.some((c) =>
+      isFuzzyDuplicate(candidate.name, c.name)
+    );
+
+    if (isBatchDuplicate) continue;
+
+    dedupedCandidates.push({
+      name: candidate.name,
+      state: candidate.state,
+      city: candidate.city ?? null,
+      estimatedLat: candidate.estimatedLat ?? null,
+      estimatedLng: candidate.estimatedLng ?? null,
+      sourceUrl: candidate.sourceUrl ?? null,
+    });
+  }
+
+  // 4. Persist non-duplicate candidates
+  if (dedupedCandidates.length > 0) {
+    await prisma.parkCandidate.createMany({
+      data: dedupedCandidates,
+      skipDuplicates: true,
+    });
+  }
+
+  return {
+    candidates: dedupedCandidates,
+    inputTokens,
+    outputTokens,
+  };
+}

--- a/src/lib/ai/park-discovery.ts
+++ b/src/lib/ai/park-discovery.ts
@@ -132,10 +132,11 @@ export async function discoverParksInState(state: string): Promise<{
   }
 
   // 1. Run 3 searches in parallel
+  // Avoid exact-match quotes — they're too restrictive for discovery
   const queries = [
-    `"off-road parks in ${state}"`,
-    `"OHV riding areas ${state}"`,
-    `"ATV trails ${state} open to public"`,
+    `off-road parks ${state} OHV`,
+    `OHV riding areas ${state} ATV UTV`,
+    `${state} off-road trails open to public`,
   ];
 
   const searchResults = await Promise.all(

--- a/src/lib/ai/research-pipeline.ts
+++ b/src/lib/ai/research-pipeline.ts
@@ -15,6 +15,7 @@ import {
   getCurrentFieldValue,
 } from "./research-lifecycle";
 import { isAllowedByRobots, clearRobotsCache } from "./robots";
+import { getDefaultReliabilityForSource } from "./domain-reliability";
 import { discoverSources } from "./source-discovery";
 
 /**
@@ -93,6 +94,14 @@ export async function researchPark(
       );
 
       for (const source of newSources) {
+        // Look up domain-level reliability for this source
+        const domainReliability = await getDefaultReliabilityForSource(
+          source.url
+        );
+
+        // Skip blocked domains (reliability === 0 from a blocked domain)
+        if (domainReliability === 0) continue;
+
         await prisma.dataSource.create({
           data: {
             parkId,
@@ -100,6 +109,7 @@ export async function researchPark(
             title: source.title,
             type: source.type,
             origin: "AI_DISCOVERED",
+            reliability: domainReliability,
           },
         });
         totalSourcesFound++;
@@ -122,6 +132,9 @@ export async function researchPark(
 
     // Track which fields were found across all sources
     const fieldsFoundInSources = new Map<string, number>();
+
+    // OP-82: Collect validation warnings across all sources
+    const validationWarnings: string[] = [];
 
     // Stage 2 & 3: Content Extraction + Data Extraction per source
     for (const source of sources) {
@@ -174,6 +187,25 @@ export async function researchPark(
           continue;
         }
 
+        // OP-81: Wrong-park detection guard
+        const { validateParkRelevance } = await import("./wrong-park-guard");
+        const relevance = await validateParkRelevance(
+          park.name,
+          park.address?.state ?? "",
+          content.text,
+        );
+        totalInputTokens += relevance.inputTokens;
+        totalOutputTokens += relevance.outputTokens;
+
+        if (!relevance.isRelevant) {
+          // Auto-mark as wrong park
+          await prisma.dataSource.update({
+            where: { id: source.id },
+            data: { crawlStatus: "WRONG_PARK", crawlError: relevance.reason },
+          });
+          continue;
+        }
+
         // Link source to session
         await prisma.researchSessionSource.create({
           data: { sessionId: session.id, dataSourceId: source.id },
@@ -209,6 +241,15 @@ export async function researchPark(
           const fieldName = addressFields.includes(key)
             ? `address.${key}`
             : key;
+
+          // OP-82: Post-extraction validation
+          const { validateExtraction } = await import("./extraction-validator");
+          const validation = validateExtraction(fieldName, fieldData.value, park.address?.state ?? null);
+          if (!validation.valid) {
+            // Drop this field — don't create a FieldExtraction record
+            validationWarnings.push(`${fieldName}: ${validation.reason}`);
+            continue;
+          }
 
           const currentValueJson = getCurrentFieldValue(
             park as unknown as import("@/lib/types").DbPark,
@@ -373,9 +414,15 @@ export async function researchPark(
     });
 
     // Complete session
+    const summaryParts = [
+      `Processed ${sources.length} sources. Extracted ${totalFieldsExtracted} fields. ${remainingFields.length} fields remaining.`,
+    ];
+    if (validationWarnings.length > 0) {
+      summaryParts.push(`Validation warnings: ${validationWarnings.join("; ")}`);
+    }
     await completeSession(session.id, {
       status: "COMPLETED",
-      summary: `Processed ${sources.length} sources. Extracted ${totalFieldsExtracted} fields. ${remainingFields.length} fields remaining.`,
+      summary: summaryParts.join(" "),
       fieldsExtracted: totalFieldsExtracted,
       sourcesFound: totalSourcesFound,
       inputTokens: totalInputTokens,

--- a/src/lib/ai/seed-domain-reliability.ts
+++ b/src/lib/ai/seed-domain-reliability.ts
@@ -1,0 +1,78 @@
+import { prisma } from "@/lib/prisma";
+
+type SeedEntry = {
+  domainPattern: string;
+  defaultReliability: number;
+  isBlocked: boolean;
+  notes: string;
+};
+
+export const SEED_DOMAINS: SeedEntry[] = [
+  {
+    domainPattern: ".gov",
+    defaultReliability: 85,
+    isBlocked: false,
+    notes: "Government sites — high trust",
+  },
+  {
+    domainPattern: "riderplanet-usa.com",
+    defaultReliability: 90,
+    isBlocked: false,
+    notes: "Established OHV directory — very reliable",
+  },
+  {
+    domainPattern: "facebook.com",
+    defaultReliability: 60,
+    isBlocked: false,
+    notes: "Facebook pages — moderate reliability",
+  },
+  {
+    domainPattern: "fb.com",
+    defaultReliability: 60,
+    isBlocked: false,
+    notes: "Facebook short domain",
+  },
+  {
+    domainPattern: "recreation.gov",
+    defaultReliability: 85,
+    isBlocked: false,
+    notes: "Federal recreation portal",
+  },
+  {
+    domainPattern: "alltrails.com",
+    defaultReliability: 70,
+    isBlocked: false,
+    notes: "Trail review site",
+  },
+  {
+    domainPattern: "tripadvisor.com",
+    defaultReliability: 65,
+    isBlocked: false,
+    notes: "Travel review site",
+  },
+  {
+    domainPattern: "yelp.com",
+    defaultReliability: 60,
+    isBlocked: false,
+    notes: "Business review site",
+  },
+];
+
+/**
+ * Seed the DomainReliability table with initial entries.
+ * Uses upsert to skip entries that already exist (matched by domainPattern).
+ */
+export async function seedDomainReliability(): Promise<void> {
+  for (const entry of SEED_DOMAINS) {
+    await prisma.domainReliability.upsert({
+      where: { domainPattern: entry.domainPattern },
+      update: {},
+      create: {
+        domainPattern: entry.domainPattern,
+        defaultReliability: entry.defaultReliability,
+        isBlocked: entry.isBlocked,
+        notes: entry.notes,
+      },
+    });
+  }
+}

--- a/src/lib/ai/state-bounding-boxes.ts
+++ b/src/lib/ai/state-bounding-boxes.ts
@@ -1,0 +1,63 @@
+/**
+ * Approximate bounding boxes for all 50 US states.
+ * Used by post-extraction validation (OP-82) to catch obviously wrong
+ * lat/lng values before they reach the review queue.
+ *
+ * Values are intentionally generous (rounded outward) so legitimate
+ * coordinates near state borders are never rejected.
+ */
+export const STATE_BOUNDING_BOXES: Record<
+  string,
+  { minLat: number; maxLat: number; minLng: number; maxLng: number }
+> = {
+  AL: { minLat: 30.2, maxLat: 35.0, minLng: -88.5, maxLng: -84.9 },
+  AK: { minLat: 51.2, maxLat: 71.4, minLng: -179.2, maxLng: -129.9 },
+  AZ: { minLat: 31.3, maxLat: 37.0, minLng: -114.8, maxLng: -109.0 },
+  AR: { minLat: 33.0, maxLat: 36.5, minLng: -94.6, maxLng: -89.6 },
+  CA: { minLat: 32.5, maxLat: 42.0, minLng: -124.5, maxLng: -114.0 },
+  CO: { minLat: 37.0, maxLat: 41.0, minLng: -109.1, maxLng: -102.0 },
+  CT: { minLat: 41.0, maxLat: 42.1, minLng: -73.7, maxLng: -71.8 },
+  DE: { minLat: 38.4, maxLat: 39.8, minLng: -75.8, maxLng: -75.0 },
+  FL: { minLat: 24.4, maxLat: 31.0, minLng: -87.6, maxLng: -80.0 },
+  GA: { minLat: 30.4, maxLat: 35.0, minLng: -85.6, maxLng: -80.8 },
+  HI: { minLat: 18.9, maxLat: 22.2, minLng: -160.3, maxLng: -154.8 },
+  ID: { minLat: 42.0, maxLat: 49.0, minLng: -117.2, maxLng: -111.0 },
+  IL: { minLat: 37.0, maxLat: 42.5, minLng: -91.5, maxLng: -87.0 },
+  IN: { minLat: 37.8, maxLat: 41.8, minLng: -88.1, maxLng: -84.8 },
+  IA: { minLat: 40.4, maxLat: 43.5, minLng: -96.6, maxLng: -90.1 },
+  KS: { minLat: 37.0, maxLat: 40.0, minLng: -102.1, maxLng: -94.6 },
+  KY: { minLat: 36.5, maxLat: 39.1, minLng: -89.6, maxLng: -81.9 },
+  LA: { minLat: 29.0, maxLat: 33.0, minLng: -94.0, maxLng: -89.0 },
+  ME: { minLat: 43.1, maxLat: 47.5, minLng: -71.1, maxLng: -66.9 },
+  MD: { minLat: 37.9, maxLat: 39.7, minLng: -79.5, maxLng: -75.0 },
+  MA: { minLat: 41.2, maxLat: 42.9, minLng: -73.5, maxLng: -69.9 },
+  MI: { minLat: 41.7, maxLat: 48.3, minLng: -90.4, maxLng: -82.4 },
+  MN: { minLat: 43.5, maxLat: 49.4, minLng: -97.2, maxLng: -89.5 },
+  MS: { minLat: 30.2, maxLat: 35.0, minLng: -91.7, maxLng: -88.1 },
+  MO: { minLat: 36.0, maxLat: 40.6, minLng: -95.8, maxLng: -89.1 },
+  MT: { minLat: 44.4, maxLat: 49.0, minLng: -116.1, maxLng: -104.0 },
+  NE: { minLat: 40.0, maxLat: 43.0, minLng: -104.1, maxLng: -95.3 },
+  NV: { minLat: 35.0, maxLat: 42.0, minLng: -120.0, maxLng: -114.0 },
+  NH: { minLat: 42.7, maxLat: 45.3, minLng: -72.6, maxLng: -70.7 },
+  NJ: { minLat: 38.9, maxLat: 41.4, minLng: -75.6, maxLng: -73.9 },
+  NM: { minLat: 31.3, maxLat: 37.0, minLng: -109.1, maxLng: -103.0 },
+  NY: { minLat: 40.5, maxLat: 45.0, minLng: -79.8, maxLng: -71.9 },
+  NC: { minLat: 33.8, maxLat: 36.6, minLng: -84.3, maxLng: -75.5 },
+  ND: { minLat: 45.9, maxLat: 49.0, minLng: -104.1, maxLng: -96.6 },
+  OH: { minLat: 38.4, maxLat: 42.0, minLng: -84.8, maxLng: -80.5 },
+  OK: { minLat: 33.6, maxLat: 37.0, minLng: -103.0, maxLng: -94.4 },
+  OR: { minLat: 42.0, maxLat: 46.3, minLng: -124.6, maxLng: -116.5 },
+  PA: { minLat: 39.7, maxLat: 42.3, minLng: -80.5, maxLng: -74.7 },
+  RI: { minLat: 41.1, maxLat: 42.0, minLng: -71.9, maxLng: -71.1 },
+  SC: { minLat: 32.0, maxLat: 35.2, minLng: -83.4, maxLng: -78.5 },
+  SD: { minLat: 42.5, maxLat: 46.0, minLng: -104.1, maxLng: -96.4 },
+  TN: { minLat: 35.0, maxLat: 36.7, minLng: -90.3, maxLng: -81.6 },
+  TX: { minLat: 25.8, maxLat: 36.5, minLng: -106.7, maxLng: -93.5 },
+  UT: { minLat: 37.0, maxLat: 42.0, minLng: -114.1, maxLng: -109.0 },
+  VT: { minLat: 42.7, maxLat: 45.0, minLng: -73.4, maxLng: -71.5 },
+  VA: { minLat: 36.5, maxLat: 39.5, minLng: -83.7, maxLng: -75.2 },
+  WA: { minLat: 45.5, maxLat: 49.0, minLng: -124.8, maxLng: -116.9 },
+  WV: { minLat: 37.2, maxLat: 40.6, minLng: -82.6, maxLng: -77.7 },
+  WI: { minLat: 42.5, maxLat: 47.1, minLng: -92.9, maxLng: -86.8 },
+  WY: { minLat: 41.0, maxLat: 45.0, minLng: -111.1, maxLng: -104.1 },
+};

--- a/src/lib/ai/wrong-park-guard.ts
+++ b/src/lib/ai/wrong-park-guard.ts
@@ -1,0 +1,43 @@
+import { generateObject } from "ai";
+import { z } from "zod";
+import { EXTRACTION_MODEL } from "./config";
+
+const relevanceSchema = z.object({
+  isAboutTargetPark: z.boolean(),
+  reason: z.string(),
+});
+
+/** Max content length sent to the relevance check (cheap validation call). */
+const MAX_RELEVANCE_CONTENT_CHARS = 4000;
+
+/**
+ * Validates whether web content is primarily about the target park.
+ * Returns true if content is relevant, false if it's about a different park.
+ */
+export async function validateParkRelevance(
+  parkName: string,
+  state: string,
+  contentText: string,
+): Promise<{
+  isRelevant: boolean;
+  reason: string;
+  inputTokens: number;
+  outputTokens: number;
+}> {
+  const truncatedContent = contentText.slice(0, MAX_RELEVANCE_CONTENT_CHARS);
+
+  const result = await generateObject({
+    model: EXTRACTION_MODEL,
+    schema: relevanceSchema,
+    system:
+      "You are validating whether web page content is primarily about a specific off-road park. Answer based on the content provided.",
+    prompt: `Is the following content primarily about '${parkName}' in ${state}? The content may mention other parks — that's fine as long as the primary focus is on the target park. If the content is a directory listing that mentions many parks equally, or is primarily about a different park that just links to the target, answer no.\n\nContent:\n${truncatedContent}`,
+  });
+
+  return {
+    isRelevant: result.object.isAboutTargetPark,
+    reason: result.object.reason,
+    inputTokens: result.usage?.inputTokens ?? 0,
+    outputTokens: result.usage?.outputTokens ?? 0,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ export type FieldConfidence = "OPERATOR_CONFIRMED" | "HUMAN_VERIFIED" | "AI_EXTR
 export type FieldExtractionStatus = "PENDING_REVIEW" | "APPROVED" | "REJECTED" | "SUPERSEDED" | "CONFLICT";
 export type ResearchTrigger = "SCHEDULED_CRON" | "ADMIN_MANUAL" | "OPERATOR_SOURCES" | "NEW_PARK_SEEDED" | "SOURCE_CHANGED";
 export type ResearchSessionStatus = "IN_PROGRESS" | "COMPLETED" | "FAILED" | "PARTIAL";
+export type ParkCandidateStatus = "PENDING" | "ACCEPTED" | "REJECTED";
 
 // Ownership type
 export type Ownership = "private" | "public" | "mixed" | "unknown";
@@ -418,6 +419,8 @@ export type DataSourceSummary = {
   contentChanged: boolean;
   crawlStatus: CrawlStatus;
   crawlError: string | null;
+  approveCount: number;
+  rejectCount: number;
   createdAt: string;
 };
 
@@ -455,6 +458,14 @@ export type ResearchSessionSummary = {
   completedAt: string | null;
 };
 
+export type DomainAccuracyStat = {
+  domain: string;
+  totalApproves: number;
+  totalRejects: number;
+  accuracy: number;
+  sourceCount: number;
+};
+
 export type AIResearchDashboard = {
   totalParks: number;
   parksByResearchStatus: Record<ResearchStatus, number>;
@@ -462,4 +473,30 @@ export type AIResearchDashboard = {
   totalSessions: number;
   totalCostUSD: number;
   recentSessions: ResearchSessionSummary[];
+  domainAccuracy?: DomainAccuracyStat[];
+};
+
+// Domain Reliability (OP-78)
+export type DomainReliabilitySummary = {
+  id: string;
+  domainPattern: string;
+  defaultReliability: number;
+  isBlocked: boolean;
+  notes: string | null;
+  createdAt: string;
+};
+
+// Park Discovery (OP-85/86)
+export type ParkCandidateSummary = {
+  id: string;
+  name: string;
+  state: string;
+  city: string | null;
+  estimatedLat: number | null;
+  estimatedLng: number | null;
+  sourceUrl: string | null;
+  status: ParkCandidateStatus;
+  rejectedReason: string | null;
+  seededParkId: string | null;
+  createdAt: string;
 };

--- a/test/lib/ai/extraction-validator.test.ts
+++ b/test/lib/ai/extraction-validator.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import { validateExtraction } from "@/lib/ai/extraction-validator";
+
+describe("validateExtraction", () => {
+  // ---- Latitude ----
+  describe("latitude", () => {
+    it("accepts valid latitude within state bounding box", () => {
+      const result = validateExtraction("latitude", 34.0, "CA");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects latitude outside state bounding box", () => {
+      // 47 is well north of Texas (25.8–36.5)
+      const result = validateExtraction("latitude", 47.0, "TX");
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("outside TX bounding box");
+    });
+
+    it("accepts valid latitude with unknown state (just range check)", () => {
+      const result = validateExtraction("latitude", 35.0, null);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts valid latitude with unrecognized state abbreviation", () => {
+      const result = validateExtraction("latitude", 35.0, "XX");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects latitude outside global range", () => {
+      const result = validateExtraction("latitude", 91.0, null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("outside valid range");
+    });
+
+    it("rejects latitude below -90", () => {
+      const result = validateExtraction("latitude", -91.0, null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects non-numeric latitude", () => {
+      const result = validateExtraction("latitude", "34.0", null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("must be a number");
+    });
+
+    it("rejects NaN latitude", () => {
+      const result = validateExtraction("latitude", NaN, null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("accepts latitude at exact boundary of state bbox", () => {
+      // CA minLat is 32.5
+      const result = validateExtraction("latitude", 32.5, "CA");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("handles lowercase state abbreviation", () => {
+      const result = validateExtraction("latitude", 34.0, "ca");
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  // ---- Longitude ----
+  describe("longitude", () => {
+    it("accepts valid longitude within state bounding box", () => {
+      const result = validateExtraction("longitude", -118.0, "CA");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects longitude outside state bounding box", () => {
+      // -80 is east coast, far from CA (-124.5 to -114.0)
+      const result = validateExtraction("longitude", -80.0, "CA");
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("outside CA bounding box");
+    });
+
+    it("accepts valid longitude with null state", () => {
+      const result = validateExtraction("longitude", -100.0, null);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects longitude outside global range", () => {
+      const result = validateExtraction("longitude", 181.0, null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects longitude below -180", () => {
+      const result = validateExtraction("longitude", -181.0, null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects non-numeric longitude", () => {
+      const result = validateExtraction("longitude", "-118", null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("must be a number");
+    });
+  });
+
+  // ---- Price fields ----
+  describe("price fields", () => {
+    const priceFields = [
+      "dayPassUSD",
+      "vehicleEntryFeeUSD",
+      "riderFeeUSD",
+      "membershipFeeUSD",
+    ];
+
+    for (const field of priceFields) {
+      describe(field, () => {
+        it("accepts $0", () => {
+          expect(validateExtraction(field, 0, null)).toEqual({ valid: true });
+        });
+
+        it("accepts $25", () => {
+          expect(validateExtraction(field, 25, null)).toEqual({ valid: true });
+        });
+
+        it("accepts $500", () => {
+          expect(validateExtraction(field, 500, null)).toEqual({ valid: true });
+        });
+
+        it("rejects negative price", () => {
+          const result = validateExtraction(field, -10, null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("outside valid range");
+        });
+
+        it("rejects price over $500", () => {
+          const result = validateExtraction(field, 1000, null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("outside valid range");
+        });
+
+        it("rejects non-numeric price", () => {
+          const result = validateExtraction(field, "25", null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("must be a number");
+        });
+
+        it("rejects NaN", () => {
+          const result = validateExtraction(field, NaN, null);
+          expect(result.valid).toBe(false);
+        });
+      });
+    }
+  });
+
+  // ---- Phone fields ----
+  describe("phone fields", () => {
+    const phoneFields = ["phone", "campingPhone"];
+
+    for (const field of phoneFields) {
+      describe(field, () => {
+        it("accepts 10-digit phone number", () => {
+          const result = validateExtraction(field, "5551234567", null);
+          expect(result).toEqual({ valid: true });
+        });
+
+        it("accepts formatted phone number with 10+ digits", () => {
+          const result = validateExtraction(field, "(555) 123-4567", null);
+          expect(result).toEqual({ valid: true });
+        });
+
+        it("accepts phone with country code (11 digits)", () => {
+          const result = validateExtraction(field, "+1-555-123-4567", null);
+          expect(result).toEqual({ valid: true });
+        });
+
+        it("rejects 7-digit phone number", () => {
+          const result = validateExtraction(field, "5551234", null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("7 digits");
+          expect(result.reason).toContain("minimum 10");
+        });
+
+        it("rejects empty string", () => {
+          const result = validateExtraction(field, "", null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("0 digits");
+        });
+
+        it("rejects non-string", () => {
+          const result = validateExtraction(field, 5551234567, null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("must be a string");
+        });
+      });
+    }
+  });
+
+  // ---- URL fields ----
+  describe("URL fields", () => {
+    const urlFields = ["website", "campingWebsite"];
+
+    for (const field of urlFields) {
+      describe(field, () => {
+        it("accepts valid https URL", () => {
+          const result = validateExtraction(field, "https://example.com", null);
+          expect(result).toEqual({ valid: true });
+        });
+
+        it("accepts valid http URL", () => {
+          const result = validateExtraction(field, "http://example.com/park", null);
+          expect(result).toEqual({ valid: true });
+        });
+
+        it("rejects invalid URL (no protocol)", () => {
+          const result = validateExtraction(field, "example.com", null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("not a valid URL");
+        });
+
+        it("rejects random string", () => {
+          const result = validateExtraction(field, "not a url at all", null);
+          expect(result.valid).toBe(false);
+        });
+
+        it("rejects non-string", () => {
+          const result = validateExtraction(field, 12345, null);
+          expect(result.valid).toBe(false);
+          expect(result.reason).toContain("must be a string");
+        });
+      });
+    }
+  });
+
+  // ---- Email ----
+  describe("contactEmail", () => {
+    it("accepts valid email", () => {
+      const result = validateExtraction("contactEmail", "info@park.com", null);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts email with subdomain", () => {
+      const result = validateExtraction("contactEmail", "user@mail.park.org", null);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects email without @", () => {
+      const result = validateExtraction("contactEmail", "notanemail", null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("not a valid email");
+    });
+
+    it("rejects email without dot after @", () => {
+      const result = validateExtraction("contactEmail", "user@nodot", null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects empty string", () => {
+      const result = validateExtraction("contactEmail", "", null);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects non-string", () => {
+      const result = validateExtraction("contactEmail", 123, null);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain("must be a string");
+    });
+
+    it("rejects email with spaces", () => {
+      const result = validateExtraction("contactEmail", "user @park.com", null);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // ---- Unknown / other fields ----
+  describe("unknown fields", () => {
+    it("always passes for unrecognized fields", () => {
+      expect(validateExtraction("notes", "some notes", null)).toEqual({ valid: true });
+    });
+
+    it("always passes for acres", () => {
+      expect(validateExtraction("acres", 500, null)).toEqual({ valid: true });
+    });
+
+    it("always passes for isFree", () => {
+      expect(validateExtraction("isFree", true, null)).toEqual({ valid: true });
+    });
+
+    it("always passes for address.city", () => {
+      expect(validateExtraction("address.city", "Denver", null)).toEqual({ valid: true });
+    });
+
+    it("passes for terrain array (enum enforcement is Zod's job)", () => {
+      expect(validateExtraction("terrain", ["sand", "rocks"], null)).toEqual({ valid: true });
+    });
+  });
+
+  // ---- Edge cases ----
+  describe("edge cases", () => {
+    it("latitude at exactly 0 is valid", () => {
+      expect(validateExtraction("latitude", 0, null)).toEqual({ valid: true });
+    });
+
+    it("longitude at exactly 0 is valid", () => {
+      expect(validateExtraction("longitude", 0, null)).toEqual({ valid: true });
+    });
+
+    it("latitude at exactly -90 is valid", () => {
+      expect(validateExtraction("latitude", -90, null)).toEqual({ valid: true });
+    });
+
+    it("longitude at exactly 180 is valid", () => {
+      expect(validateExtraction("longitude", 180, null)).toEqual({ valid: true });
+    });
+
+    it("price at exactly 0 is valid", () => {
+      expect(validateExtraction("dayPassUSD", 0, null)).toEqual({ valid: true });
+    });
+
+    it("price at exactly 500 is valid", () => {
+      expect(validateExtraction("dayPassUSD", 500, null)).toEqual({ valid: true });
+    });
+
+    it("price at 500.01 is invalid", () => {
+      const result = validateExtraction("dayPassUSD", 500.01, null);
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/test/lib/ai/park-discovery.test.ts
+++ b/test/lib/ai/park-discovery.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  levenshteinDistance,
+  normalizeParkName,
+} from "@/lib/ai/park-discovery";
+
+describe("levenshteinDistance", () => {
+  it("should return 0 for identical strings", () => {
+    expect(levenshteinDistance("hello", "hello")).toBe(0);
+  });
+
+  it("should return 0 for two empty strings", () => {
+    expect(levenshteinDistance("", "")).toBe(0);
+  });
+
+  it("should return length of other string when one is empty", () => {
+    expect(levenshteinDistance("", "abc")).toBe(3);
+    expect(levenshteinDistance("abc", "")).toBe(3);
+  });
+
+  it("should return 1 for a single character difference", () => {
+    expect(levenshteinDistance("cat", "bat")).toBe(1);
+    expect(levenshteinDistance("cat", "car")).toBe(1);
+    expect(levenshteinDistance("cat", "cats")).toBe(1);
+  });
+
+  it("should return 2 for two-character differences", () => {
+    expect(levenshteinDistance("cat", "bar")).toBe(2);
+  });
+
+  it("should return high distance for completely different strings", () => {
+    expect(levenshteinDistance("abc", "xyz")).toBe(3);
+    expect(levenshteinDistance("hello", "world")).toBeGreaterThanOrEqual(4);
+  });
+
+  it("should be symmetric", () => {
+    expect(levenshteinDistance("kitten", "sitting")).toBe(
+      levenshteinDistance("sitting", "kitten")
+    );
+  });
+
+  it("should handle classic kitten/sitting example", () => {
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+  });
+});
+
+describe("normalizeParkName", () => {
+  it("should lowercase the name", () => {
+    expect(normalizeParkName("Glamis Dunes")).toBe("glamis dunes");
+  });
+
+  it("should strip common suffixes like 'park'", () => {
+    expect(normalizeParkName("Glamis Dunes Park")).toBe("glamis dunes");
+  });
+
+  it("should strip 'off-road' and 'offroad'", () => {
+    expect(normalizeParkName("Hollister Hills Off-Road")).toBe(
+      "hollister hills"
+    );
+    expect(normalizeParkName("Hollister Hills Offroad")).toBe(
+      "hollister hills"
+    );
+  });
+
+  it("should strip 'OHV' and 'ATV'", () => {
+    expect(normalizeParkName("Pismo Beach OHV")).toBe("pismo beach");
+    expect(normalizeParkName("Some ATV Area")).toBe("some");
+  });
+
+  it("should strip 'trails' and 'trail'", () => {
+    expect(normalizeParkName("Mountain Creek Trails")).toBe("mountain creek");
+    expect(normalizeParkName("Pine Trail")).toBe("pine");
+  });
+
+  it("should strip 'recreation' and 'recreational'", () => {
+    expect(normalizeParkName("Ocotillo Wells Recreation")).toBe(
+      "ocotillo wells"
+    );
+    expect(normalizeParkName("Ocotillo Wells Recreational")).toBe(
+      "ocotillo wells"
+    );
+  });
+
+  it("should strip 'riding' and 'area'", () => {
+    expect(normalizeParkName("Clear Creek Riding Area")).toBe("clear creek");
+  });
+
+  it("should strip multiple suffixes at once", () => {
+    expect(
+      normalizeParkName("Hollister Hills OHV Recreation Area")
+    ).toBe("hollister hills");
+  });
+
+  it("should remove non-alphanumeric characters", () => {
+    expect(normalizeParkName("St. Anthony's Sand-Dunes")).toBe(
+      "st anthony s sand dunes"
+    );
+  });
+
+  it("should collapse multiple spaces", () => {
+    expect(normalizeParkName("  Glamis   Dunes   Park  ")).toBe(
+      "glamis dunes"
+    );
+  });
+});
+
+describe("fuzzy dedup logic", () => {
+  it("should detect exact name match after normalization", () => {
+    const a = normalizeParkName("Glamis Dunes OHV Park");
+    const b = normalizeParkName("Glamis Dunes Off-Road Park");
+    expect(a).toBe("glamis dunes");
+    expect(b).toBe("glamis dunes");
+    expect(levenshteinDistance(a, b)).toBe(0);
+  });
+
+  it("should detect near-match within threshold (short names)", () => {
+    const a = normalizeParkName("Pismo Beach");
+    const b = normalizeParkName("Pismo Bech"); // typo
+    const dist = levenshteinDistance(a, b);
+    // "pismo beach" vs "pismo bech" — distance should be small
+    expect(dist).toBeLessThanOrEqual(3);
+  });
+
+  it("should detect near-match within threshold (long names)", () => {
+    const a = normalizeParkName("St Anthony Sand Dunes Special Recreation");
+    const b = normalizeParkName(
+      "Saint Anthony Sand Dunes Special Recreation"
+    );
+    const normA = normalizeParkName(a);
+    const normB = normalizeParkName(b);
+    const dist = levenshteinDistance(normA, normB);
+    // "st anthony sand dunes" vs "saint anthony sand dunes" — some difference
+    // With suffix stripping, these become shorter; distance of ~3 is within the <=5 threshold
+    expect(dist).toBeLessThanOrEqual(5);
+  });
+
+  it("should NOT match genuinely different parks", () => {
+    const a = normalizeParkName("Glamis Dunes");
+    const b = normalizeParkName("Pismo Beach");
+    const dist = levenshteinDistance(a, b);
+    expect(dist).toBeGreaterThan(3);
+  });
+
+  it("should catch duplicate with 'OHV' vs no suffix", () => {
+    const a = normalizeParkName("Carnegie SVRA OHV Park");
+    const b = normalizeParkName("Carnegie SVRA");
+    // Both normalize — "ohv" and "park" stripped
+    expect(levenshteinDistance(a, b)).toBe(0);
+  });
+});

--- a/test/lib/ai/wrong-park-guard.test.ts
+++ b/test/lib/ai/wrong-park-guard.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateObject } from "ai";
+import { validateParkRelevance } from "@/lib/ai/wrong-park-guard";
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/config", () => ({
+  EXTRACTION_MODEL: "mock-model",
+}));
+
+const mockGenerateObject = vi.mocked(generateObject);
+
+describe("validateParkRelevance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return isRelevant: true when content is about the target park", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        isAboutTargetPark: true,
+        reason: "The page is primarily about Hollister Hills SVRA.",
+      },
+      usage: { inputTokens: 500, outputTokens: 50 },
+    } as never);
+
+    const result = await validateParkRelevance(
+      "Hollister Hills SVRA",
+      "California",
+      "Welcome to Hollister Hills State Vehicular Recreation Area. We offer 150 miles of trails for OHV riding.",
+    );
+
+    expect(result.isRelevant).toBe(true);
+    expect(result.reason).toBe(
+      "The page is primarily about Hollister Hills SVRA.",
+    );
+    expect(result.inputTokens).toBe(500);
+    expect(result.outputTokens).toBe(50);
+  });
+
+  it("should return isRelevant: false when content is about a different park", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: {
+        isAboutTargetPark: false,
+        reason:
+          "This is a directory page listing dozens of OHV parks in California.",
+      },
+      usage: { inputTokens: 600, outputTokens: 40 },
+    } as never);
+
+    const result = await validateParkRelevance(
+      "Hollister Hills SVRA",
+      "California",
+      "California OHV Parks Directory: Hollister Hills, Oceano Dunes, Carnegie, Hungry Valley...",
+    );
+
+    expect(result.isRelevant).toBe(false);
+    expect(result.reason).toBe(
+      "This is a directory page listing dozens of OHV parks in California.",
+    );
+    expect(result.inputTokens).toBe(600);
+    expect(result.outputTokens).toBe(40);
+  });
+
+  it("should truncate content to 4000 characters", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: { isAboutTargetPark: true, reason: "Content is relevant." },
+      usage: { inputTokens: 800, outputTokens: 30 },
+    } as never);
+
+    const longContent = "A".repeat(10_000);
+    await validateParkRelevance("Test Park", "Texas", longContent);
+
+    const callArgs = mockGenerateObject.mock.calls[0]![0];
+    const prompt = callArgs.prompt as string;
+
+    // The prompt should contain the truncated content (4000 chars of "A")
+    // but NOT the full 10,000 chars
+    expect(prompt).toContain("A".repeat(4000));
+    expect(prompt).not.toContain("A".repeat(4001));
+  });
+
+  it("should return zero tokens when usage is undefined", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: { isAboutTargetPark: true, reason: "Relevant content." },
+      usage: undefined,
+    } as never);
+
+    const result = await validateParkRelevance(
+      "Test Park",
+      "Texas",
+      "Some content about Test Park.",
+    );
+
+    expect(result.inputTokens).toBe(0);
+    expect(result.outputTokens).toBe(0);
+  });
+
+  it("should pass the correct system and user prompts", async () => {
+    mockGenerateObject.mockResolvedValue({
+      object: { isAboutTargetPark: true, reason: "Relevant." },
+      usage: { inputTokens: 100, outputTokens: 20 },
+    } as never);
+
+    await validateParkRelevance("Red River Gorge OHV", "Kentucky", "Trail info here.");
+
+    const callArgs = mockGenerateObject.mock.calls[0]![0];
+    expect(callArgs.system).toBe(
+      "You are validating whether web page content is primarily about a specific off-road park. Answer based on the content provided.",
+    );
+    expect(callArgs.prompt).toContain("Red River Gorge OHV");
+    expect(callArgs.prompt).toContain("Kentucky");
+    expect(callArgs.prompt).toContain("Trail info here.");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
         // AI Research Engine - integration-only files
         "src/lib/ai/research-pipeline.ts", // Orchestrator: Prisma + LLM + network
         "src/lib/ai/park-data-extractor.ts", // LLM wrapper: requires Anthropic API
+        "src/lib/ai/park-discovery.ts", // Discovery: SerpApi + LLM + Prisma (helpers tested separately)
         "src/lib/ai/field-display-names.ts", // Pure constant map, no logic
 
         // AI Research - server components and API routes with Prisma/auth deps


### PR DESCRIPTION
Six stories implemented, three deferred with scaffolds:

OP-78: Domain Reliability Tiers
  - DomainReliability model with admin CRUD API + UI table
  - Seeded with known-good domains (.gov, riderplanet-usa, etc.)
  - Source discovery pipeline auto-inherits domain reliability
  - Blocked domains skip source creation entirely

OP-79: Extraction Accuracy Feedback Loop
  - approveCount/rejectCount on DataSource, incremented per review
  - Domain accuracy aggregation in getDomainAccuracyStats()
  - Dashboard widget showing domain accuracy trends
  - Low-accuracy badge (<20%) on SourceManagementTable

OP-81: Wrong-Park Detection Guard
  - LLM validation call per source before extraction
  - "Is this content about [park] in [state]?" check
  - Auto-marks WRONG_PARK on failure, saves extraction tokens

OP-82: Post-Extraction Validation Rules
  - lat/lng state bounding box check (all 50 states)
  - Price range $0-500, phone 10+ digits, URL/email format
  - Invalid fields dropped with warnings on session summary

OP-85: Park Discovery Pipeline
  - ParkCandidate model for discovered park candidates
  - SerpApi search + LLM structured extraction from snippets
  - Levenshtein fuzzy dedup against existing parks
  - POST /api/admin/ai-research/discovery trigger

OP-86: Park Discovery Admin Page
  - /admin/ai-research/discovery with candidate table
  - Accept (seeds Park + triggers research), Reject, Bulk actions
  - State selector to trigger new discovery searches
  - Nav link added to admin sidebar

Scaffolds (OP-80, OP-83, OP-84):
  - bulk-research.ts, cross-validation.ts stubs
  - /admin/ai-research/conflicts coming-soon page

Schema: DomainReliability + ParkCandidate models, ParkCandidateStatus enum, approveCount/rejectCount on DataSource.
Tests: 113 new (wrong-park-guard, extraction-validator, park-discovery).