### PR TITLE
Add SUPER_ADMIN role with admin-console role management

### DIFF
--- a/prisma/migrations/20260507000000_super_admin_role/migration.sql
+++ b/prisma/migrations/20260507000000_super_admin_role/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "UserRole" ADD VALUE 'SUPER_ADMIN';

--- a/prisma/migrations/20260507000001_seed_super_admin/migration.sql
+++ b/prisma/migrations/20260507000001_seed_super_admin/migration.sql
@@ -1,0 +1,5 @@
+-- Promote the bootstrap super admin if the user exists.
+-- Idempotent: no-op when the user has not yet signed in.
+UPDATE "User"
+SET "role" = 'SUPER_ADMIN'
+WHERE "email" = 'mike.sassatelli@gmail.com';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ enum UserRole {
   USER
   ADMIN
   OPERATOR
+  SUPER_ADMIN
 }
 
 // Park Models

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -33,7 +33,7 @@ export default async function AdminLayout({
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     redirect("/");
   }
 

--- a/src/app/admin/parks/[id]/edit/page.tsx
+++ b/src/app/admin/parks/[id]/edit/page.tsx
@@ -17,7 +17,7 @@ export default async function EditParkPage({ params }: EditParkPageProps) {
     redirect("/api/auth/signin");
   }
 
-  if (session.user.role !== "ADMIN") {
+  if (session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
     redirect("/");
   }
 

--- a/src/app/admin/parks/bulk-upload/page.tsx
+++ b/src/app/admin/parks/bulk-upload/page.tsx
@@ -17,7 +17,7 @@ export default async function BulkUploadPage() {
 
   // Require admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     redirect("/");
   }
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,83 +1,46 @@
+import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { Users as UsersIcon } from "lucide-react";
+import {
+  UserManagementTable,
+  type AssignableRole,
+  type ManagedUser,
+} from "@/components/admin/UserManagementTable";
 
 export default async function AdminUsersPage() {
-  const users = await prisma.user.findMany({
+  const session = await auth();
+  const viewerRole = session?.user?.role;
+  const canEditRoles = viewerRole === "SUPER_ADMIN";
+
+  const rows = await prisma.user.findMany({
     orderBy: { createdAt: "desc" },
     include: {
-      _count: {
-        select: {
-          submittedParks: true,
-        },
-      },
+      _count: { select: { submittedParks: true } },
     },
   });
 
+  const users: ManagedUser[] = rows.map((u) => ({
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role as AssignableRole,
+    submittedParkCount: u._count.submittedParks,
+    createdAt: u.createdAt.toISOString(),
+  }));
+
   return (
     <div>
-      <h1 className="text-3xl font-bold text-foreground mb-8">User Management</h1>
+      <h1 className="text-3xl font-bold text-foreground mb-2">User Management</h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        {canEditRoles
+          ? "As a super admin, you can promote or demote users."
+          : "Only the super admin can change user roles."}
+      </p>
 
-      <div className="bg-card rounded-lg shadow border border-border overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-border">
-            <thead className="bg-muted/50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  User
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Email
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Role
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Parks Submitted
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Joined
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-card divide-y divide-border">
-              {users.map((user) => (
-                <tr key={user.id} className="hover:bg-accent/50 transition-colors">
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="flex items-center">
-                      <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center mr-3">
-                        <UsersIcon className="w-4 h-4 text-muted-foreground" />
-                      </div>
-                      <div className="text-sm font-medium text-foreground">
-                        {user.name || "Anonymous"}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-foreground">{user.email}</div>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap">
-                    <span
-                      className={`px-2 py-1 text-xs font-medium rounded-full ${
-                        user.role === "ADMIN"
-                          ? "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300"
-                          : "bg-muted text-foreground"
-                      }`}
-                    >
-                      {user.role}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
-                    {user._count.submittedParks}
-                  </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
-                    {new Date(user.createdAt).toLocaleDateString()}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <UserManagementTable
+        users={users}
+        currentUserId={session?.user?.id ?? ""}
+        canEditRoles={canEditRoles}
+      />
     </div>
   );
 }

--- a/src/app/api/admin/claims/[id]/approve/route.ts
+++ b/src/app/api/admin/claims/[id]/approve/route.ts
@@ -12,7 +12,7 @@ type RouteParams = {
 // Approves a park claim: creates an Operator + OperatorUser, links park to operator, marks claim APPROVED.
 export async function POST(_request: Request, { params }: RouteParams) {
   const session = await auth();
-  if (!session?.user?.id || session.user.role !== "ADMIN") {
+  if (!session?.user?.id || (session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN")) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -76,9 +76,9 @@ export async function POST(_request: Request, { params }: RouteParams) {
       },
     });
 
-    // Only promote to OPERATOR if the user isn't already an ADMIN —
+    // Only promote to OPERATOR if the user isn't already an ADMIN or SUPER_ADMIN —
     // admins can own parks without losing their admin privileges.
-    if (claim.user.role !== "ADMIN") {
+    if (claim.user.role !== "ADMIN" && claim.user.role !== "SUPER_ADMIN") {
       await tx.user.update({
         where: { id: claim.userId },
         data: { role: "OPERATOR" },

--- a/src/app/api/admin/claims/[id]/reject/route.ts
+++ b/src/app/api/admin/claims/[id]/reject/route.ts
@@ -15,7 +15,7 @@ interface RejectBody {
 // POST /api/admin/claims/[id]/reject
 export async function POST(request: Request, { params }: RouteParams) {
   const session = await auth();
-  if (!session?.user?.id || session.user.role !== "ADMIN") {
+  if (!session?.user?.id || session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/claims/[id]/route.ts
+++ b/src/app/api/admin/claims/[id]/route.ts
@@ -14,7 +14,7 @@ type RouteParams = {
 // it has no remaining parks or users.
 export async function DELETE(_request: Request, { params }: RouteParams) {
   const session = await auth();
-  if (!session?.user?.id || session.user.role !== "ADMIN") {
+  if (!session?.user?.id || session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/claims/route.ts
+++ b/src/app/api/admin/claims/route.ts
@@ -9,7 +9,7 @@ type ClaimStatus = "PENDING" | "APPROVED" | "REJECTED";
 // GET /api/admin/claims?status=PENDING&page=1&limit=20
 export async function GET(request: Request) {
   const session = await auth();
-  if (!session?.user?.id || session.user.role !== "ADMIN") {
+  if (!session?.user?.id || session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/parks/[id]/approve/route.ts
+++ b/src/app/api/admin/parks/[id]/approve/route.ts
@@ -18,7 +18,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
     // Check if user is admin
     const userRole = (session.user as { role?: string })?.role;
-    if (userRole !== "ADMIN") {
+    if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/admin/parks/[id]/reject/route.ts
+++ b/src/app/api/admin/parks/[id]/reject/route.ts
@@ -18,7 +18,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
     // Check if user is admin
     const userRole = (session.user as { role?: string })?.role;
-    if (userRole !== "ADMIN") {
+    if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/admin/parks/[id]/route.ts
+++ b/src/app/api/admin/parks/[id]/route.ts
@@ -21,7 +21,7 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
 
     // Check if user is admin
     const userRole = (session.user as { role?: string })?.role;
-    if (userRole !== "ADMIN") {
+    if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
@@ -56,7 +56,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     // Check if user is admin
     const userRole = (session.user as { role?: string })?.role;
-    if (userRole !== "ADMIN") {
+    if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/admin/parks/bulk-upload/route.ts
+++ b/src/app/api/admin/parks/bulk-upload/route.ts
@@ -347,7 +347,7 @@ export async function POST(
     }
 
     const userRole = (session.user as { role?: string })?.role;
-    if (userRole !== "ADMIN") {
+    if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
       return NextResponse.json(
         { success: false, created: 0, errors: [] },
         { status: 403 }

--- a/src/app/api/admin/parks/list/route.ts
+++ b/src/app/api/admin/parks/list/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/photos/[id]/approve/route.ts
+++ b/src/app/api/admin/photos/[id]/approve/route.ts
@@ -20,7 +20,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   // Check if user is admin
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json(
       { error: "Admin access required" },
       { status: 403 },

--- a/src/app/api/admin/photos/[id]/reject/route.ts
+++ b/src/app/api/admin/photos/[id]/reject/route.ts
@@ -20,7 +20,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   // Check if user is admin
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json(
       { error: "Admin access required" },
       { status: 403 },

--- a/src/app/api/admin/photos/[id]/route.ts
+++ b/src/app/api/admin/photos/[id]/route.ts
@@ -16,7 +16,7 @@ export async function PATCH(
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -80,7 +80,7 @@ export async function DELETE(
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/photos/bulk-upload/route.ts
+++ b/src/app/api/admin/photos/bulk-upload/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/[id]/approve/route.ts
+++ b/src/app/api/admin/reviews/[id]/approve/route.ts
@@ -21,7 +21,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   // Check admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/[id]/hide/route.ts
+++ b/src/app/api/admin/reviews/[id]/hide/route.ts
@@ -21,7 +21,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   // Check admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/[id]/restore/route.ts
+++ b/src/app/api/admin/reviews/[id]/restore/route.ts
@@ -21,7 +21,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
 
   // Check admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/[id]/route.ts
+++ b/src/app/api/admin/reviews/[id]/route.ts
@@ -21,7 +21,7 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
 
   // Check admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/route.ts
+++ b/src/app/api/admin/reviews/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
 
   // Check admin role
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN") {
+  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/users/[id]/role/route.ts
+++ b/src/app/api/admin/users/[id]/role/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+const ASSIGNABLE_ROLES = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"] as const;
+type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+// PATCH /api/admin/users/[id]/role — only SUPER_ADMIN may promote/demote users.
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.user.role !== "SUPER_ADMIN") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  let body: { role?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const role = body.role;
+  if (!role || !ASSIGNABLE_ROLES.includes(role as AssignableRole)) {
+    return NextResponse.json(
+      { error: `Invalid role. Must be one of: ${ASSIGNABLE_ROLES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  // Prevent the super admin from demoting themselves and locking the org out
+  // of role administration. They can be demoted by another super admin.
+  if (id === session.user.id && role !== "SUPER_ADMIN") {
+    return NextResponse.json(
+      { error: "Super admins cannot demote themselves" },
+      { status: 400 },
+    );
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true, role: true },
+  });
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const updated = await prisma.user.update({
+    where: { id },
+    data: { role: role as AssignableRole },
+    select: { id: true, email: true, name: true, role: true },
+  });
+
+  return NextResponse.json(updated);
+}

--- a/src/app/api/parks/[slug]/conditions/route.ts
+++ b/src/app/api/parks/[slug]/conditions/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: Request, { params }: RouteParams) {
   }
 
   const userRole = (session.user as { role?: string }).role;
-  const isAdmin = userRole === "ADMIN";
+  const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
 
   // Operator scope is park-specific: user must be a member of the operator
   // account that owns this park.

--- a/src/app/api/parks/[slug]/photos/route.ts
+++ b/src/app/api/parks/[slug]/photos/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     // Check if user is admin
     const userRole = (session.user as { role?: string })?.role;
-    const isAdmin = userRole === "ADMIN";
+    const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
 
     // Create photo record in database
     const photo = await prisma.parkPhoto.create({

--- a/src/app/api/parks/submit/route.ts
+++ b/src/app/api/parks/submit/route.ts
@@ -81,7 +81,7 @@ export async function POST(request: Request) {
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  const isAdmin = userRole === "ADMIN";
+  const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
 
   try {
     const data: SubmitParkRequest = await request.json();

--- a/src/app/api/photos/[id]/route.ts
+++ b/src/app/api/photos/[id]/route.ts
@@ -32,7 +32,7 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
 
   // Check if user is authorized (photo owner or admin)
   const userRole = (session.user as { role?: string })?.role;
-  const isAdmin = userRole === "ADMIN";
+  const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
   const isOwner = photo.userId === session.user.id;
 
   if (!isAdmin && !isOwner) {

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -141,7 +141,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
   }));
 
   const userRole = (session?.user as { role?: string })?.role;
-  const isAdmin = userRole === "ADMIN";
+  const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
 
   // Fetch any existing claim from this user for this park (any status)
   const existingClaim = session?.user?.id

--- a/src/components/admin/UserManagementTable.tsx
+++ b/src/components/admin/UserManagementTable.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Users as UsersIcon } from "lucide-react";
+
+export type AssignableRole = "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN";
+
+const ASSIGNABLE_ROLES: AssignableRole[] = [
+  "USER",
+  "OPERATOR",
+  "ADMIN",
+  "SUPER_ADMIN",
+];
+
+export interface ManagedUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  role: AssignableRole;
+  submittedParkCount: number;
+  createdAt: string;
+}
+
+interface UserManagementTableProps {
+  users: ManagedUser[];
+  /** ID of the currently signed-in viewer (used to disable self-demote). */
+  currentUserId: string;
+  /** Whether the viewer can edit roles. Only true for SUPER_ADMIN. */
+  canEditRoles: boolean;
+}
+
+function roleBadgeClass(role: string): string {
+  switch (role) {
+    case "SUPER_ADMIN":
+      return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300";
+    case "ADMIN":
+      return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
+    case "OPERATOR":
+      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+    default:
+      return "bg-muted text-foreground";
+  }
+}
+
+export function UserManagementTable({
+  users,
+  currentUserId,
+  canEditRoles,
+}: UserManagementTableProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRoleChange(userId: string, nextRole: AssignableRole) {
+    setError(null);
+    setSavingId(userId);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/role`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: nextRole }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(data?.error || `Failed to update role (${res.status})`);
+      }
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="bg-card rounded-lg shadow border border-border overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  User
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Email
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Role
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Parks Submitted
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Joined
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-card divide-y divide-border">
+              {users.map((user) => {
+                const isSelf = user.id === currentUserId;
+                const isSaving = savingId === user.id || pending;
+                return (
+                  <tr
+                    key={user.id}
+                    className="hover:bg-accent/50 transition-colors"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center mr-3">
+                          <UsersIcon className="w-4 h-4 text-muted-foreground" />
+                        </div>
+                        <div className="text-sm font-medium text-foreground">
+                          {user.name || "Anonymous"}
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="text-sm text-foreground">
+                        {user.email}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      {canEditRoles ? (
+                        <label className="sr-only" htmlFor={`role-${user.id}`}>
+                          Role for {user.email ?? user.id}
+                        </label>
+                      ) : null}
+                      {canEditRoles ? (
+                        <select
+                          id={`role-${user.id}`}
+                          aria-label={`Role for ${user.email ?? user.id}`}
+                          disabled={isSaving}
+                          value={user.role}
+                          onChange={(e) =>
+                            handleRoleChange(
+                              user.id,
+                              e.target.value as AssignableRole,
+                            )
+                          }
+                          className="text-xs font-medium rounded-md border border-border bg-background px-2 py-1 disabled:opacity-50"
+                        >
+                          {ASSIGNABLE_ROLES.map((r) => (
+                            <option
+                              key={r}
+                              value={r}
+                              disabled={isSelf && r !== "SUPER_ADMIN"}
+                            >
+                              {r}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span
+                          className={`px-2 py-1 text-xs font-medium rounded-full ${roleBadgeClass(user.role)}`}
+                        >
+                          {user.role}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
+                      {user.submittedParkCount}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
+                      {new Date(user.createdAt).toLocaleDateString()}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -9,8 +9,11 @@ import { auth } from "@/lib/auth";
 /** A session that is guaranteed to have a user (post-auth-guard). */
 type AuthenticatedSession = Session & { user: NonNullable<Session["user"]> };
 
+/** Roles that grant access to the admin console. */
+const ADMIN_ROLES = new Set(["ADMIN", "SUPER_ADMIN"]);
+
 /**
- * Verify the request comes from an authenticated ADMIN user.
+ * Verify the request comes from an authenticated admin (ADMIN or SUPER_ADMIN).
  * Returns the session on success, or a NextResponse 401/403 on failure.
  *
  * Usage:
@@ -23,7 +26,22 @@ export async function requireAdmin(): Promise<AuthenticatedSession | NextRespons
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  if (session.user.role !== "ADMIN") {
+  if (!ADMIN_ROLES.has(session.user.role ?? "")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return session as AuthenticatedSession;
+}
+
+/**
+ * Verify the request comes from an authenticated SUPER_ADMIN user.
+ * Used for actions only the super admin may take (e.g. promoting/demoting admins).
+ */
+export async function requireSuperAdmin(): Promise<AuthenticatedSession | NextResponse> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.user.role !== "SUPER_ADMIN") {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   return session as AuthenticatedSession;

--- a/test/app/api/admin/users/[id]/role/route.test.ts
+++ b/test/app/api/admin/users/[id]/role/route.test.ts
@@ -1,0 +1,119 @@
+import { PATCH } from "@/app/api/admin/users/[id]/role/route";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+const superAdmin = { user: { id: "super-1", role: "SUPER_ADMIN" } };
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/admin/users/u1/role", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const params = { params: Promise.resolve({ id: "u1" }) };
+
+describe("PATCH /api/admin/users/[id]/role", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller is a regular ADMIN (not super admin)", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "admin-1", role: "ADMIN" },
+    });
+    const res = await PATCH(makeRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    const res = await PATCH(makeRequest("{not json"), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid role", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    const res = await PATCH(makeRequest({ role: "ROOT" }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects super admin demoting themselves", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    const res = await PATCH(makeRequest({ role: "ADMIN" }), {
+      params: Promise.resolve({ id: "super-1" }),
+    });
+    expect(res.status).toBe(400);
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when target user does not exist", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    (prisma.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(
+      null,
+    );
+    const res = await PATCH(makeRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("promotes a user to ADMIN", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    (prisma.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "u1",
+      role: "USER",
+    });
+    (prisma.user.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "u1",
+      email: "user@example.com",
+      name: "User",
+      role: "ADMIN",
+    });
+
+    const res = await PATCH(makeRequest({ role: "ADMIN" }), params);
+    expect(res.status).toBe(200);
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { role: "ADMIN" },
+      select: { id: true, email: true, name: true, role: true },
+    });
+    const body = await res.json();
+    expect(body.role).toBe("ADMIN");
+  });
+
+  it("allows super admin to confirm their own role (no-op)", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(superAdmin);
+    (prisma.user.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "super-1",
+      role: "SUPER_ADMIN",
+    });
+    (prisma.user.update as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "super-1",
+      email: "super@example.com",
+      name: "Super",
+      role: "SUPER_ADMIN",
+    });
+
+    const res = await PATCH(makeRequest({ role: "SUPER_ADMIN" }), {
+      params: Promise.resolve({ id: "super-1" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/components/admin/UserManagementTable.test.tsx
+++ b/test/components/admin/UserManagementTable.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  UserManagementTable,
+  type ManagedUser,
+} from "@/components/admin/UserManagementTable";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+const baseUsers: ManagedUser[] = [
+  {
+    id: "u1",
+    name: "Alice",
+    email: "alice@example.com",
+    role: "USER",
+    submittedParkCount: 2,
+    createdAt: "2024-06-01T00:00:00.000Z",
+  },
+  {
+    id: "u2",
+    name: "Bob",
+    email: "bob@example.com",
+    role: "ADMIN",
+    submittedParkCount: 5,
+    createdAt: "2024-07-01T00:00:00.000Z",
+  },
+  {
+    id: "super-1",
+    name: "Mike",
+    email: "mike.sassatelli@gmail.com",
+    role: "SUPER_ADMIN",
+    submittedParkCount: 0,
+    createdAt: "2024-01-01T00:00:00.000Z",
+  },
+];
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockFetch = vi.fn();
+  global.fetch = mockFetch as unknown as typeof fetch;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("UserManagementTable", () => {
+  it("renders read-only role badges when canEditRoles is false", () => {
+    render(
+      <UserManagementTable
+        users={baseUsers}
+        currentUserId="someone-else"
+        canEditRoles={false}
+      />,
+    );
+
+    expect(screen.getByText("USER")).toBeInTheDocument();
+    expect(screen.getByText("ADMIN")).toBeInTheDocument();
+    expect(screen.getByText("SUPER_ADMIN")).toBeInTheDocument();
+    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
+  });
+
+  it("renders a role select per user when canEditRoles is true", () => {
+    render(
+      <UserManagementTable
+        users={baseUsers}
+        currentUserId="super-1"
+        canEditRoles={true}
+      />,
+    );
+
+    expect(screen.getAllByRole("combobox")).toHaveLength(3);
+  });
+
+  it("disables non-SUPER_ADMIN options for the current viewer (no self-demote)", () => {
+    render(
+      <UserManagementTable
+        users={baseUsers}
+        currentUserId="super-1"
+        canEditRoles={true}
+      />,
+    );
+
+    const ownSelect = screen.getByLabelText(
+      "Role for mike.sassatelli@gmail.com",
+    ) as HTMLSelectElement;
+    const options = Array.from(ownSelect.querySelectorAll("option"));
+    expect(options.find((o) => o.value === "USER")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "ADMIN")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "OPERATOR")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "SUPER_ADMIN")?.disabled).toBe(false);
+  });
+
+  it("PATCHes the role API and refreshes on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const user = userEvent.setup();
+
+    render(
+      <UserManagementTable
+        users={baseUsers}
+        currentUserId="super-1"
+        canEditRoles={true}
+      />,
+    );
+
+    const aliceSelect = screen.getByLabelText("Role for alice@example.com");
+    await user.selectOptions(aliceSelect, "ADMIN");
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/admin/users/u1/role", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "ADMIN" }),
+    });
+
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+  });
+
+  it("shows the API error when the request fails", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "Super admins cannot demote themselves" }),
+    });
+    const user = userEvent.setup();
+
+    render(
+      <UserManagementTable
+        users={baseUsers}
+        currentUserId="super-1"
+        canEditRoles={true}
+      />,
+    );
+
+    const bobSelect = screen.getByLabelText("Role for bob@example.com");
+    await user.selectOptions(bobSelect, "USER");
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /super admins cannot demote/i,
+      ),
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/test/lib/api-helpers.test.ts
+++ b/test/lib/api-helpers.test.ts
@@ -1,4 +1,4 @@
-import { requireAdmin, requireAuth } from "@/lib/api-helpers";
+import { requireAdmin, requireAuth, requireSuperAdmin } from "@/lib/api-helpers";
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { vi, describe, it, expect, beforeEach } from "vitest";
@@ -53,6 +53,52 @@ describe("requireAdmin", () => {
     (auth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
 
     const result = await requireAdmin();
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(result).toEqual(session);
+  });
+
+  it("should return session when user is super admin", async () => {
+    const session = { user: { id: "su-1", role: "SUPER_ADMIN" } };
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
+
+    const result = await requireAdmin();
+
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(result).toEqual(session);
+  });
+});
+
+describe("requireSuperAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await requireSuperAdmin();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(401);
+  });
+
+  it("should return 403 when user is a regular admin", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "admin-1", role: "ADMIN" },
+    });
+
+    const result = await requireSuperAdmin();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+  });
+
+  it("should return session when user is super admin", async () => {
+    const session = { user: { id: "su-1", role: "SUPER_ADMIN" } };
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
+
+    const result = await requireSuperAdmin();
 
     expect(result).not.toBeInstanceOf(NextResponse);
     expect(result).toEqual(session);


### PR DESCRIPTION
## Summary
- Adds a `SUPER_ADMIN` tier above `ADMIN` and seeds **mike.sassatelli@gmail.com** as the bootstrap super admin via Prisma migrations
- Adds `PATCH /api/admin/users/[id]/role` (super-admin only, with self-demote protection) and a role-select column on **/admin/users** that's only interactive for super admins
- Updates every admin gate across the app (admin layout, all `/api/admin/*` routes, the `isAdmin` checks on user-facing routes, and the claim-approval branch that preserves admin privileges for park owners) to also accept `SUPER_ADMIN`

The enum addition and seed run as two separate migrations because Postgres won't let you use a newly-added enum value in the same transaction it was created in.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 1923 tests pass, including new coverage for `requireSuperAdmin`, the role PATCH endpoint, and the management table component
- [ ] After deploy: sign in as mike.sassatelli@gmail.com, confirm role badge shows `SUPER_ADMIN` on `/admin/users`, promote a test user to `ADMIN`, confirm a regular `ADMIN` viewing the page sees badges only (no select)

🤖 Generated with [Claude Code](https://claude.com/claude-code)