### PR TITLE
fix(ui): show Admin Panel link to SUPER_ADMIN in UserMenu

### DIFF
--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -22,6 +22,8 @@ interface UserMenuProps {
 }
 
 export function UserMenu({ user, onSignOut }: UserMenuProps) {
+  const isAdmin = user.role === "ADMIN" || user.role === "SUPER_ADMIN";
+  const showPrivilegedSection = isAdmin || user.role === "OPERATOR";
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -35,10 +37,10 @@ export function UserMenu({ user, onSignOut }: UserMenuProps) {
           <div className="font-medium">{user.name}</div>
           <div className="text-xs text-muted-foreground">{user.email}</div>
         </div>
-        {(user.role === "ADMIN" || user.role === "OPERATOR") && (
+        {showPrivilegedSection && (
           <>
             <DropdownMenuSeparator />
-            {user.role === "ADMIN" && (
+            {isAdmin && (
               <DropdownMenuItem asChild>
                 <Link href="/admin" className="cursor-pointer">
                   <Settings className="w-4 h-4 mr-2" />

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -9,13 +9,13 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       image?: string | null;
-      /** User role — "ADMIN" for admins, undefined for regular users */
+      /** User role — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | undefined */
       role?: string;
     };
   }
 
   interface User {
-    /** User role stored in DB — "ADMIN" or null */
+    /** User role stored in DB — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | null */
     role?: string | null;
   }
 }

--- a/test/components/layout/UserMenu.test.tsx
+++ b/test/components/layout/UserMenu.test.tsx
@@ -73,6 +73,13 @@ describe("UserMenu", () => {
     role: "OPERATOR",
   };
 
+  const superAdminUser = {
+    name: "Super Admin",
+    email: "super@example.com",
+    image: null,
+    role: "SUPER_ADMIN",
+  };
+
   it("should render dropdown menu", () => {
     render(<UserMenu user={regularUser} onSignOut={mockOnSignOut} />);
 
@@ -164,6 +171,27 @@ describe("UserMenu", () => {
   it("should render Admin Panel link for admin users", () => {
     const { container } = render(
       <UserMenu user={adminUser} onSignOut={mockOnSignOut} />,
+    );
+
+    const adminLink = container.querySelector('a[href="/admin"]');
+    expect(adminLink).toBeInTheDocument();
+  });
+
+  it("should show Admin Panel for super admin users", () => {
+    render(<UserMenu user={superAdminUser} onSignOut={mockOnSignOut} />);
+
+    expect(screen.getByText("Admin Panel")).toBeInTheDocument();
+  });
+
+  it("should show Manage Parks for super admin users", () => {
+    render(<UserMenu user={superAdminUser} onSignOut={mockOnSignOut} />);
+
+    expect(screen.getByText("Manage Parks")).toBeInTheDocument();
+  });
+
+  it("should render Admin Panel link for super admin users", () => {
+    const { container } = render(
+      <UserMenu user={superAdminUser} onSignOut={mockOnSignOut} />,
     );
 
     const adminLink = container.querySelector('a[href="/admin"]');


### PR DESCRIPTION
## Summary
- The UserMenu dropdown was the only remaining UI gate still using strict `role === "ADMIN"`, so super admins lost the Admin Panel + Manage Parks links after #136 shipped
- Both links now treat `SUPER_ADMIN` as an admin (and surface the operator portal link same as a regular `ADMIN` does)
- Tightens the role doc-comments in `next-auth.d.ts` to enumerate every role we now use

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/components/layout/UserMenu.test.tsx` — 21 tests pass (3 new SUPER_ADMIN cases)
- [ ] After deploy: log in as mike.sassatelli@gmail.com, open the user menu, confirm Admin Panel + Manage Parks both show

🤖 Generated with [Claude Code](https://claude.com/claude-code)