### PR TITLE
feat(weather): NWS forecast + current on park detail (OP-52, OP-53)

### DIFF
--- a/planning/BACKLOG.md
+++ b/planning/BACKLOG.md
@@ -153,10 +153,10 @@
 | Key | Title | Status | Type | Notes |
 |-----|-------|--------|------|-------|
 | OP-90 | Park Card Default Filler Redesign | done | feature | Stylized Mapbox sepia thumbnail (USGS-quadrangle legend, Light-sepia treatment) replaces the Camera-icon filler. Pre-generated to Vercel Blob at park creation; live Mapbox fallback. `ParkMapHero` component used on both card + detail-page sidebar. Admin backfill at `/admin/map-heroes`. Merged with OP-90 PR. |
-| OP-91 | Google Places Photo Integration | backlog | feature | Parent. Auto-source photos from Google Places Photos API with strict provenance. Covers backfill for existing parks and wiring into AI discovery for new parks. See 91a/91b/91c. |
-| OP-91a | Schema: `googlePlaceId` Field + Backfill Job | backlog | feature | needs-refinement. Add `googlePlaceId` (unique, nullable) to `Park`. Admin-triggered backfill job runs Places Text Search (name + city + state) per park; matches with high confidence (name similarity + distance-from-recorded-coords thresholds) auto-link; low-confidence matches queue for admin review. Idempotent. |
-| OP-91b | Places Photo Sync Pipeline | backlog | feature | needs-refinement. For parks with a `googlePlaceId`, fetch top N Places Photos, download to Vercel Blob at `parks/{parkId}/places-{hash}.jpg`, create `ParkPhoto` with `source: 'google_places'` and Google-required attribution. Blob URL uniqueness enforces per-photo provenance. Monthly refresh cron. Auto-approve vs. admin-queue is a setting. |
-| OP-91c | AI Discovery → Places Integration | backlog | feature | needs-refinement. Wire Places lookup into the AI discovery pipeline so new parks arrive with `googlePlaceId` stamped at seed time. 91b sync job then picks them up. Removes the "every new park needs manual photo hunt" bottleneck. Depends on OP-91a + OP-91b. |
+| OP-91 | Google Places Photo Integration | deferred | feature | **Deferred 2026-05-12.** Two blockers: (1) Google Maps Platform ToS §3.2.3 prohibits caching/storing photo Content — we can persist Place IDs but not photo bytes, so the "download to Blob" provenance design is non-compliant. (2) Live-fetch alternative (Places Photo on every render) costs ~$840/mo at projected traffic; even detail-page-only hybrid is ~$84/mo. OP-90 map hero + OP-00D community CTA cover the gap acceptably for now. Revisit if/when traffic + cost economics change. |
+| OP-91a | Schema: `googlePlaceId` Field + Backfill Job | deferred | feature | Deferred with parent OP-91. |
+| OP-91b | Places Photo Sync Pipeline | deferred | feature | Deferred with parent OP-91. ToS blocker — Places photos cannot be downloaded to our own storage. |
+| OP-91c | AI Discovery → Places Integration | deferred | feature | Deferred with parent OP-91. |
 
 ---
 
@@ -189,14 +189,31 @@
 
 ---
 
-## E10 · Weather Integration *(Future)*
+## E10 · Weather Integration *(Phase 2)*
+
+**Provider: National Weather Service (api.weather.gov).** Free, no API key, US-only (all parks are US-based), authoritative for alerts. Two-step lookup: `/points/{lat},{lng}` → grid identifier (cached indefinitely per park, invalidated on coord edit) → `/gridpoints/.../forecast`. Grid resolution pre-warmed at park creation (alongside map-hero gen).
+
+**Caching (Next.js fetch cache with tags):** grid lookup indefinite, 7-day forecast 6h, current observations 30m, active alerts 10m. All tagged `park:{parkId}:weather` for coord-edit invalidation.
+
+**Parks without coordinates:** weather UI does not render. AI research backfills coords over time.
 
 | Key | Title | Status | Type | Notes |
 |-----|-------|--------|------|-------|
-| OP-52 | Weather API Integration & Caching | backlog | feature | needs-refinement. Provider selection, server-side caching with TTL, background refresh, rate limiting. |
-| OP-53 | Current & Forecast Weather Display | backlog | feature | Weather widget on park detail; current conditions + 5-7 day forecast; icons. |
-| OP-54 | Weather Alerts & Warnings | backlog | feature | needs-refinement. NWS alerts, severity levels, park closure indicators. |
-| OP-55 | Rain Likelihood on Park Cards | backlog | feature | Rain badge on ParkCard; color-coded probability; batch fetching for efficiency. |
+| OP-52 | NWS Integration & Caching | backlog | feature | `src/lib/weather/` module: `getOrResolveGrid`, `getForecast`, `getCurrentConditions`, `getActiveAlerts`. Vercel Runtime/Next fetch cache per table above. Identifiable User-Agent header. Hook grid pre-warm into park-creation pipeline. Graceful null fallback on NWS 5xx. Tests for cache hit/miss + error paths. |
+| OP-53 | Current & Forecast Weather Display | backlog | feature | `<WeatherCard />` on park detail sidebar. Current temp + conditions icon (Lucide) + feels-like. 5-day forecast row: day, icon, hi/lo, precip%. Loading skeleton + "Weather unavailable" empty state. |
+| OP-54 | Weather Alerts & Warnings | backlog | feature | NWS severe+ alerts as banner at top of park detail page (e.g. "Red Flag Warning until 6pm"). Full alerts list in modal on "View all alerts." **Park closure indicators are out of scope** — closures are operator-controlled via OP-65, not weather-driven. |
+| OP-55 | Rain Likelihood on Park Cards | backlog | feature | Rain badge (☂ + probability) on `<ParkCard />`. Today's max precip% across the day. Color thresholds: green <20%, amber 20–60%, red >60%. Server-rendered using same cache as OP-53 (most calls cache-hit). Hidden when forecast unavailable. |
+
+---
+
+## E21 · User Notifications *(Future)*
+
+**Premise:** Email notifications triggered by various events (severe weather at favorited parks, new reviews, operator updates, trail conditions). Centralized opt-in/opt-out preferences in user profile — no notification ships without granular user control.
+
+| Key | Title | Status | Type | Notes |
+|-----|-------|--------|------|-------|
+| OP-92 | Notification Preferences in User Profile | backlog | feature | needs-refinement. New `UserNotificationPreferences` model (or JSON column on `User`). Profile UI section with per-channel toggles: weather-alerts at favorited parks, new-review-on-favorited-park, operator-update, trail-condition-change. Default all OFF; explicit opt-in. One-click unsubscribe link in every email. Foundation for OP-93+. |
+| OP-93 | Severe Weather Email Alerts | backlog | feature | needs-refinement. Cron job scans favorited parks for active NWS severe+ alerts; sends email to opted-in users. Dedup so a user gets one email per (park, alert) pair. Depends on OP-92 + OP-54. |
 
 ---
 

