### PR TITLE
Operator: select park card hero photo

### DIFF
--- a/prisma/migrations/20260421000000_park_hero_selection/migration.sql
+++ b/prisma/migrations/20260421000000_park_hero_selection/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "HeroSource" AS ENUM ('AUTO', 'PHOTO', 'MAP');
+
+-- AlterTable
+ALTER TABLE "Park" ADD COLUMN     "heroPhotoId" TEXT,
+ADD COLUMN     "heroSource" "HeroSource" NOT NULL DEFAULT 'AUTO';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Park_heroPhotoId_key" ON "Park"("heroPhotoId");
+
+-- AddForeignKey
+ALTER TABLE "Park" ADD CONSTRAINT "Park_heroPhotoId_fkey" FOREIGN KEY ("heroPhotoId") REFERENCES "ParkPhoto"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -117,6 +117,14 @@ model Park {
   mapHeroUrl          String?
   mapHeroGeneratedAt  DateTime?
 
+  // Operator-selected hero image for their park card.
+  // - heroSource AUTO (default): first APPROVED photo, falls back to map hero.
+  // - heroSource PHOTO: use heroPhotoId (must be an APPROVED photo on this park).
+  // - heroSource MAP: force use of map hero (mapHeroUrl or live ParkMapHero).
+  heroPhotoId String?    @unique
+  heroPhoto   ParkPhoto? @relation("ParkHeroPhoto", fields: [heroPhotoId], references: [id], onDelete: SetNull)
+  heroSource  HeroSource @default(AUTO)
+
   // Aggregated review data
   averageRating            Float?
   averageDifficulty        Float?
@@ -374,8 +382,9 @@ model ParkPhoto {
   caption String?     @db.Text
   status  PhotoStatus @default(PENDING)
 
-  park Park  @relation(fields: [parkId], references: [id], onDelete: Cascade)
-  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  park       Park  @relation(fields: [parkId], references: [id], onDelete: Cascade)
+  user       User? @relation(fields: [userId], references: [id], onDelete: SetNull)
+  heroForPark Park? @relation("ParkHeroPhoto")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -384,6 +393,12 @@ model ParkPhoto {
   @@index([parkId])
   @@index([userId])
   @@index([status])
+}
+
+enum HeroSource {
+  AUTO
+  PHOTO
+  MAP
 }
 
 enum PhotoStatus {

--- a/src/app/api/operator/parks/[parkSlug]/route.ts
+++ b/src/app/api/operator/parks/[parkSlug]/route.ts
@@ -35,6 +35,8 @@ const ALLOWED_SCALAR_FIELDS = new Set([
   "noiseLimitDBA",
 ]);
 
+const VALID_HERO_SOURCES = new Set(["AUTO", "PHOTO", "MAP"]);
+
 // Array/relation fields that operators can update
 const ALLOWED_ARRAY_FIELDS = new Set(["terrain", "amenities", "camping", "vehicleTypes"]);
 
@@ -66,6 +68,8 @@ const PARK_SCALAR_SELECT = {
   sparkArrestorRequired: true,
   helmetsRequired: true,
   noiseLimitDBA: true,
+  heroSource: true,
+  heroPhotoId: true,
 } as const;
 
 const PARK_ARRAY_SELECT = {
@@ -142,6 +146,77 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (currentValue !== value) {
       updateData[key] = value;
       changes[key] = { from: currentValue, to: value };
+    }
+  }
+
+  // Hero selection: heroSource + heroPhotoId. Validate before applying.
+  if ("heroSource" in body || "heroPhotoId" in body) {
+    const incomingSource =
+      "heroSource" in body ? body.heroSource : park.heroSource;
+    const incomingPhotoId =
+      "heroPhotoId" in body
+        ? (body.heroPhotoId as string | null | undefined)
+        : park.heroPhotoId;
+
+    if (
+      typeof incomingSource !== "string" ||
+      !VALID_HERO_SOURCES.has(incomingSource)
+    ) {
+      return NextResponse.json(
+        { error: "Invalid heroSource" },
+        { status: 400 }
+      );
+    }
+
+    // heroPhotoId must be null/undefined OR reference an APPROVED photo on this park.
+    let resolvedPhotoId: string | null = null;
+    if (incomingSource === "PHOTO") {
+      if (!incomingPhotoId || typeof incomingPhotoId !== "string") {
+        return NextResponse.json(
+          { error: "heroPhotoId is required when heroSource is PHOTO" },
+          { status: 400 }
+        );
+      }
+      const photo = await prisma.parkPhoto.findUnique({
+        where: { id: incomingPhotoId },
+        select: { id: true, parkId: true, status: true },
+      });
+      if (!photo || photo.parkId !== park.id) {
+        return NextResponse.json(
+          { error: "heroPhotoId does not belong to this park" },
+          { status: 400 }
+        );
+      }
+      if (photo.status !== "APPROVED") {
+        return NextResponse.json(
+          { error: "heroPhotoId must reference an APPROVED photo" },
+          { status: 400 }
+        );
+      }
+      resolvedPhotoId = photo.id;
+    } else if (incomingPhotoId && typeof incomingPhotoId === "string") {
+      // Caller supplied a photoId but source != PHOTO — validate it still
+      // belongs to this park (and approved), so we can persist it for an
+      // easy toggle back without losing the selection.
+      const photo = await prisma.parkPhoto.findUnique({
+        where: { id: incomingPhotoId },
+        select: { id: true, parkId: true, status: true },
+      });
+      if (!photo || photo.parkId !== park.id || photo.status !== "APPROVED") {
+        // Silently clear rather than 400 — non-PHOTO modes don't use it.
+        resolvedPhotoId = null;
+      } else {
+        resolvedPhotoId = photo.id;
+      }
+    }
+
+    if (incomingSource !== park.heroSource) {
+      updateData.heroSource = incomingSource;
+      changes.heroSource = { from: park.heroSource, to: incomingSource };
+    }
+    if (resolvedPhotoId !== park.heroPhotoId) {
+      updateData.heroPhotoId = resolvedPhotoId;
+      changes.heroPhotoId = { from: park.heroPhotoId, to: resolvedPhotoId };
     }
   }
 

--- a/src/app/operator/[parkSlug]/OperatorSidebar.tsx
+++ b/src/app/operator/[parkSlug]/OperatorSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { Activity, BarChart3, MapPin } from "lucide-react";
+import { Activity, BarChart3, Image, MapPin } from "lucide-react";
 
 interface OperatorSidebarProps {
   parkSlug: string;
@@ -17,6 +17,7 @@ export function OperatorSidebar({ parkSlug }: OperatorSidebarProps) {
     { href: `/operator/${parkSlug}/dashboard${fromParam}`, label: "Dashboard", icon: BarChart3 },
     { href: `/operator/${parkSlug}/conditions${fromParam}`, label: "Trail Status", icon: Activity },
     { href: `/operator/${parkSlug}/settings${fromParam}`, label: "Park Details", icon: MapPin },
+    { href: `/operator/${parkSlug}/park-card${fromParam}`, label: "Park Card", icon: Image },
   ];
 
   return (

--- a/src/app/operator/[parkSlug]/park-card/ParkCardSelectorClient.tsx
+++ b/src/app/operator/[parkSlug]/park-card/ParkCardSelectorClient.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ParkCard } from "@/components/parks/ParkCard";
+import { ParkMapHero } from "@/components/parks/ParkMapHero";
+import type { Park } from "@/lib/types";
+import { resolveParkHeroImage } from "@/lib/park-hero";
+import Image from "next/image";
+import { CheckCircle } from "lucide-react";
+
+type HeroSource = "AUTO" | "PHOTO" | "MAP";
+
+interface ApprovedPhoto {
+  id: string;
+  url: string;
+  caption: string | null;
+}
+
+interface Props {
+  parkSlug: string;
+  previewPark: Park;
+  approvedPhotos: ApprovedPhoto[];
+  initialHeroSource: HeroSource;
+  initialHeroPhotoId: string | null;
+}
+
+export function ParkCardSelectorClient({
+  parkSlug,
+  previewPark,
+  approvedPhotos,
+  initialHeroSource,
+  initialHeroPhotoId,
+}: Props) {
+  const [heroSource, setHeroSource] = useState<HeroSource>(initialHeroSource);
+  const [heroPhotoId, setHeroPhotoId] = useState<string | null>(
+    initialHeroPhotoId
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Compute the preview park shape live so the ParkCard reflects the current
+  // selection without a server round-trip.
+  const previewWithHero = useMemo<Park>(() => {
+    const selectedPhoto = approvedPhotos.find((p) => p.id === heroPhotoId);
+    const heroImage = resolveParkHeroImage({
+      heroSource,
+      heroPhotoId,
+      heroPhoto: selectedPhoto
+        ? { id: selectedPhoto.id, url: selectedPhoto.url, status: "APPROVED" }
+        : null,
+      photos: approvedPhotos.map((p) => ({
+        id: p.id,
+        url: p.url,
+        status: "APPROVED" as const,
+      })),
+    });
+    return { ...previewPark, heroImage: heroImage ?? undefined };
+  }, [heroSource, heroPhotoId, approvedPhotos, previewPark]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      const res = await fetch(`/api/operator/parks/${parkSlug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          heroSource,
+          heroPhotoId,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const canSave =
+    !isSaving &&
+    // Require a photo selection if source is PHOTO.
+    (heroSource !== "PHOTO" || !!heroPhotoId);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold">Park Card</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Choose which image is shown on your park&apos;s card across
+          Offroad Parks.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Live preview */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Preview</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="max-w-sm">
+              <ParkCard
+                park={previewWithHero}
+                isFavorite={false}
+                onToggleFavorite={() => {}}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Selector */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Hero image source</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <RadioRow
+              name="heroSource"
+              value="AUTO"
+              checked={heroSource === "AUTO"}
+              onChange={() => setHeroSource("AUTO")}
+              label="Auto (recommended)"
+              description="First approved photo, or the map image if you don't have any photos yet."
+            />
+
+            <RadioRow
+              name="heroSource"
+              value="MAP"
+              checked={heroSource === "MAP"}
+              onChange={() => setHeroSource("MAP")}
+              label="Use map image"
+              description="Always show the map thumbnail, even when approved photos exist."
+            >
+              <div className="mt-3 w-48 h-28 overflow-hidden rounded-md border border-border">
+                <ParkMapHero park={previewPark} hideLegend />
+              </div>
+            </RadioRow>
+
+            <RadioRow
+              name="heroSource"
+              value="PHOTO"
+              checked={heroSource === "PHOTO"}
+              onChange={() => setHeroSource("PHOTO")}
+              label="Use an uploaded photo"
+              description={
+                approvedPhotos.length === 0
+                  ? "No approved photos yet — upload one first."
+                  : "Pick any approved photo below."
+              }
+            >
+              {approvedPhotos.length > 0 && heroSource === "PHOTO" && (
+                <div className="mt-3 grid grid-cols-3 gap-2">
+                  {approvedPhotos.map((photo) => {
+                    const selected = photo.id === heroPhotoId;
+                    return (
+                      <button
+                        key={photo.id}
+                        type="button"
+                        onClick={() => setHeroPhotoId(photo.id)}
+                        className={`relative aspect-[4/3] overflow-hidden rounded-md border-2 transition ${
+                          selected
+                            ? "border-primary ring-2 ring-primary/30"
+                            : "border-border hover:border-primary/40"
+                        }`}
+                        aria-pressed={selected}
+                      >
+                        <Image
+                          src={photo.url}
+                          alt={photo.caption ?? "Park photo"}
+                          fill
+                          className="object-cover"
+                          sizes="200px"
+                        />
+                        {selected && (
+                          <span className="absolute top-1 right-1 bg-primary text-primary-foreground rounded-full p-0.5">
+                            <CheckCircle className="w-4 h-4" />
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </RadioRow>
+
+            <div className="pt-4 border-t flex items-center gap-3">
+              <Button onClick={handleSave} disabled={!canSave}>
+                {isSaving ? "Saving…" : "Save"}
+              </Button>
+              {saveSuccess && (
+                <span
+                  className="text-sm text-green-700 dark:text-green-400 flex items-center gap-1"
+                  role="status"
+                >
+                  <CheckCircle className="w-4 h-4" /> Saved
+                </span>
+              )}
+              {saveError && (
+                <span className="text-sm text-red-600" role="alert">
+                  {saveError}
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function RadioRow({
+  name,
+  value,
+  checked,
+  onChange,
+  label,
+  description,
+  children,
+}: {
+  name: string;
+  value: string;
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  description?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <label
+      className={`block rounded-lg border p-4 cursor-pointer transition ${
+        checked
+          ? "border-primary bg-primary/5"
+          : "border-border hover:border-primary/40"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <input
+          type="radio"
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={onChange}
+          className="mt-1"
+        />
+        <div className="flex-1">
+          <div className="font-medium">{label}</div>
+          {description && (
+            <div className="text-sm text-muted-foreground mt-0.5">
+              {description}
+            </div>
+          )}
+          {children}
+        </div>
+      </div>
+    </label>
+  );
+}

--- a/src/app/operator/[parkSlug]/park-card/page.tsx
+++ b/src/app/operator/[parkSlug]/park-card/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from "next/navigation";
+import { getOperatorContext } from "@/lib/operator-auth";
+import { prisma } from "@/lib/prisma";
+import { transformDbPark } from "@/lib/types";
+import { ParkCardSelectorClient } from "./ParkCardSelectorClient";
+
+interface ParkCardPageProps {
+  params: Promise<{ parkSlug: string }>;
+}
+
+export default async function OperatorParkCardPage({ params }: ParkCardPageProps) {
+  const { parkSlug } = await params;
+  const ctx = await getOperatorContext(parkSlug);
+  if (!ctx) redirect("/");
+
+  const park = await prisma.park.findUnique({
+    where: { id: ctx.parkId },
+    include: {
+      terrain: true,
+      amenities: true,
+      camping: true,
+      vehicleTypes: true,
+      address: true,
+      photos: {
+        where: { status: "APPROVED" },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, url: true, caption: true, status: true },
+      },
+    },
+  });
+
+  if (!park) redirect("/");
+
+  // Shape a Park for preview; transformDbPark drops photo data, so we'll
+  // pass through heroImage / approved photos separately.
+  const previewPark = transformDbPark({
+    ...park,
+    photos: park.photos,
+  });
+
+  const approvedPhotos = park.photos.map((p) => ({
+    id: p.id,
+    url: p.url,
+    caption: p.caption ?? null,
+  }));
+
+  return (
+    <ParkCardSelectorClient
+      parkSlug={parkSlug}
+      previewPark={previewPark}
+      approvedPhotos={approvedPhotos}
+      initialHeroSource={park.heroSource}
+      initialHeroPhotoId={park.heroPhotoId}
+    />
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import UtvParksApp from "@/components/ui/OffroadParksApp";
 import { prisma } from "@/lib/prisma";
+import { resolveParkHeroImage } from "@/lib/park-hero";
 import { transformDbPark } from "@/lib/types";
 
 // Force dynamic rendering to always show fresh data
@@ -26,7 +27,16 @@ export default async function Page() {
           createdAt: "desc",
         },
         select: {
+          id: true,
           url: true,
+          status: true,
+        },
+      },
+      heroPhoto: {
+        select: {
+          id: true,
+          url: true,
+          status: true,
         },
       },
       // Latest published trail condition — drives the condition badge on
@@ -49,10 +59,10 @@ export default async function Page() {
     },
   });
 
-  // Transform to client format with hero images
+  // Transform to client format with hero images (respects operator selection)
   const parks = dbParks.map((park) => ({
     ...transformDbPark(park),
-    heroImage: park.photos[0]?.url || null,
+    heroImage: resolveParkHeroImage(park),
   }));
 
   return <UtvParksApp parks={parks} />;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { resolveParkHeroImage } from "@/lib/park-hero";
 import { transformDbPark, transformDbReview } from "@/lib/types";
 import type { DbReview } from "@/lib/types";
 import { UserProfileClient } from "@/components/profile/UserProfileClient";
@@ -32,7 +33,16 @@ export default async function ProfilePage() {
               createdAt: "desc",
             },
             select: {
+              id: true,
               url: true,
+              status: true,
+            },
+          },
+          heroPhoto: {
+            select: {
+              id: true,
+              url: true,
+              status: true,
             },
           },
         },
@@ -45,7 +55,7 @@ export default async function ProfilePage() {
     .filter((f) => f.park.status === "APPROVED")
     .map((f) => ({
       ...transformDbPark(f.park),
-      heroImage: f.park.photos[0]?.url || null,
+      heroImage: resolveParkHeroImage(f.park),
     }));
 
   // Fetch user's reviews

--- a/src/lib/park-hero.ts
+++ b/src/lib/park-hero.ts
@@ -1,0 +1,68 @@
+/**
+ * Park hero image resolution.
+ *
+ * A park's card hero image can come from three sources, controlled by the
+ * `heroSource` column on Park:
+ *
+ * - `AUTO`  (default) — Use the first APPROVED photo, or null if none (in
+ *                       which case callers fall back to the map hero).
+ * - `PHOTO`           — Use the specific `heroPhotoId` chosen by the
+ *                       operator. If that photo is missing or not APPROVED,
+ *                       fall back to AUTO behavior.
+ * - `MAP`             — Return null so the card falls back to the map hero
+ *                       (`mapHeroUrl` or live `<ParkMapHero>`).
+ *
+ * The helper accepts a minimal, structural park shape so callers do not have
+ * to load the full relation graph — `photos` should be the APPROVED subset
+ * (matching the Prisma includes used on the home/profile pages), and
+ * `heroPhoto` (if present) should be the specifically selected hero photo.
+ */
+
+export type ParkHeroInput = {
+  heroSource?: "AUTO" | "PHOTO" | "MAP" | null;
+  heroPhotoId?: string | null;
+  // Optional: the full heroPhoto relation, if loaded alongside the park.
+  heroPhoto?: {
+    id: string;
+    url: string;
+    status: "PENDING" | "APPROVED" | "REJECTED";
+  } | null;
+  // APPROVED photos list (already filtered). First entry is used for AUTO.
+  photos?: Array<{
+    id?: string;
+    url: string;
+    status?: "PENDING" | "APPROVED" | "REJECTED";
+  }>;
+};
+
+export function resolveParkHeroImage(park: ParkHeroInput): string | null {
+  const source = park.heroSource ?? "AUTO";
+
+  if (source === "MAP") {
+    // Caller falls back to the map hero (mapHeroUrl or live ParkMapHero).
+    return null;
+  }
+
+  if (source === "PHOTO" && park.heroPhotoId) {
+    // Prefer the loaded relation if available.
+    if (park.heroPhoto) {
+      if (park.heroPhoto.status === "APPROVED") {
+        return park.heroPhoto.url;
+      }
+      // Selected photo is not APPROVED — fall through to AUTO.
+    } else if (park.photos && park.photos.length > 0) {
+      // No relation loaded — look up in the APPROVED photos list.
+      const match = park.photos.find((p) => p.id === park.heroPhotoId);
+      if (match && (match.status === undefined || match.status === "APPROVED")) {
+        return match.url;
+      }
+    }
+  }
+
+  // AUTO (or PHOTO fallback): first APPROVED photo, else null.
+  const first = park.photos?.[0];
+  if (first && (first.status === undefined || first.status === "APPROVED")) {
+    return first.url;
+  }
+  return null;
+}

--- a/test/app/profile/page.test.tsx
+++ b/test/app/profile/page.test.tsx
@@ -90,7 +90,10 @@ describe("ProfilePage", () => {
               where: { status: "APPROVED" },
               take: 1,
               orderBy: { createdAt: "desc" },
-              select: { url: true },
+              select: { id: true, url: true, status: true },
+            },
+            heroPhoto: {
+              select: { id: true, url: true, status: true },
             },
           },
         },

--- a/test/lib/park-hero.test.ts
+++ b/test/lib/park-hero.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { resolveParkHeroImage } from "@/lib/park-hero";
+
+describe("resolveParkHeroImage", () => {
+  const approvedPhotoA = {
+    id: "photo-a",
+    url: "https://example.com/a.jpg",
+    status: "APPROVED" as const,
+  };
+  const approvedPhotoB = {
+    id: "photo-b",
+    url: "https://example.com/b.jpg",
+    status: "APPROVED" as const,
+  };
+
+  describe("AUTO source (default)", () => {
+    it("returns the first approved photo URL when photos exist", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "AUTO",
+          photos: [approvedPhotoA, approvedPhotoB],
+        })
+      ).toBe(approvedPhotoA.url);
+    });
+
+    it("falls back to null when there are no photos (caller uses map hero)", () => {
+      expect(
+        resolveParkHeroImage({ heroSource: "AUTO", photos: [] })
+      ).toBeNull();
+    });
+
+    it("defaults to AUTO when heroSource is missing", () => {
+      expect(
+        resolveParkHeroImage({ photos: [approvedPhotoA] })
+      ).toBe(approvedPhotoA.url);
+    });
+  });
+
+  describe("MAP source", () => {
+    it("returns null regardless of photos (caller renders map hero)", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "MAP",
+          photos: [approvedPhotoA],
+        })
+      ).toBeNull();
+    });
+
+    it("returns null when no photos either", () => {
+      expect(
+        resolveParkHeroImage({ heroSource: "MAP", photos: [] })
+      ).toBeNull();
+    });
+  });
+
+  describe("PHOTO source", () => {
+    it("returns the selected heroPhoto URL when APPROVED", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: approvedPhotoB.id,
+          heroPhoto: approvedPhotoB,
+          photos: [approvedPhotoA, approvedPhotoB],
+        })
+      ).toBe(approvedPhotoB.url);
+    });
+
+    it("falls back to AUTO when heroPhoto is REJECTED", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: approvedPhotoB.id,
+          heroPhoto: { ...approvedPhotoB, status: "REJECTED" },
+          photos: [approvedPhotoA],
+        })
+      ).toBe(approvedPhotoA.url);
+    });
+
+    it("falls back to AUTO when heroPhoto relation is missing and no match in photos", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: "missing-photo-id",
+          heroPhoto: null,
+          photos: [approvedPhotoA],
+        })
+      ).toBe(approvedPhotoA.url);
+    });
+
+    it("falls back to null when PHOTO is selected, photo is missing, and no other photos", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: "missing-photo-id",
+          heroPhoto: null,
+          photos: [],
+        })
+      ).toBeNull();
+    });
+
+    it("falls back to AUTO when heroPhotoId is null", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: null,
+          photos: [approvedPhotoA],
+        })
+      ).toBe(approvedPhotoA.url);
+    });
+
+    it("resolves heroPhotoId from photos list when relation not loaded", () => {
+      expect(
+        resolveParkHeroImage({
+          heroSource: "PHOTO",
+          heroPhotoId: approvedPhotoB.id,
+          photos: [approvedPhotoA, approvedPhotoB],
+        })
+      ).toBe(approvedPhotoB.url);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Operators can now choose what image shows on their park's card. A new **Park Card** page in the operator portal lets them pick between three modes, and the home and profile feeds both honor the selection.

### Schema changes
- New enum: `HeroSource` — `AUTO`, `PHOTO`, `MAP`
- `Park.heroSource HeroSource @default(AUTO)` — controls the resolution mode
- `Park.heroPhotoId String? @unique` — FK to `ParkPhoto` (named relation `ParkHeroPhoto`, `onDelete: SetNull`) so operators can lock a specific image
- `ParkPhoto.heroForPark` — back-reference for the relation
- Migration: `prisma/migrations/20260421000000_park_hero_selection/`

### Hero resolution
Centralized in `src/lib/park-hero.ts` via `resolveParkHeroImage(park)`:
- **AUTO** (default) — first `APPROVED` photo, else `null` (card falls back to `ParkMapHero`)
- **PHOTO** — `heroPhotoId` when it resolves to an `APPROVED` photo on this park, else AUTO fallback
- **MAP** — always `null` so the card renders `ParkMapHero` (`mapHeroUrl` or live Mapbox)

Both `src/app/page.tsx` and `src/app/profile/page.tsx` now load `heroPhoto` alongside `photos` and call the helper.

### Operator UI
- New route: `/operator/[parkSlug]/park-card`
  - Server component loads the park + its approved photos
  - Client shows a live `<ParkCard>` preview next to a radio-style selector; the PHOTO option reveals a thumbnail grid of approved photos
  - Save posts `{ heroSource, heroPhotoId }` to `/api/operator/parks/[parkSlug]` and surfaces success/error inline
- Sidebar link added to `OperatorSidebar.tsx` using the `Image` lucide icon

### API
`PATCH /api/operator/parks/[parkSlug]` now accepts `heroSource` and `heroPhotoId`. It rejects unknown sources, enforces that a `PHOTO` selection references an `APPROVED` photo on this park, and logs changes to `ParkEditLog`.

### Tests
- New: `test/lib/park-hero.test.ts` — 11 cases covering all three modes plus missing / rejected photo fallbacks
- Updated `test/app/profile/page.test.tsx` to match the broader photo select and the new `heroPhoto` include
- `npm run lint`, `npx tsc --noEmit`, `npm test` (1827 passing) all green

## Test plan

- [ ] Run the migration locally and confirm `Park.heroSource` defaults to `AUTO` on existing rows
- [ ] Visit `/operator/[parkSlug]/park-card` as an operator and confirm the preview updates live as modes/photos change
- [ ] Save each mode (AUTO, MAP, PHOTO with a selected approved photo) and confirm it persists + shows on `/`
- [ ] Try to PATCH a `heroPhotoId` that belongs to another park — should 400
- [ ] Try PATCH with `heroSource: "PHOTO"` and a rejected / missing photo — should 400

Generated with [Claude Code](https://claude.com/claude-code)