### PR TITLE
fix(build): prisma generate before next build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma migrate deploy && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Vercel restores \`node_modules\` from the build cache across deploys. When a merged PR adds new Prisma fields, \`prisma migrate deploy\` applies the SQL to the DB but the cached \`@prisma/client\` still has pre-migration types. \`next build\` then fails typechecking.
- PR [#129](https://github.com/mikesassatelli/offroad-parks/pull/129) hit exactly this: \`Property 'heroSource' does not exist on type ...\` during \`next build\` on Vercel.
- Add \`prisma generate\` as the first step of the build script so the generated client is always in sync with \`schema.prisma\` before Next.js typechecks.

## Test plan
- [ ] Vercel preview build on this PR succeeds
- [ ] After merge, production build on master succeeds (same deploy that previously failed)