### PR TITLE
Operator: per-park display name override

### DIFF
--- a/prisma/migrations/20260421013454_park_operator_display_name/migration.sql
+++ b/prisma/migrations/20260421013454_park_operator_display_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Park" ADD COLUMN "operatorDisplayName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,8 @@ model Park {
   address          Address?
   operator         Operator?        @relation(fields: [operatorId], references: [id], onDelete: SetNull)
   operatorId       String?
+  // Per-park override of the operator org name displayed on the park detail page
+  operatorDisplayName String?
   parkClaims       ParkClaim[]
   editLogs         ParkEditLog[]
 

--- a/src/app/api/operator/parks/[parkSlug]/route.ts
+++ b/src/app/api/operator/parks/[parkSlug]/route.ts
@@ -33,7 +33,11 @@ const ALLOWED_SCALAR_FIELDS = new Set([
   "sparkArrestorRequired",
   "helmetsRequired",
   "noiseLimitDBA",
+  "operatorDisplayName",
 ]);
+
+// Maximum length for the per-park operator display name override
+const OPERATOR_DISPLAY_NAME_MAX_LENGTH = 200;
 
 // Array/relation fields that operators can update
 const ALLOWED_ARRAY_FIELDS = new Set(["terrain", "amenities", "camping", "vehicleTypes"]);
@@ -66,6 +70,7 @@ const PARK_SCALAR_SELECT = {
   sparkArrestorRequired: true,
   helmetsRequired: true,
   noiseLimitDBA: true,
+  operatorDisplayName: true,
 } as const;
 
 const PARK_ARRAY_SELECT = {
@@ -136,12 +141,33 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   const updateData: PatchBody = {};
   const changes: Record<string, { from: unknown; to: unknown }> = {};
 
+  // Validate operatorDisplayName length (if provided) before any normalization
+  if ("operatorDisplayName" in body) {
+    const raw = body.operatorDisplayName;
+    if (typeof raw === "string" && raw.trim().length > OPERATOR_DISPLAY_NAME_MAX_LENGTH) {
+      return NextResponse.json(
+        { error: `operatorDisplayName must be at most ${OPERATOR_DISPLAY_NAME_MAX_LENGTH} characters` },
+        { status: 400 }
+      );
+    }
+  }
+
   for (const [key, value] of Object.entries(body)) {
     if (!ALLOWED_SCALAR_FIELDS.has(key)) continue;
+    let normalized: unknown = value;
+    // Trim operatorDisplayName; empty or whitespace-only → null so the override falls back
+    if (key === "operatorDisplayName") {
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        normalized = trimmed.length === 0 ? null : trimmed;
+      } else if (value == null) {
+        normalized = null;
+      }
+    }
     const currentValue = (park as Record<string, unknown>)[key];
-    if (currentValue !== value) {
-      updateData[key] = value;
-      changes[key] = { from: currentValue, to: value };
+    if (currentValue !== normalized) {
+      updateData[key] = normalized;
+      changes[key] = { from: currentValue, to: normalized };
     }
   }
 

--- a/src/app/operator/[parkSlug]/settings/OperatorSettingsClient.tsx
+++ b/src/app/operator/[parkSlug]/settings/OperatorSettingsClient.tsx
@@ -13,6 +13,7 @@ import { CheckCircle, MapPin } from "lucide-react";
 
 interface ParkData {
   name: string;
+  operatorDisplayName: string | null;
   website: string | null;
   phone: string | null;
   campingWebsite: string | null;
@@ -147,6 +148,22 @@ export function OperatorSettingsClient({ parkSlug, parkName }: OperatorSettingsC
                 onChange={(e) => handleChange("name", e.target.value)}
                 className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
               />
+            </div>
+            <div>
+              <label className="text-sm font-medium block mb-1">
+                Display name on park detail page
+              </label>
+              <input
+                type="text"
+                maxLength={200}
+                value={park.operatorDisplayName ?? ""}
+                onChange={(e) => handleChange("operatorDisplayName", e.target.value)}
+                className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                placeholder="e.g. Desert Riders Association"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Shown publicly as &ldquo;This listing is managed by {"{name}"}&rdquo;. Leave blank to use your account name.
+              </p>
             </div>
             <div className="grid sm:grid-cols-2 gap-4">
               <div>

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -80,6 +80,13 @@ export default async function ParkPage({ params }: ParkPageProps) {
     notFound();
   }
 
+  // Resolve the operator display name: prefer the per-park override when it is
+  // a non-empty trimmed string, otherwise fall back to the operator org name.
+  const override = dbPark.operatorDisplayName?.trim();
+  const resolvedOperatorName = override && override.length > 0
+    ? override
+    : (dbPark.operator?.name ?? null);
+
   // Fetch approved photos for this park
   const photos = await prisma.parkPhoto.findMany({
     where: {
@@ -132,7 +139,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
       parkDbId={dbPark.id}
       existingClaim={existingClaim}
       isOperatorOfPark={isOperatorOfPark}
-      operatorName={dbPark.operator?.name ?? null}
+      operatorName={resolvedOperatorName}
     />
   );
 }

--- a/test/app/api/operator/parks/[parkSlug]/route.test.ts
+++ b/test/app/api/operator/parks/[parkSlug]/route.test.ts
@@ -65,6 +65,7 @@ const mockPark = {
   sparkArrestorRequired: null,
   helmetsRequired: null,
   noiseLimitDBA: null,
+  operatorDisplayName: null,
   terrain: [{ terrain: "sand" }, { terrain: "rocks" }],
   amenities: [{ amenity: "restrooms" }],
   camping: [],
@@ -226,6 +227,91 @@ describe("PATCH /api/operator/parks/[parkSlug]", () => {
     });
     // Amenity not changed — should not be touched
     expect(txParkAmenity.deleteMany).not.toHaveBeenCalled();
+  });
+
+  describe("operatorDisplayName", () => {
+    it("should accept and trim operatorDisplayName", async () => {
+      (auth as any).mockResolvedValue(operatorSession);
+      (prisma.park.findUnique as any).mockResolvedValue(mockPark);
+
+      const txParkUpdate = vi.fn().mockResolvedValue({});
+      const updatedPark = { ...mockPark, operatorDisplayName: "Custom Name" };
+
+      (prisma.$transaction as any).mockImplementation(async (fn: any) => {
+        return fn({
+          park: {
+            update: txParkUpdate,
+            findUnique: vi.fn().mockResolvedValue(updatedPark),
+          },
+          parkTerrain: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkAmenity: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkCamping: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkVehicleType: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkEditLog: { create: vi.fn().mockResolvedValue({ id: "log-1" }) },
+        });
+      });
+
+      const response = await PATCH(
+        makePatchRequest({ operatorDisplayName: "  Custom Name  " }),
+        { params: Promise.resolve({ parkSlug: "test-park" }) }
+      );
+
+      expect(response.status).toBe(200);
+      expect(txParkUpdate).toHaveBeenCalledWith({
+        where: { id: "park-1" },
+        data: { operatorDisplayName: "Custom Name" },
+      });
+    });
+
+    it("should normalize empty/whitespace-only operatorDisplayName to null", async () => {
+      (auth as any).mockResolvedValue(operatorSession);
+      (prisma.park.findUnique as any).mockResolvedValue({
+        ...mockPark,
+        operatorDisplayName: "Previous",
+      });
+
+      const txParkUpdate = vi.fn().mockResolvedValue({});
+      const updatedPark = { ...mockPark, operatorDisplayName: null };
+
+      (prisma.$transaction as any).mockImplementation(async (fn: any) => {
+        return fn({
+          park: {
+            update: txParkUpdate,
+            findUnique: vi.fn().mockResolvedValue(updatedPark),
+          },
+          parkTerrain: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkAmenity: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkCamping: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkVehicleType: { deleteMany: vi.fn(), createMany: vi.fn() },
+          parkEditLog: { create: vi.fn().mockResolvedValue({ id: "log-1" }) },
+        });
+      });
+
+      const response = await PATCH(
+        makePatchRequest({ operatorDisplayName: "   " }),
+        { params: Promise.resolve({ parkSlug: "test-park" }) }
+      );
+
+      expect(response.status).toBe(200);
+      expect(txParkUpdate).toHaveBeenCalledWith({
+        where: { id: "park-1" },
+        data: { operatorDisplayName: null },
+      });
+    });
+
+    it("should reject operatorDisplayName longer than 200 characters", async () => {
+      (auth as any).mockResolvedValue(operatorSession);
+      (prisma.park.findUnique as any).mockResolvedValue(mockPark);
+
+      const response = await PATCH(
+        makePatchRequest({ operatorDisplayName: "a".repeat(201) }),
+        { params: Promise.resolve({ parkSlug: "test-park" }) }
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toMatch(/200 characters/);
+    });
   });
 
   it("should handle clearing all terrain by passing empty array", async () => {

--- a/test/app/parks/[id]/page.test.tsx
+++ b/test/app/parks/[id]/page.test.tsx
@@ -33,13 +33,14 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/features/parks/detail/ParkDetailPage", () => ({
-  ParkDetailPage: ({ park, photos, currentUserId, isAdmin }: any) => (
+  ParkDetailPage: ({ park, photos, currentUserId, isAdmin, operatorName }: any) => (
     <div data-testid="park-detail-page">
       <h1>{park.name}</h1>
       <div data-testid="park-state">{park.state}</div>
       <div data-testid="photos-count">{photos.length} photos</div>
       <div data-testid="user-id">{currentUserId || "no-user"}</div>
       <div data-testid="is-admin">{isAdmin ? "admin" : "not-admin"}</div>
+      <div data-testid="operator-name">{operatorName ?? "no-operator"}</div>
     </div>
   ),
 }));
@@ -318,6 +319,84 @@ describe("Park Detail Page", () => {
       render(component);
 
       expect(screen.getByTestId("photos-count")).toHaveTextContent("0 photos");
+    });
+
+    describe("operator display name resolution", () => {
+      it("should use operatorDisplayName override when it is a non-empty trimmed string", async () => {
+        vi.mocked(prisma.park.findUnique).mockResolvedValue({
+          ...mockDbPark,
+          operatorDisplayName: "Custom Display Name",
+          operator: { name: "Account Name" },
+        } as any);
+        vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+        vi.mocked(auth).mockResolvedValue(null as any);
+
+        const component = await ParkPage({
+          params: Promise.resolve({ id: "test-park" }),
+        });
+        render(component);
+
+        expect(screen.getByTestId("operator-name")).toHaveTextContent(
+          "Custom Display Name"
+        );
+      });
+
+      it("should fall back to operator.name when operatorDisplayName is null", async () => {
+        vi.mocked(prisma.park.findUnique).mockResolvedValue({
+          ...mockDbPark,
+          operatorDisplayName: null,
+          operator: { name: "Account Name" },
+        } as any);
+        vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+        vi.mocked(auth).mockResolvedValue(null as any);
+
+        const component = await ParkPage({
+          params: Promise.resolve({ id: "test-park" }),
+        });
+        render(component);
+
+        expect(screen.getByTestId("operator-name")).toHaveTextContent(
+          "Account Name"
+        );
+      });
+
+      it("should fall back to operator.name when operatorDisplayName is whitespace-only", async () => {
+        vi.mocked(prisma.park.findUnique).mockResolvedValue({
+          ...mockDbPark,
+          operatorDisplayName: "   ",
+          operator: { name: "Account Name" },
+        } as any);
+        vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+        vi.mocked(auth).mockResolvedValue(null as any);
+
+        const component = await ParkPage({
+          params: Promise.resolve({ id: "test-park" }),
+        });
+        render(component);
+
+        expect(screen.getByTestId("operator-name")).toHaveTextContent(
+          "Account Name"
+        );
+      });
+
+      it("should pass null when neither override nor operator is set", async () => {
+        vi.mocked(prisma.park.findUnique).mockResolvedValue({
+          ...mockDbPark,
+          operatorDisplayName: null,
+          operator: null,
+        } as any);
+        vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+        vi.mocked(auth).mockResolvedValue(null as any);
+
+        const component = await ParkPage({
+          params: Promise.resolve({ id: "test-park" }),
+        });
+        render(component);
+
+        expect(screen.getByTestId("operator-name")).toHaveTextContent(
+          "no-operator"
+        );
+      });
     });
 
     it("should pass current user ID to detail page", async () => {


### PR DESCRIPTION
## Summary

- Adds `Park.operatorDisplayName String?` so operators can override the organization name displayed on their park detail page ("This listing is managed by {name}").
- Park detail page resolves the display name as: trimmed `operatorDisplayName` if non-empty, otherwise `operator.name`, otherwise `null` (which already renders as "a verified operator").
- Operator settings UI (`OperatorSettingsClient`) gains a "Display name on park detail page" text field with helper copy; persisted via the existing `PATCH /api/operator/parks/[parkSlug]`.
- API route accepts `operatorDisplayName`, trims input, normalizes empty/whitespace to `null`, and rejects values longer than 200 characters with a 400.

## Migration

New versioned migration `prisma/migrations/20260421013454_park_operator_display_name` adds a nullable `operatorDisplayName TEXT` column to `Park`. No data backfill required — existing parks keep the current behavior (falls through to `operator.name`).

## Fallback behavior

| `operatorDisplayName` | `operator.name` | Rendered |
| --- | --- | --- |
| `"Custom Co."` | `"Account Name"` | `Custom Co.` |
| `null` | `"Account Name"` | `Account Name` |
| `"   "` (whitespace) | `"Account Name"` | `Account Name` |
| `null` | `null` | `a verified operator` (pre-existing fallback) |

## Test plan

- [x] `npm run lint` — no new errors
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 1823 tests pass
- [ ] Manual: as an operator, visit `/operator/[slug]/settings`, fill "Display name on park detail page", save, confirm it appears on `/parks/[slug]` under "This listing is managed by ...".
- [ ] Manual: clear the field, save, confirm detail page falls back to the operator account name.
- [ ] Manual: attempt to save a value longer than 200 chars, confirm the API returns 400.