--- a/planning/SPRINT.md
+++ b/planning/SPRINT.md
@@ -1,3 +1,26 @@
+# Sprint 6 · Week of 2026-05-11
+
+## Goal
+Ship weather integration end-to-end: NWS-backed forecast + current conditions on park detail, severe-alert banner, and rain-likelihood badge on park cards. All four E10 stories.
+
+## In Progress
+- [ ] OP-52 — NWS Integration & Caching
+- [ ] OP-53 — Current & Forecast Weather Display
+- [ ] OP-54 — Weather Alerts & Warnings
+- [ ] OP-55 — Rain Likelihood on Park Cards
+
+## Up Next
+*(none — focused sprint on E10)*
+
+## Blocked
+*(none)*
+
+## Notes / Decisions
+- E20 OP-91 (Google Places) deferred: Google Maps Platform ToS prohibits caching photo Content; live-fetch alternative costs ~$840/mo at projected traffic. OP-90 map hero + OP-00D community CTA cover the gap acceptably.
+- New epic E21 (User Notifications) created. OP-93 (severe-weather email alerts) shelved behind OP-92 (preferences foundation) — explicit opt-in only, every channel toggleable from profile.
+
+---
+
 # Sprint 5 · Week of 2026-04-14
 
 ## Goal
@@ -7,9 +30,7 @@ Close the biggest "unfinished" gap on the consumer site: parks without photos. S
 *(none)*
 
 ## Up Next
-- [ ] OP-91a — Schema: `googlePlaceId` field + backfill job
-- [ ] OP-91b — Places Photo Sync Pipeline
-- [ ] OP-91c — AI Discovery → Places Integration (depends on 91a + 91b)
+*(deferred — see Sprint 6)*
 
 ## Blocked
 *(none)*

--- a/src/app/api/admin/parks/[id]/route.ts
+++ b/src/app/api/admin/parks/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { generateMapHeroAsync } from "@/lib/map-hero/generate";
@@ -184,8 +184,11 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     revalidatePath(`/parks/${park.slug}`);
 
     // Regenerate map hero if coords changed (OP-90).
+    // Also invalidate the weather cache (OP-52) — the cached NWS grid
+    // resolution and forecast are tied to the previous coords.
     if (coordsChanged) {
       generateMapHeroAsync(park.id, "admin-edit");
+      revalidateTag(`park:${park.id}:weather`, "max");
     }
 
     return NextResponse.json({ success: true, park });

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ParkDetailPage } from "@/features/parks/detail/ParkDetailPage";
 import { auth } from "@/lib/auth";
 import { isAlertActive, sortAlertsForDisplay } from "@/lib/park-alerts";
 import type { ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
+import { getCurrentConditions, getForecast } from "@/lib/weather";
 
 interface ParkPageProps {
   params: Promise<{ id: string }>;
@@ -140,6 +141,20 @@ export default async function ParkPage({ params }: ParkPageProps) {
     createdAt: a.createdAt.toISOString(),
   }));
 
+  // OP-53: weather data. Fetched in parallel; each surface degrades to
+  // null/empty independently on failure (NWS occasionally 5xx, outside-US
+  // coords resolve as null). Coords come from the park root, falling back
+  // to the address record — same precedence as map-hero generation.
+  const weatherLat = dbPark.latitude ?? dbPark.address?.latitude ?? null;
+  const weatherLng = dbPark.longitude ?? dbPark.address?.longitude ?? null;
+  const [weatherCurrent, weatherForecast] =
+    weatherLat != null && weatherLng != null
+      ? await Promise.all([
+          getCurrentConditions(dbPark.id, weatherLat, weatherLng),
+          getForecast(dbPark.id, weatherLat, weatherLng),
+        ])
+      : [null, []];
+
   const userRole = (session?.user as { role?: string })?.role;
   const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
 
@@ -173,6 +188,8 @@ export default async function ParkPage({ params }: ParkPageProps) {
       isOperatorOfPark={isOperatorOfPark}
       operatorName={resolvedOperatorName}
       alerts={activeAlerts}
+      weatherCurrent={weatherCurrent}
+      weatherForecast={weatherForecast}
     />
   );
 }

--- a/src/components/parks/WeatherCard.tsx
+++ b/src/components/parks/WeatherCard.tsx
@@ -1,0 +1,141 @@
+/**
+ * Weather widget on the park detail sidebar (OP-53). Presentational only —
+ * data is fetched server-side in src/app/parks/[id]/page.tsx via the lib
+ * in src/lib/weather and handed in via props.
+ */
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { weatherIconKey, type WeatherIconKey } from "@/lib/weather/icons";
+import type { CurrentConditions, DailyForecast } from "@/lib/weather/types";
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudHail,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Droplets,
+  Snowflake,
+  Sun,
+  Wind,
+  type LucideIcon,
+} from "lucide-react";
+
+const WEATHER_ICON: Record<WeatherIconKey, LucideIcon> = {
+  thunderstorm: CloudLightning,
+  hail: CloudHail,
+  snow: CloudSnow,
+  sleet: Snowflake,
+  drizzle: CloudDrizzle,
+  rain: CloudRain,
+  fog: CloudFog,
+  wind: Wind,
+  partlyCloudy: CloudSun,
+  cloudy: Cloud,
+  sunny: Sun,
+  unknown: Cloud,
+};
+
+interface WeatherCardProps {
+  current: CurrentConditions | null;
+  forecast: DailyForecast[];
+}
+
+export function WeatherCard({ current, forecast }: WeatherCardProps) {
+  // Hide entirely when both surfaces are empty — better than rendering a
+  // card that just says "Weather unavailable" on every park without
+  // observations. Most parks have a forecast even when current obs are null.
+  if (!current && forecast.length === 0) {
+    return null;
+  }
+
+  const CurrentIcon = WEATHER_ICON[weatherIconKey(current?.shortForecast)];
+
+  return (
+    <Card data-testid="weather-card">
+      <CardHeader>
+        <CardTitle className="text-base">Weather</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {current && (
+          <div className="flex items-center gap-4">
+            <CurrentIcon
+              className="w-12 h-12 text-primary flex-shrink-0"
+              aria-hidden="true"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-baseline gap-2">
+                <span className="text-3xl font-semibold tabular-nums">
+                  {current.temperatureF != null
+                    ? `${Math.round(current.temperatureF)}°`
+                    : "—"}
+                </span>
+                {current.feelsLikeF != null &&
+                  Math.round(current.feelsLikeF) !==
+                    Math.round(current.temperatureF ?? 0) && (
+                    <span className="text-xs text-muted-foreground">
+                      Feels {Math.round(current.feelsLikeF)}°
+                    </span>
+                  )}
+              </div>
+              <p className="text-sm text-card-foreground/80 truncate">
+                {current.shortForecast || "Current conditions"}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {forecast.length > 0 && (
+          <div
+            className="grid grid-cols-5 gap-1 pt-2 border-t border-border"
+            role="list"
+            aria-label="5-day forecast"
+          >
+            {forecast.map((day) => {
+              const DayIcon = WEATHER_ICON[weatherIconKey(day.shortForecast)];
+              return (
+                <div
+                  key={day.date}
+                  role="listitem"
+                  className="flex flex-col items-center text-center gap-1 py-1"
+                >
+                  <span className="text-xs font-medium text-card-foreground/80">
+                    {day.dayName}
+                  </span>
+                  <DayIcon
+                    className="w-5 h-5 text-card-foreground/70"
+                    aria-hidden="true"
+                  />
+                  <span className="text-xs tabular-nums">
+                    <span className="font-semibold">
+                      {day.highF != null ? Math.round(day.highF) : "—"}°
+                    </span>
+                    <span className="text-muted-foreground">
+                      {" / "}
+                      {day.lowF != null ? Math.round(day.lowF) : "—"}°
+                    </span>
+                  </span>
+                  {day.precipProbability != null &&
+                    day.precipProbability >= 20 && (
+                      <span
+                        className="text-[10px] inline-flex items-center gap-0.5 text-blue-700 dark:text-blue-300"
+                        aria-label={`${day.precipProbability}% precipitation`}
+                      >
+                        <Droplets className="w-2.5 h-2.5" aria-hidden="true" />
+                        {day.precipProbability}%
+                      </span>
+                    )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <p className="text-[10px] text-muted-foreground pt-1">
+          Source: National Weather Service
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -20,6 +20,8 @@ import { ParkOverviewCard } from "./components/ParkOverviewCard";
 import { CampingInfoCard } from "./components/CampingInfoCard";
 import { ParkMapHero } from "@/components/parks/ParkMapHero";
 import { ParkAlertsBanner, type ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
+import { WeatherCard } from "@/components/parks/WeatherCard";
+import type { CurrentConditions, DailyForecast } from "@/lib/weather/types";
 import { ReviewList, ReviewForm, StarRating, DifficultyRating } from "@/components/reviews";
 import { TrailConditionsDisplay } from "@/features/trail-conditions/TrailConditionsDisplay";
 import { useReviews } from "@/hooks/useReviews";
@@ -56,6 +58,10 @@ interface ParkDetailPageProps {
   isOperatorOfPark?: boolean;
   operatorName?: string | null;
   alerts?: ParkAlertDisplay[];
+  /** OP-53: server-fetched current conditions. Null when unavailable. */
+  weatherCurrent?: CurrentConditions | null;
+  /** OP-53: server-fetched 5-day forecast. Empty when unavailable. */
+  weatherForecast?: DailyForecast[];
 }
 
 function ParkDetailPageInner({
@@ -68,6 +74,8 @@ function ParkDetailPageInner({
   isOperatorOfPark,
   operatorName,
   alerts,
+  weatherCurrent,
+  weatherForecast,
 }: ParkDetailPageProps) {
   const router = useRouter();
   const { data: session } = useSession();
@@ -421,6 +429,12 @@ function ParkDetailPageInner({
                 </div>
               )}
               <TrailConditionsDisplay parkSlug={park.id} />
+              {/* OP-53: NWS forecast + current. Renders nothing when both
+                  are empty (parks without coords or outside NWS coverage). */}
+              <WeatherCard
+                current={weatherCurrent ?? null}
+                forecast={weatherForecast ?? []}
+              />
               <ParkContactSidebar park={park} />
               <CampingInfoCard park={park} />
               <ParkClaimCTA

--- a/src/lib/weather/icons.ts
+++ b/src/lib/weather/icons.ts
@@ -1,0 +1,61 @@
+/**
+ * Map NWS condition strings → a small keyword enum, then resolve to a Lucide
+ * icon at the call site via a static Record. The enum indirection lets
+ * consumers use the same lookup pattern as ParkAlertsBanner's SEVERITY_ICON,
+ * which avoids the react-hooks/static-components lint rule that flags
+ * `const Icon = func(...)` reassignment in render.
+ *
+ * NWS uses free-text descriptions (e.g. "Mostly Sunny", "Areas of Fog");
+ * we match by keyword in priority order — more specific terms first.
+ */
+
+export type WeatherIconKey =
+  | "thunderstorm"
+  | "hail"
+  | "snow"
+  | "sleet"
+  | "drizzle"
+  | "rain"
+  | "fog"
+  | "wind"
+  | "partlyCloudy"
+  | "cloudy"
+  | "sunny"
+  | "unknown";
+
+interface IconRule {
+  keywords: readonly string[];
+  key: WeatherIconKey;
+}
+
+// Order matters — first match wins. More specific phrases go first.
+const RULES: readonly IconRule[] = [
+  { keywords: ["thunderstorm", "thunder", "lightning"], key: "thunderstorm" },
+  { keywords: ["hail"], key: "hail" },
+  { keywords: ["blizzard", "snow shower", "snow"], key: "snow" },
+  { keywords: ["freezing", "sleet", "ice"], key: "sleet" },
+  { keywords: ["drizzle"], key: "drizzle" },
+  { keywords: ["rain", "shower"], key: "rain" },
+  { keywords: ["fog", "haze", "mist"], key: "fog" },
+  { keywords: ["wind", "breezy", "blustery"], key: "wind" },
+  { keywords: ["partly", "mostly cloudy", "partly sunny"], key: "partlyCloudy" },
+  { keywords: ["cloud", "overcast"], key: "cloudy" },
+  { keywords: ["sunny", "clear", "fair", "hot"], key: "sunny" },
+];
+
+/**
+ * Classify a NWS condition string into a stable keyword. Used at call sites
+ * to index into an icon Record. Returns "unknown" for nulls / unmatched.
+ */
+export function weatherIconKey(
+  condition: string | null | undefined,
+): WeatherIconKey {
+  if (!condition) return "unknown";
+  const lower = condition.toLowerCase();
+  for (const rule of RULES) {
+    if (rule.keywords.some((k) => lower.includes(k))) {
+      return rule.key;
+    }
+  }
+  return "unknown";
+}

--- a/src/lib/weather/index.ts
+++ b/src/lib/weather/index.ts
@@ -1,0 +1,17 @@
+export {
+  getOrResolveGrid,
+  getForecast,
+  getCurrentConditions,
+  getActiveAlerts,
+  getParkWeather,
+} from "./nws-client";
+export { weatherIconKey, type WeatherIconKey } from "./icons";
+export type {
+  CurrentConditions,
+  DailyForecast,
+  ForecastPeriod,
+  NwsGrid,
+  ParkWeather,
+  WeatherAlert,
+  AlertSeverity,
+} from "./types";

--- a/src/lib/weather/nws-client.ts
+++ b/src/lib/weather/nws-client.ts
@@ -1,0 +1,395 @@
+/**
+ * NWS (National Weather Service) client (OP-52).
+ *
+ * api.weather.gov is free and authoritative for US weather + alerts. Two-step
+ * lookup: /points/{lat},{lng} returns a stable grid identifier, then
+ * /gridpoints/{office}/{x},{y}/forecast returns the actual forecast.
+ *
+ * Caching: Next.js fetch cache with tags. Grid lookups are cached
+ * indefinitely (revalidate: false) — the grid for a coordinate never
+ * changes. Forecast / current / alerts get short TTLs. Coord edits invalidate
+ * via revalidateTag("park:{parkId}:weather").
+ *
+ * NWS asks API consumers to identify themselves via User-Agent.
+ */
+
+import type {
+  CurrentConditions,
+  DailyForecast,
+  ForecastPeriod,
+  NwsGrid,
+  ParkWeather,
+  WeatherAlert,
+} from "./types";
+
+const NWS_BASE = "https://api.weather.gov";
+const USER_AGENT = "offroad-parks (mike.sassatelli@gmail.com)";
+
+const GRID_TAG_PREFIX = "park:";
+const GRID_TAG_SUFFIX = ":weather";
+
+const FORECAST_TTL_SECONDS = 6 * 60 * 60; // 6h
+const CURRENT_TTL_SECONDS = 30 * 60; // 30min
+const ALERTS_TTL_SECONDS = 10 * 60; // 10min
+
+function tagForPark(parkId: string): string {
+  return `${GRID_TAG_PREFIX}${parkId}${GRID_TAG_SUFFIX}`;
+}
+
+interface NwsFetchOpts {
+  parkId: string;
+  /** seconds, or false for indefinite. */
+  revalidate: number | false;
+}
+
+/**
+ * Wrapper around fetch that adds the NWS-required User-Agent and Next.js
+ * fetch cache config. Returns null on any non-OK response — NWS is reliable
+ * but does 5xx occasionally; the UI should degrade gracefully rather than
+ * crash a park detail page.
+ */
+async function nwsFetch<T>(url: string, opts: NwsFetchOpts): Promise<T | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "application/geo+json",
+      },
+      next: {
+        revalidate: opts.revalidate,
+        tags: [tagForPark(opts.parkId)],
+      },
+    });
+    if (!res.ok) {
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface NwsPointsResponse {
+  properties: {
+    gridId: string;
+    gridX: number;
+    gridY: number;
+    forecast: string;
+    forecastHourly: string;
+    observationStations: string;
+    relativeLocation?: {
+      properties?: {
+        city?: string;
+        state?: string;
+      };
+    };
+  };
+}
+
+/**
+ * Resolve a coordinate to an NWS grid. Cached indefinitely keyed by URL;
+ * invalidated via the park's weather tag when coords change.
+ *
+ * Returns null when NWS does not cover the coord (e.g. outside US) or the
+ * request fails.
+ */
+export async function getOrResolveGrid(
+  parkId: string,
+  lat: number,
+  lng: number,
+): Promise<NwsGrid | null> {
+  // Round to 4 decimal places (~11m) to maximize cache key reuse between
+  // near-identical coord queries and to satisfy NWS's input expectations.
+  const roundedLat = Math.round(lat * 10000) / 10000;
+  const roundedLng = Math.round(lng * 10000) / 10000;
+  const url = `${NWS_BASE}/points/${roundedLat},${roundedLng}`;
+
+  const data = await nwsFetch<NwsPointsResponse>(url, {
+    parkId,
+    revalidate: false,
+  });
+  if (!data) return null;
+
+  const p = data.properties;
+  return {
+    office: p.gridId,
+    gridX: p.gridX,
+    gridY: p.gridY,
+    forecastUrl: p.forecast,
+    forecastHourlyUrl: p.forecastHourly,
+    stationsUrl: p.observationStations,
+    city: p.relativeLocation?.properties?.city ?? null,
+    state: p.relativeLocation?.properties?.state ?? null,
+  };
+}
+
+interface NwsForecastResponse {
+  properties: {
+    periods: Array<{
+      name: string;
+      startTime: string;
+      endTime: string;
+      isDaytime: boolean;
+      temperature: number;
+      temperatureUnit: string;
+      probabilityOfPrecipitation: { value: number | null };
+      shortForecast: string;
+      icon: string;
+    }>;
+  };
+}
+
+function periodFromRaw(
+  raw: NwsForecastResponse["properties"]["periods"][number],
+): ForecastPeriod {
+  return {
+    name: raw.name,
+    startTime: raw.startTime,
+    isDaytime: raw.isDaytime,
+    temperatureF: raw.temperature,
+    precipProbability: raw.probabilityOfPrecipitation?.value ?? null,
+    shortForecast: raw.shortForecast,
+    iconCode: raw.icon ?? null,
+  };
+}
+
+/**
+ * Fold NWS's alternating day/night periods into one entry per calendar day.
+ * NWS returns up to ~14 periods (today + 6 days, each with day+night). We
+ * keep the first 5 days for the OP-53 display row.
+ */
+function periodsToDaily(periods: ForecastPeriod[]): DailyForecast[] {
+  const byDate = new Map<string, { day?: ForecastPeriod; night?: ForecastPeriod }>();
+
+  for (const period of periods) {
+    const date = period.startTime.slice(0, 10);
+    const entry = byDate.get(date) ?? {};
+    if (period.isDaytime) {
+      entry.day = period;
+    } else {
+      entry.night = period;
+    }
+    byDate.set(date, entry);
+  }
+
+  const out: DailyForecast[] = [];
+  const sortedDates = Array.from(byDate.keys()).sort();
+  for (const date of sortedDates) {
+    const { day, night } = byDate.get(date)!;
+    const ref = day ?? night;
+    if (!ref) continue;
+
+    const high = day?.temperatureF ?? null;
+    const low = night?.temperatureF ?? null;
+    const precips = [
+      day?.precipProbability,
+      night?.precipProbability,
+    ].filter((p): p is number => typeof p === "number");
+    const maxPrecip = precips.length > 0 ? Math.max(...precips) : null;
+
+    out.push({
+      date,
+      dayName: dayNameFromIso(ref.startTime),
+      highF: high,
+      lowF: low,
+      precipProbability: maxPrecip,
+      shortForecast: (day ?? night)!.shortForecast,
+      iconCode: (day ?? night)!.iconCode,
+    });
+  }
+
+  return out.slice(0, 5);
+}
+
+function dayNameFromIso(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { weekday: "short" });
+}
+
+/**
+ * 5-day forecast for a park. Returns [] on any failure (including
+ * unresolvable grid) so the UI can render an empty state cleanly.
+ */
+export async function getForecast(
+  parkId: string,
+  lat: number,
+  lng: number,
+): Promise<DailyForecast[]> {
+  const grid = await getOrResolveGrid(parkId, lat, lng);
+  if (!grid) return [];
+
+  const data = await nwsFetch<NwsForecastResponse>(grid.forecastUrl, {
+    parkId,
+    revalidate: FORECAST_TTL_SECONDS,
+  });
+  if (!data) return [];
+
+  const periods = data.properties.periods.map(periodFromRaw);
+  return periodsToDaily(periods);
+}
+
+interface NwsStationsResponse {
+  features: Array<{
+    id: string;
+    properties: {
+      stationIdentifier: string;
+    };
+  }>;
+}
+
+interface NwsObservationResponse {
+  properties: {
+    timestamp: string;
+    textDescription: string;
+    icon: string | null;
+    temperature: { unitCode: string; value: number | null };
+    windChill: { unitCode: string; value: number | null };
+    heatIndex: { unitCode: string; value: number | null };
+  };
+}
+
+/**
+ * Convert a unit-coded value to Fahrenheit. NWS observation values come
+ * back in Celsius (`wmoUnit:degC`) by default; older endpoints used `unit:degF`.
+ * Defensive: if the unit code is unrecognized we assume Celsius.
+ */
+function toFahrenheit(value: number | null, unitCode: string): number | null {
+  if (value == null) return null;
+  if (unitCode.endsWith("degF")) return value;
+  // Default to Celsius -> Fahrenheit
+  return Math.round((value * 9) / 5 + 32);
+}
+
+/**
+ * Current conditions for a park, pulled from the nearest reporting station.
+ * Returns null when no station has a recent valid observation — many remote
+ * stations report only intermittently. UI must handle null gracefully.
+ */
+export async function getCurrentConditions(
+  parkId: string,
+  lat: number,
+  lng: number,
+): Promise<CurrentConditions | null> {
+  const grid = await getOrResolveGrid(parkId, lat, lng);
+  if (!grid) return null;
+
+  const stations = await nwsFetch<NwsStationsResponse>(grid.stationsUrl, {
+    parkId,
+    revalidate: false, // station list is stable
+  });
+  if (!stations || stations.features.length === 0) return null;
+
+  // Try the first 3 stations until one returns a usable temperature. NWS
+  // station availability is uneven; some return null temperatures.
+  for (const station of stations.features.slice(0, 3)) {
+    const stationId = station.properties.stationIdentifier;
+    const obsUrl = `${NWS_BASE}/stations/${stationId}/observations/latest`;
+    const obs = await nwsFetch<NwsObservationResponse>(obsUrl, {
+      parkId,
+      revalidate: CURRENT_TTL_SECONDS,
+    });
+    if (!obs) continue;
+    const temp = toFahrenheit(
+      obs.properties.temperature.value,
+      obs.properties.temperature.unitCode,
+    );
+    if (temp == null) continue;
+
+    const heatIndex = toFahrenheit(
+      obs.properties.heatIndex.value,
+      obs.properties.heatIndex.unitCode,
+    );
+    const windChill = toFahrenheit(
+      obs.properties.windChill.value,
+      obs.properties.windChill.unitCode,
+    );
+    const feelsLike = heatIndex ?? windChill ?? null;
+
+    return {
+      temperatureF: temp,
+      feelsLikeF: feelsLike,
+      shortForecast: obs.properties.textDescription ?? "",
+      iconCode: obs.properties.icon ?? null,
+      observedAt: obs.properties.timestamp,
+    };
+  }
+  return null;
+}
+
+interface NwsAlertsResponse {
+  features: Array<{
+    properties: {
+      id: string;
+      event: string;
+      severity: string;
+      headline: string | null;
+      description: string;
+      effective: string;
+      expires: string | null;
+      urgency: string;
+    };
+  }>;
+}
+
+const VALID_SEVERITIES: ReadonlySet<string> = new Set([
+  "Extreme",
+  "Severe",
+  "Moderate",
+  "Minor",
+  "Unknown",
+]);
+
+/**
+ * Active NWS alerts at a park's coordinates. Empty array on no alerts /
+ * fetch failure. Severity is normalized to the typed enum so callers can
+ * trust the value.
+ */
+export async function getActiveAlerts(
+  parkId: string,
+  lat: number,
+  lng: number,
+): Promise<WeatherAlert[]> {
+  const roundedLat = Math.round(lat * 10000) / 10000;
+  const roundedLng = Math.round(lng * 10000) / 10000;
+  const url = `${NWS_BASE}/alerts/active?point=${roundedLat},${roundedLng}`;
+
+  const data = await nwsFetch<NwsAlertsResponse>(url, {
+    parkId,
+    revalidate: ALERTS_TTL_SECONDS,
+  });
+  if (!data) return [];
+
+  return data.features.map((f) => {
+    const severity = VALID_SEVERITIES.has(f.properties.severity)
+      ? (f.properties.severity as WeatherAlert["severity"])
+      : "Unknown";
+    return {
+      id: f.properties.id,
+      event: f.properties.event,
+      severity,
+      headline: f.properties.headline,
+      description: f.properties.description,
+      effective: f.properties.effective,
+      expires: f.properties.expires,
+      urgency: f.properties.urgency,
+    };
+  });
+}
+
+/**
+ * Convenience: fetch all three weather surfaces for a park in parallel.
+ * Each surface degrades independently to null/empty on failure.
+ */
+export async function getParkWeather(
+  parkId: string,
+  lat: number,
+  lng: number,
+): Promise<ParkWeather> {
+  const [current, forecast, alerts] = await Promise.all([
+    getCurrentConditions(parkId, lat, lng),
+    getForecast(parkId, lat, lng),
+    getActiveAlerts(parkId, lat, lng),
+  ]);
+  return { current, forecast, alerts };
+}

--- a/src/lib/weather/types.ts
+++ b/src/lib/weather/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Weather types (OP-52). Surface-level shapes consumed by UI components —
+ * intentionally minimal and decoupled from raw NWS payloads. The NWS client
+ * maps from the api.weather.gov response shapes into these.
+ */
+
+/**
+ * NWS grid identifier. Returned by /points/{lat},{lng}. Stable for a given
+ * coordinate, so cached indefinitely keyed by URL with a coord-invalidation tag.
+ */
+export interface NwsGrid {
+  office: string;
+  gridX: number;
+  gridY: number;
+  forecastUrl: string;
+  forecastHourlyUrl: string;
+  stationsUrl: string;
+  city: string | null;
+  state: string | null;
+}
+
+export interface CurrentConditions {
+  temperatureF: number | null;
+  feelsLikeF: number | null;
+  shortForecast: string;
+  /** NWS icon URL — used only to derive a Lucide icon via icons.ts. */
+  iconCode: string | null;
+  observedAt: string;
+}
+
+export interface ForecastPeriod {
+  /** "Today" | "Tonight" | "Monday" | "Monday Night" | etc. */
+  name: string;
+  startTime: string;
+  isDaytime: boolean;
+  temperatureF: number;
+  /** 0–100, or null when NWS did not return a value. */
+  precipProbability: number | null;
+  shortForecast: string;
+  iconCode: string | null;
+}
+
+/**
+ * 5-day display-shape: one daytime entry + one overnight entry per calendar
+ * day, normalized into hi/lo. NWS returns 7-period sequences (today + 6 days
+ * = 13 periods); we pair-fold them.
+ */
+export interface DailyForecast {
+  date: string;
+  dayName: string;
+  highF: number | null;
+  lowF: number | null;
+  /** Higher of day/night precip probability. */
+  precipProbability: number | null;
+  shortForecast: string;
+  iconCode: string | null;
+}
+
+export type AlertSeverity =
+  | "Extreme"
+  | "Severe"
+  | "Moderate"
+  | "Minor"
+  | "Unknown";
+
+export interface WeatherAlert {
+  id: string;
+  event: string;
+  severity: AlertSeverity;
+  headline: string | null;
+  description: string;
+  effective: string;
+  expires: string | null;
+  /** "Immediate" | "Expected" | "Future" | "Past" | "Unknown" */
+  urgency: string;
+}
+
+/**
+ * Light helper bundle returned by `getParkWeather` — single call from server
+ * components, avoids the awkward `await Promise.all(...)` boilerplate at
+ * call sites.
+ */
+export interface ParkWeather {
+  current: CurrentConditions | null;
+  forecast: DailyForecast[];
+  alerts: WeatherAlert[];
+}

--- a/test/app/api/admin/parks/[id]/route.test.ts
+++ b/test/app/api/admin/parks/[id]/route.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/lib/prisma", () => ({
 // Mock Next.js cache revalidation
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
 }));
 
 // OP-90: map-hero generation is fire-and-forget; stub so tests don't trigger

--- a/test/components/parks/WeatherCard.test.tsx
+++ b/test/components/parks/WeatherCard.test.tsx
@@ -1,0 +1,127 @@
+import { WeatherCard } from "@/components/parks/WeatherCard";
+import type { CurrentConditions, DailyForecast } from "@/lib/weather/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+const CURRENT: CurrentConditions = {
+  temperatureF: 72,
+  feelsLikeF: 70,
+  shortForecast: "Mostly Sunny",
+  iconCode: null,
+  observedAt: "2026-05-12T12:00:00Z",
+};
+
+const FORECAST: DailyForecast[] = [
+  {
+    date: "2026-05-12",
+    dayName: "Mon",
+    highF: 75,
+    lowF: 52,
+    precipProbability: 20,
+    shortForecast: "Partly Sunny",
+    iconCode: null,
+  },
+  {
+    date: "2026-05-13",
+    dayName: "Tue",
+    highF: 70,
+    lowF: 48,
+    precipProbability: 60,
+    shortForecast: "Rain",
+    iconCode: null,
+  },
+];
+
+describe("WeatherCard", () => {
+  it("renders nothing when both current and forecast are empty", () => {
+    const { container } = render(<WeatherCard current={null} forecast={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders current temperature and condition", () => {
+    render(<WeatherCard current={CURRENT} forecast={[]} />);
+    expect(screen.getByText("72°")).toBeInTheDocument();
+    expect(screen.getByText("Mostly Sunny")).toBeInTheDocument();
+  });
+
+  it("hides feels-like when it equals the actual temperature", () => {
+    const sameFeels: CurrentConditions = {
+      ...CURRENT,
+      temperatureF: 72,
+      feelsLikeF: 72,
+    };
+    render(<WeatherCard current={sameFeels} forecast={[]} />);
+    expect(screen.queryByText(/Feels/)).not.toBeInTheDocument();
+  });
+
+  it("shows feels-like when meaningfully different from actual", () => {
+    const hot: CurrentConditions = {
+      ...CURRENT,
+      temperatureF: 95,
+      feelsLikeF: 105,
+    };
+    render(<WeatherCard current={hot} forecast={[]} />);
+    expect(screen.getByText(/Feels 105°/)).toBeInTheDocument();
+  });
+
+  it("renders 5-day forecast row when forecast data is present", () => {
+    render(<WeatherCard current={null} forecast={FORECAST} />);
+    expect(screen.getByText("Mon")).toBeInTheDocument();
+    expect(screen.getByText("Tue")).toBeInTheDocument();
+    expect(screen.getByText("75°")).toBeInTheDocument();
+    expect(screen.getByText("/ 52°")).toBeInTheDocument();
+  });
+
+  it("shows precipitation probability badge only when >= 20%", () => {
+    const lowAndHigh: DailyForecast[] = [
+      {
+        date: "2026-05-12",
+        dayName: "Mon",
+        highF: 75,
+        lowF: 52,
+        precipProbability: 10, // hidden
+        shortForecast: "Sunny",
+        iconCode: null,
+      },
+      {
+        date: "2026-05-13",
+        dayName: "Tue",
+        highF: 70,
+        lowF: 48,
+        precipProbability: 60, // shown
+        shortForecast: "Rain",
+        iconCode: null,
+      },
+    ];
+    render(<WeatherCard current={null} forecast={lowAndHigh} />);
+    expect(screen.queryByText("10%")).not.toBeInTheDocument();
+    expect(screen.getByText("60%")).toBeInTheDocument();
+  });
+
+  it("renders em-dash for missing hi/lo values", () => {
+    const missing: DailyForecast[] = [
+      {
+        date: "2026-05-12",
+        dayName: "Mon",
+        highF: null,
+        lowF: null,
+        precipProbability: null,
+        shortForecast: "Cloudy",
+        iconCode: null,
+      },
+    ];
+    render(<WeatherCard current={null} forecast={missing} />);
+    expect(screen.getByText("—°")).toBeInTheDocument();
+    expect(screen.getByText("/ —°")).toBeInTheDocument();
+  });
+
+  it("includes NWS attribution", () => {
+    render(<WeatherCard current={CURRENT} forecast={FORECAST} />);
+    expect(screen.getByText(/National Weather Service/)).toBeInTheDocument();
+  });
+
+  it("has data-testid for parent-component integration tests", () => {
+    render(<WeatherCard current={CURRENT} forecast={FORECAST} />);
+    expect(screen.getByTestId("weather-card")).toBeInTheDocument();
+  });
+});

--- a/test/lib/weather/icons.test.ts
+++ b/test/lib/weather/icons.test.ts
@@ -1,0 +1,69 @@
+import { weatherIconKey } from "@/lib/weather/icons";
+import { describe, expect, it } from "vitest";
+
+describe("weatherIconKey", () => {
+  it("returns 'sunny' for sunny / clear / fair conditions", () => {
+    expect(weatherIconKey("Sunny")).toBe("sunny");
+    expect(weatherIconKey("Clear")).toBe("sunny");
+    expect(weatherIconKey("Fair")).toBe("sunny");
+  });
+
+  it("returns 'partlyCloudy' for partly conditions", () => {
+    expect(weatherIconKey("Partly Sunny")).toBe("partlyCloudy");
+    expect(weatherIconKey("Partly Cloudy")).toBe("partlyCloudy");
+    expect(weatherIconKey("Mostly Cloudy")).toBe("partlyCloudy");
+  });
+
+  it("returns 'rain' for rain and showers", () => {
+    expect(weatherIconKey("Rain")).toBe("rain");
+    expect(weatherIconKey("Slight Chance Showers")).toBe("rain");
+    expect(weatherIconKey("Heavy Rain")).toBe("rain");
+  });
+
+  it("returns 'snow' for snow conditions", () => {
+    expect(weatherIconKey("Snow")).toBe("snow");
+    expect(weatherIconKey("Snow Showers")).toBe("snow");
+    expect(weatherIconKey("Blizzard")).toBe("snow");
+  });
+
+  it("returns 'thunderstorm' for thunderstorms", () => {
+    expect(weatherIconKey("Thunderstorms")).toBe("thunderstorm");
+    expect(weatherIconKey("Scattered Thunderstorms")).toBe("thunderstorm");
+    expect(weatherIconKey("Lightning")).toBe("thunderstorm");
+  });
+
+  it("returns 'fog' for fog/haze/mist", () => {
+    expect(weatherIconKey("Areas of Fog")).toBe("fog");
+    expect(weatherIconKey("Haze")).toBe("fog");
+  });
+
+  it("returns 'wind' for windy conditions", () => {
+    expect(weatherIconKey("Breezy")).toBe("wind");
+    expect(weatherIconKey("Windy")).toBe("wind");
+  });
+
+  it("returns 'sleet' for freezing precipitation", () => {
+    expect(weatherIconKey("Freezing Rain")).toBe("sleet");
+    expect(weatherIconKey("Sleet")).toBe("sleet");
+    expect(weatherIconKey("Ice Pellets")).toBe("sleet");
+  });
+
+  it("falls back to 'unknown' for null/empty/unknown", () => {
+    expect(weatherIconKey(null)).toBe("unknown");
+    expect(weatherIconKey(undefined)).toBe("unknown");
+    expect(weatherIconKey("")).toBe("unknown");
+    expect(weatherIconKey("Smoke and Volcanic Ash")).toBe("unknown");
+  });
+
+  it("is case-insensitive", () => {
+    expect(weatherIconKey("SUNNY")).toBe("sunny");
+    expect(weatherIconKey("rain")).toBe("rain");
+  });
+
+  it("prioritizes more-specific keywords over generic ones", () => {
+    // "Partly Sunny" hits "partly" rule before "sunny" rule
+    expect(weatherIconKey("Partly Sunny")).toBe("partlyCloudy");
+    // "Snow Showers" hits "snow shower" rule, not "shower"
+    expect(weatherIconKey("Snow Showers")).toBe("snow");
+  });
+});

--- a/test/lib/weather/nws-client.test.ts
+++ b/test/lib/weather/nws-client.test.ts
@@ -1,0 +1,425 @@
+import {
+  getActiveAlerts,
+  getCurrentConditions,
+  getForecast,
+  getOrResolveGrid,
+  getParkWeather,
+} from "@/lib/weather/nws-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// NWS client uses global fetch with `next: { revalidate, tags }`. In test we
+// just stub fetch to return whatever payload we want.
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const PARK_ID = "park-test";
+const LAT = 39.7392;
+const LNG = -104.9903; // Denver-ish
+
+const POINTS_RESPONSE = {
+  properties: {
+    gridId: "BOU",
+    gridX: 62,
+    gridY: 61,
+    forecast: "https://api.weather.gov/gridpoints/BOU/62,61/forecast",
+    forecastHourly: "https://api.weather.gov/gridpoints/BOU/62,61/forecast/hourly",
+    observationStations: "https://api.weather.gov/gridpoints/BOU/62,61/stations",
+    relativeLocation: {
+      properties: {
+        city: "Denver",
+        state: "CO",
+      },
+    },
+  },
+};
+
+const FORECAST_RESPONSE = {
+  properties: {
+    periods: [
+      {
+        name: "Today",
+        startTime: "2026-05-12T06:00:00-06:00",
+        endTime: "2026-05-12T18:00:00-06:00",
+        isDaytime: true,
+        temperature: 75,
+        temperatureUnit: "F",
+        probabilityOfPrecipitation: { value: 20 },
+        shortForecast: "Partly Sunny",
+        icon: "https://api.weather.gov/icons/land/day/sct?size=medium",
+      },
+      {
+        name: "Tonight",
+        startTime: "2026-05-12T18:00:00-06:00",
+        endTime: "2026-05-13T06:00:00-06:00",
+        isDaytime: false,
+        temperature: 52,
+        temperatureUnit: "F",
+        probabilityOfPrecipitation: { value: 40 },
+        shortForecast: "Chance Showers",
+        icon: "https://api.weather.gov/icons/land/night/rain,40?size=medium",
+      },
+      {
+        name: "Wednesday",
+        startTime: "2026-05-13T06:00:00-06:00",
+        endTime: "2026-05-13T18:00:00-06:00",
+        isDaytime: true,
+        temperature: 70,
+        temperatureUnit: "F",
+        probabilityOfPrecipitation: { value: 60 },
+        shortForecast: "Rain",
+        icon: "https://api.weather.gov/icons/land/day/rain?size=medium",
+      },
+      {
+        name: "Wednesday Night",
+        startTime: "2026-05-13T18:00:00-06:00",
+        endTime: "2026-05-14T06:00:00-06:00",
+        isDaytime: false,
+        temperature: 48,
+        temperatureUnit: "F",
+        probabilityOfPrecipitation: { value: null },
+        shortForecast: "Cloudy",
+        icon: null,
+      },
+    ],
+  },
+};
+
+const STATIONS_RESPONSE = {
+  features: [
+    { id: "https://api.weather.gov/stations/KDEN", properties: { stationIdentifier: "KDEN" } },
+    { id: "https://api.weather.gov/stations/KAPA", properties: { stationIdentifier: "KAPA" } },
+  ],
+};
+
+const OBSERVATION_RESPONSE = {
+  properties: {
+    timestamp: "2026-05-12T12:00:00+00:00",
+    textDescription: "Mostly Sunny",
+    icon: "https://api.weather.gov/icons/land/day/sct?size=medium",
+    temperature: { unitCode: "wmoUnit:degC", value: 22.2 }, // ~72°F
+    windChill: { unitCode: "wmoUnit:degC", value: null },
+    heatIndex: { unitCode: "wmoUnit:degC", value: null },
+  },
+};
+
+const ALERTS_RESPONSE = {
+  features: [
+    {
+      properties: {
+        id: "urn:nws:alert:123",
+        event: "Red Flag Warning",
+        severity: "Severe",
+        headline: "Red Flag Warning until 6 PM MDT",
+        description: "Critical fire weather conditions.",
+        effective: "2026-05-12T12:00:00-06:00",
+        expires: "2026-05-12T18:00:00-06:00",
+        urgency: "Expected",
+      },
+    },
+    {
+      properties: {
+        id: "urn:nws:alert:124",
+        event: "Wind Advisory",
+        severity: "Moderate",
+        headline: "Wind Advisory",
+        description: "Windy.",
+        effective: "2026-05-12T12:00:00-06:00",
+        expires: null,
+        urgency: "Expected",
+      },
+    },
+  ],
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getOrResolveGrid", () => {
+  it("returns grid info from /points", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE));
+
+    const grid = await getOrResolveGrid(PARK_ID, LAT, LNG);
+
+    expect(grid).toEqual({
+      office: "BOU",
+      gridX: 62,
+      gridY: 61,
+      forecastUrl: POINTS_RESPONSE.properties.forecast,
+      forecastHourlyUrl: POINTS_RESPONSE.properties.forecastHourly,
+      stationsUrl: POINTS_RESPONSE.properties.observationStations,
+      city: "Denver",
+      state: "CO",
+    });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/points/39.7392,-104.9903");
+  });
+
+  it("sends the NWS-required User-Agent header", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE));
+    await getOrResolveGrid(PARK_ID, LAT, LNG);
+    const init = fetchMock.mock.calls[0][1] as RequestInit & { next?: unknown };
+    const headers = init.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toMatch(/offroad-parks/);
+    expect(headers["Accept"]).toBe("application/geo+json");
+  });
+
+  it("uses indefinite revalidation and a park-scoped tag for grid lookups", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE));
+    await getOrResolveGrid(PARK_ID, LAT, LNG);
+    const init = fetchMock.mock.calls[0][1] as RequestInit & {
+      next?: { revalidate: number | false; tags: string[] };
+    };
+    expect(init.next?.revalidate).toBe(false);
+    expect(init.next?.tags).toEqual([`park:${PARK_ID}:weather`]);
+  });
+
+  it("returns null on NWS error status", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 500));
+    const grid = await getOrResolveGrid(PARK_ID, LAT, LNG);
+    expect(grid).toBeNull();
+  });
+
+  it("returns null when fetch throws", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    const grid = await getOrResolveGrid(PARK_ID, LAT, LNG);
+    expect(grid).toBeNull();
+  });
+
+  it("rounds coords to 4 decimal places for cache-key reuse", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE));
+    await getOrResolveGrid(PARK_ID, 39.73928374, -104.99031234);
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/points/39.7393,-104.9903");
+  });
+});
+
+describe("getForecast", () => {
+  it("returns a folded 5-day forecast with hi/lo per day", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(FORECAST_RESPONSE));
+
+    const forecast = await getForecast(PARK_ID, LAT, LNG);
+
+    expect(forecast).toHaveLength(2);
+    const day1 = forecast[0];
+    expect(day1.date).toBe("2026-05-12");
+    expect(day1.highF).toBe(75);
+    expect(day1.lowF).toBe(52);
+    expect(day1.precipProbability).toBe(40); // max of 20 + 40
+    expect(day1.shortForecast).toBe("Partly Sunny");
+
+    const day2 = forecast[1];
+    expect(day2.date).toBe("2026-05-13");
+    expect(day2.highF).toBe(70);
+    expect(day2.lowF).toBe(48);
+    expect(day2.precipProbability).toBe(60); // null treated as missing
+  });
+
+  it("uses 6h revalidation on the forecast call", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(FORECAST_RESPONSE));
+    await getForecast(PARK_ID, LAT, LNG);
+    const init = fetchMock.mock.calls[1][1] as { next: { revalidate: number } };
+    expect(init.next.revalidate).toBe(6 * 60 * 60);
+  });
+
+  it("returns [] when grid resolution fails", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const forecast = await getForecast(PARK_ID, LAT, LNG);
+    expect(forecast).toEqual([]);
+  });
+
+  it("returns [] when forecast fetch fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({}, false, 500));
+    const forecast = await getForecast(PARK_ID, LAT, LNG);
+    expect(forecast).toEqual([]);
+  });
+
+  it("caps at 5 days even with longer NWS response", async () => {
+    const periods = Array.from({ length: 14 }, (_, i) => ({
+      name: `Period ${i}`,
+      startTime: `2026-05-${String(12 + Math.floor(i / 2)).padStart(2, "0")}T${i % 2 === 0 ? "06" : "18"}:00:00-06:00`,
+      endTime: "2026-05-13T18:00:00-06:00",
+      isDaytime: i % 2 === 0,
+      temperature: 70 - i,
+      temperatureUnit: "F",
+      probabilityOfPrecipitation: { value: 10 },
+      shortForecast: "Sunny",
+      icon: "x",
+    }));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({ properties: { periods } }));
+    const forecast = await getForecast(PARK_ID, LAT, LNG);
+    expect(forecast.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("getCurrentConditions", () => {
+  it("converts Celsius observations to Fahrenheit", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(STATIONS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(OBSERVATION_RESPONSE));
+
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current).not.toBeNull();
+    expect(current!.temperatureF).toBe(72); // 22.2C -> 72F
+    expect(current!.shortForecast).toBe("Mostly Sunny");
+    expect(current!.observedAt).toBe("2026-05-12T12:00:00+00:00");
+  });
+
+  it("uses provided Fahrenheit values without re-conversion", async () => {
+    const fObs = {
+      ...OBSERVATION_RESPONSE,
+      properties: {
+        ...OBSERVATION_RESPONSE.properties,
+        temperature: { unitCode: "unit:degF", value: 68 },
+      },
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(STATIONS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(fObs));
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current!.temperatureF).toBe(68);
+  });
+
+  it("returns feels-like as heat index when available, else wind chill", async () => {
+    const obsWithHeat = {
+      ...OBSERVATION_RESPONSE,
+      properties: {
+        ...OBSERVATION_RESPONSE.properties,
+        heatIndex: { unitCode: "wmoUnit:degC", value: 35 }, // 95F
+        windChill: { unitCode: "wmoUnit:degC", value: null },
+      },
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(STATIONS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(obsWithHeat));
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current!.feelsLikeF).toBe(95);
+  });
+
+  it("falls through to next station when first returns null temperature", async () => {
+    const nullObs = {
+      ...OBSERVATION_RESPONSE,
+      properties: {
+        ...OBSERVATION_RESPONSE.properties,
+        temperature: { unitCode: "wmoUnit:degC", value: null },
+      },
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(STATIONS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse(nullObs))
+      .mockResolvedValueOnce(jsonResponse(OBSERVATION_RESPONSE));
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current).not.toBeNull();
+    expect(current!.temperatureF).toBe(72);
+  });
+
+  it("returns null when no stations are available", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(POINTS_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({ features: [] }));
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current).toBeNull();
+  });
+
+  it("returns null when grid resolution fails", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 404));
+    const current = await getCurrentConditions(PARK_ID, LAT, LNG);
+    expect(current).toBeNull();
+  });
+});
+
+describe("getActiveAlerts", () => {
+  it("normalizes alerts and preserves severity ordering", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(ALERTS_RESPONSE));
+    const alerts = await getActiveAlerts(PARK_ID, LAT, LNG);
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0].event).toBe("Red Flag Warning");
+    expect(alerts[0].severity).toBe("Severe");
+    expect(alerts[1].severity).toBe("Moderate");
+  });
+
+  it("normalizes unknown severity values to 'Unknown'", async () => {
+    const weird = {
+      features: [
+        {
+          properties: {
+            ...ALERTS_RESPONSE.features[0].properties,
+            severity: "Catastrophic", // not a valid NWS severity
+          },
+        },
+      ],
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(weird));
+    const alerts = await getActiveAlerts(PARK_ID, LAT, LNG);
+    expect(alerts[0].severity).toBe("Unknown");
+  });
+
+  it("uses 10min revalidation", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(ALERTS_RESPONSE));
+    await getActiveAlerts(PARK_ID, LAT, LNG);
+    const init = fetchMock.mock.calls[0][1] as { next: { revalidate: number } };
+    expect(init.next.revalidate).toBe(10 * 60);
+  });
+
+  it("returns [] on fetch failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 500));
+    const alerts = await getActiveAlerts(PARK_ID, LAT, LNG);
+    expect(alerts).toEqual([]);
+  });
+});
+
+describe("getParkWeather", () => {
+  it("fetches all three surfaces and returns a combined object", async () => {
+    // current path: points, stations, observation
+    // forecast path: points (cached), forecast
+    // alerts path: alerts (no points dep)
+    // Parallel call order via Promise.all is not guaranteed; mock 6 fetches
+    // and identify by URL pattern.
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/points/")) return Promise.resolve(jsonResponse(POINTS_RESPONSE));
+      if (url.includes("/stations") && !url.includes("/observations"))
+        return Promise.resolve(jsonResponse(STATIONS_RESPONSE));
+      if (url.includes("/observations/latest"))
+        return Promise.resolve(jsonResponse(OBSERVATION_RESPONSE));
+      if (url.includes("/forecast")) return Promise.resolve(jsonResponse(FORECAST_RESPONSE));
+      if (url.includes("/alerts/active")) return Promise.resolve(jsonResponse(ALERTS_RESPONSE));
+      return Promise.resolve(jsonResponse({}, false, 404));
+    });
+
+    const weather = await getParkWeather(PARK_ID, LAT, LNG);
+
+    expect(weather.current).not.toBeNull();
+    expect(weather.current!.temperatureF).toBe(72);
+    expect(weather.forecast.length).toBeGreaterThan(0);
+    expect(weather.alerts).toHaveLength(2);
+  });
+
+  it("degrades gracefully when all calls fail", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, false, 500));
+    const weather = await getParkWeather(PARK_ID, LAT, LNG);
+    expect(weather.current).toBeNull();
+    expect(weather.forecast).toEqual([]);
+    expect(weather.alerts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
First half of E10 · Weather Integration. Ships an NWS-backed weather library and a sidebar widget on the park detail page.

- **OP-52** — `src/lib/weather/` NWS client. Two-step grid lookup (`/points` → `/gridpoints`) with Next.js fetch caching tagged per park. Forecast 6h, current obs 30m, alerts 10m, grid indefinite. Coord-edit handler busts the tag. Graceful null/empty fallbacks on NWS 5xx. Identifiable User-Agent.
- **OP-53** — `<WeatherCard />` between TrailConditionsDisplay and ParkContactSidebar. Current temp + icon + 5-day row with hi/lo and precip%. Hides entirely when both surfaces are empty. NWS attribution inline.

Also in this PR (planning):
- **BACKLOG**: locks E10 scope; defers OP-91 Google Places (ToS + $840/mo cost); new E21 user-notifications epic (OP-92/93) for future weather email alerts.
- **SPRINT**: opens Sprint 6 around E10.

OP-54 (alerts banner) and OP-55 (rain badge on cards) ship in follow-up PRs.

## Test plan
- [x] `npm test` — 1969 / 1969 pass (32 new weather lib tests + 9 new WeatherCard tests + 1 updated route test mock)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (6 pre-existing warnings in admin route, untouched)
- [ ] Manual: verify card renders on a park with coords; verify card hidden on a park without coords
- [ ] Manual: edit a park's coords in admin; confirm next park-detail load shows fresh weather

🤖 Generated with [Claude Code](https://claude.com/claude-code)