### PR TITLE
feat(weather): severe NWS alerts banner on park detail (OP-54)

### DIFF
--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -5,7 +5,7 @@ import { ParkDetailPage } from "@/features/parks/detail/ParkDetailPage";
 import { auth } from "@/lib/auth";
 import { isAlertActive, sortAlertsForDisplay } from "@/lib/park-alerts";
 import type { ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
-import { getCurrentConditions, getForecast } from "@/lib/weather";
+import { getActiveAlerts, getCurrentConditions, getForecast } from "@/lib/weather";
 
 interface ParkPageProps {
   params: Promise<{ id: string }>;
@@ -147,13 +147,14 @@ export default async function ParkPage({ params }: ParkPageProps) {
   // to the address record — same precedence as map-hero generation.
   const weatherLat = dbPark.latitude ?? dbPark.address?.latitude ?? null;
   const weatherLng = dbPark.longitude ?? dbPark.address?.longitude ?? null;
-  const [weatherCurrent, weatherForecast] =
+  const [weatherCurrent, weatherForecast, weatherAlerts] =
     weatherLat != null && weatherLng != null
       ? await Promise.all([
           getCurrentConditions(dbPark.id, weatherLat, weatherLng),
           getForecast(dbPark.id, weatherLat, weatherLng),
+          getActiveAlerts(dbPark.id, weatherLat, weatherLng),
         ])
-      : [null, []];
+      : [null, [], []];
 
   const userRole = (session?.user as { role?: string })?.role;
   const isAdmin = userRole === "ADMIN" || userRole === "SUPER_ADMIN";
@@ -190,6 +191,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
       alerts={activeAlerts}
       weatherCurrent={weatherCurrent}
       weatherForecast={weatherForecast}
+      weatherAlerts={weatherAlerts}
     />
   );
 }

--- a/src/components/parks/WeatherAlertsBanner.tsx
+++ b/src/components/parks/WeatherAlertsBanner.tsx
@@ -1,0 +1,225 @@
+/**
+ * Severe-weather banner on the park detail page (OP-54). Renders only when
+ * at least one active NWS alert is Severe or Extreme. The banner shows the
+ * highest-priority alert inline; "View all alerts" opens a modal listing
+ * every active alert at the coord (including Moderate/Minor advisories).
+ *
+ * Out of scope: triggering park closures. Closures are operator-controlled
+ * (OP-65), never auto-driven from weather data.
+ */
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { AlertSeverity, WeatherAlert } from "@/lib/weather/types";
+import { AlertOctagon, AlertTriangle, ExternalLink, Info } from "lucide-react";
+import { useState } from "react";
+
+// Severity sort order — Extreme first, Unknown last.
+const SEVERITY_RANK: Record<AlertSeverity, number> = {
+  Extreme: 0,
+  Severe: 1,
+  Moderate: 2,
+  Minor: 3,
+  Unknown: 4,
+};
+
+const SEVERE_PLUS: ReadonlySet<AlertSeverity> = new Set(["Extreme", "Severe"]);
+
+const SEVERITY_CLASSES: Record<
+  AlertSeverity,
+  { container: string; icon: string; pill: string }
+> = {
+  Extreme: {
+    container:
+      "bg-red-50 border-red-300 text-red-900 dark:bg-red-950/40 dark:border-red-800 dark:text-red-100",
+    icon: "text-red-700 dark:text-red-300",
+    pill: "bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100",
+  },
+  Severe: {
+    container:
+      "bg-red-50 border-red-200 text-red-900 dark:bg-red-950/40 dark:border-red-900 dark:text-red-100",
+    icon: "text-red-600 dark:text-red-400",
+    pill: "bg-red-100 text-red-900 dark:bg-red-900 dark:text-red-100",
+  },
+  Moderate: {
+    container:
+      "bg-amber-50 border-amber-200 text-amber-900 dark:bg-amber-950/40 dark:border-amber-900 dark:text-amber-100",
+    icon: "text-amber-600 dark:text-amber-400",
+    pill: "bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100",
+  },
+  Minor: {
+    container:
+      "bg-blue-50 border-blue-200 text-blue-900 dark:bg-blue-950/40 dark:border-blue-900 dark:text-blue-100",
+    icon: "text-blue-600 dark:text-blue-400",
+    pill: "bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-100",
+  },
+  Unknown: {
+    container:
+      "bg-muted border-border text-foreground",
+    icon: "text-muted-foreground",
+    pill: "bg-muted text-muted-foreground",
+  },
+};
+
+const SEVERITY_ICON: Record<AlertSeverity, typeof Info> = {
+  Extreme: AlertOctagon,
+  Severe: AlertOctagon,
+  Moderate: AlertTriangle,
+  Minor: Info,
+  Unknown: Info,
+};
+
+interface WeatherAlertsBannerProps {
+  alerts: WeatherAlert[];
+}
+
+function sortBySeverity(alerts: WeatherAlert[]): WeatherAlert[] {
+  return [...alerts].sort(
+    (a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity],
+  );
+}
+
+function formatExpires(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  // Compact local-time formatting — "until 6pm Tue" reads more naturally
+  // than the raw ISO string. Day name only when not today.
+  const now = new Date();
+  const today =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: d.getMinutes() === 0 ? undefined : "2-digit",
+  });
+  if (today) return `until ${time}`;
+  const day = d.toLocaleDateString("en-US", { weekday: "short" });
+  return `until ${time} ${day}`;
+}
+
+export function WeatherAlertsBanner({ alerts }: WeatherAlertsBannerProps) {
+  const [open, setOpen] = useState(false);
+
+  if (alerts.length === 0) return null;
+  const sorted = sortBySeverity(alerts);
+  const severePlus = sorted.filter((a) => SEVERE_PLUS.has(a.severity));
+  if (severePlus.length === 0) return null;
+
+  const top = severePlus[0];
+  const topClasses = SEVERITY_CLASSES[top.severity];
+  const TopIcon = SEVERITY_ICON[top.severity];
+  const expiresText = formatExpires(top.expires);
+
+  return (
+    <div
+      role="region"
+      aria-label="Weather alerts"
+      data-testid="weather-alerts-banner"
+    >
+      <div
+        className={`border rounded-md px-4 py-3 flex items-start gap-3 ${topClasses.container}`}
+        role="alert"
+      >
+        <TopIcon
+          className={`w-5 h-5 flex-shrink-0 mt-0.5 ${topClasses.icon}`}
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold">
+            {top.event}
+            {expiresText && (
+              <span className="font-normal text-sm/normal opacity-80">
+                {" "}
+                · {expiresText}
+              </span>
+            )}
+          </p>
+          {top.headline && top.headline !== top.event && (
+            <p className="text-sm mt-0.5">{top.headline}</p>
+          )}
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="text-sm font-medium underline-offset-2 hover:underline mt-1 inline-flex items-center gap-1"
+              >
+                View all alerts
+                {alerts.length > severePlus.length && (
+                  <span className="opacity-70">({alerts.length})</span>
+                )}
+                <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </DialogTrigger>
+            <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Active weather alerts</DialogTitle>
+                <DialogDescription>
+                  {alerts.length} active{" "}
+                  {alerts.length === 1 ? "alert" : "alerts"} from the National
+                  Weather Service for this park&apos;s location.
+                </DialogDescription>
+              </DialogHeader>
+              <ul className="space-y-3">
+                {sorted.map((alert) => {
+                  const classes = SEVERITY_CLASSES[alert.severity];
+                  const Icon = SEVERITY_ICON[alert.severity];
+                  const expires = formatExpires(alert.expires);
+                  return (
+                    <li
+                      key={alert.id}
+                      className={`border rounded-md px-4 py-3 ${classes.container}`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <Icon
+                          className={`w-5 h-5 flex-shrink-0 mt-0.5 ${classes.icon}`}
+                          aria-hidden="true"
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center flex-wrap gap-2">
+                            <p className="font-semibold text-sm">
+                              {alert.event}
+                            </p>
+                            <span
+                              className={`text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5 ${classes.pill}`}
+                            >
+                              {alert.severity}
+                            </span>
+                            {expires && (
+                              <span className="text-xs opacity-80">
+                                {expires}
+                              </span>
+                            )}
+                          </div>
+                          {alert.headline && (
+                            <p className="text-sm mt-1 font-medium">
+                              {alert.headline}
+                            </p>
+                          )}
+                          <p className="text-xs mt-2 whitespace-pre-wrap leading-relaxed">
+                            {alert.description}
+                          </p>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+              <p className="text-[10px] text-muted-foreground pt-2">
+                Source: National Weather Service
+              </p>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -21,7 +21,12 @@ import { CampingInfoCard } from "./components/CampingInfoCard";
 import { ParkMapHero } from "@/components/parks/ParkMapHero";
 import { ParkAlertsBanner, type ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
 import { WeatherCard } from "@/components/parks/WeatherCard";
-import type { CurrentConditions, DailyForecast } from "@/lib/weather/types";
+import { WeatherAlertsBanner } from "@/components/parks/WeatherAlertsBanner";
+import type {
+  CurrentConditions,
+  DailyForecast,
+  WeatherAlert,
+} from "@/lib/weather/types";
 import { ReviewList, ReviewForm, StarRating, DifficultyRating } from "@/components/reviews";
 import { TrailConditionsDisplay } from "@/features/trail-conditions/TrailConditionsDisplay";
 import { useReviews } from "@/hooks/useReviews";
@@ -62,6 +67,8 @@ interface ParkDetailPageProps {
   weatherCurrent?: CurrentConditions | null;
   /** OP-53: server-fetched 5-day forecast. Empty when unavailable. */
   weatherForecast?: DailyForecast[];
+  /** OP-54: server-fetched active NWS alerts. Empty when none / unavailable. */
+  weatherAlerts?: WeatherAlert[];
 }
 
 function ParkDetailPageInner({
@@ -76,6 +83,7 @@ function ParkDetailPageInner({
   alerts,
   weatherCurrent,
   weatherForecast,
+  weatherAlerts,
 }: ParkDetailPageProps) {
   const router = useRouter();
   const { data: session } = useSession();
@@ -205,6 +213,14 @@ function ParkDetailPageInner({
       </div>
 
       <main className="max-w-7xl mx-auto px-6 py-8">
+        {/* OP-54: NWS severe-weather alerts. Renders above operator alerts
+            because weather can be life-safety; operator messaging is
+            generally informational. Self-hides when no Severe+ alert. */}
+        {weatherAlerts && weatherAlerts.length > 0 && (
+          <div className="mb-4">
+            <WeatherAlertsBanner alerts={weatherAlerts} />
+          </div>
+        )}
         {alerts && alerts.length > 0 && (
           <div className="mb-6">
             <ParkAlertsBanner alerts={alerts} />

--- a/test/components/parks/WeatherAlertsBanner.test.tsx
+++ b/test/components/parks/WeatherAlertsBanner.test.tsx
@@ -1,0 +1,132 @@
+import { WeatherAlertsBanner } from "@/components/parks/WeatherAlertsBanner";
+import type { WeatherAlert } from "@/lib/weather/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+function makeAlert(overrides: Partial<WeatherAlert> = {}): WeatherAlert {
+  return {
+    id: `urn:nws:alert:${Math.random()}`,
+    event: "Red Flag Warning",
+    severity: "Severe",
+    headline: "Red Flag Warning until 6 PM",
+    description: "Critical fire weather conditions.",
+    effective: "2026-05-12T12:00:00-06:00",
+    expires: "2026-05-12T18:00:00-06:00",
+    urgency: "Expected",
+    ...overrides,
+  };
+}
+
+describe("WeatherAlertsBanner", () => {
+  it("renders nothing when there are no alerts", () => {
+    const { container } = render(<WeatherAlertsBanner alerts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when only Moderate/Minor alerts exist", () => {
+    const { container } = render(
+      <WeatherAlertsBanner
+        alerts={[makeAlert({ severity: "Moderate" }), makeAlert({ severity: "Minor" })]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner for a Severe alert", () => {
+    render(<WeatherAlertsBanner alerts={[makeAlert({ severity: "Severe" })]} />);
+    expect(screen.getByTestId("weather-alerts-banner")).toBeInTheDocument();
+    expect(screen.getAllByText("Red Flag Warning").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the banner for an Extreme alert", () => {
+    render(
+      <WeatherAlertsBanner
+        alerts={[makeAlert({ severity: "Extreme", event: "Tornado Warning" })]}
+      />,
+    );
+    expect(screen.getByText("Tornado Warning")).toBeInTheDocument();
+  });
+
+  it("shows the highest-severity alert first in the banner", () => {
+    render(
+      <WeatherAlertsBanner
+        alerts={[
+          makeAlert({ id: "a", severity: "Severe", event: "Wind Warning" }),
+          makeAlert({ id: "b", severity: "Extreme", event: "Tornado Warning" }),
+        ]}
+      />,
+    );
+    // Banner area (the first occurrence — modal is in portal not yet open)
+    expect(screen.getByText("Tornado Warning")).toBeInTheDocument();
+  });
+
+  it("shows total alerts count in 'View all alerts' when more than the severe-plus subset", async () => {
+    const user = userEvent.setup();
+    render(
+      <WeatherAlertsBanner
+        alerts={[
+          makeAlert({ id: "a", severity: "Severe" }),
+          makeAlert({ id: "b", severity: "Moderate", event: "Wind Advisory" }),
+          makeAlert({ id: "c", severity: "Minor", event: "Air Quality" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/View all alerts/)).toBeInTheDocument();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+
+    await user.click(screen.getByText(/View all alerts/));
+
+    // All three alerts appear in modal
+    expect(
+      screen.getByText("Active weather alerts"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Wind Advisory")).toBeInTheDocument();
+    expect(screen.getByText("Air Quality")).toBeInTheDocument();
+  });
+
+  it("modal lists alerts sorted by severity (Extreme → Minor)", async () => {
+    const user = userEvent.setup();
+    render(
+      <WeatherAlertsBanner
+        alerts={[
+          makeAlert({ id: "a", severity: "Minor", event: "Air Quality" }),
+          makeAlert({ id: "b", severity: "Extreme", event: "Tornado" }),
+          makeAlert({ id: "c", severity: "Moderate", event: "Wind Advisory" }),
+        ]}
+      />,
+    );
+    await user.click(screen.getByText(/View all alerts/));
+    const modal = screen.getByRole("dialog");
+    const items = modal.querySelectorAll("li");
+    // Order: Tornado (Extreme), Wind Advisory (Moderate), Air Quality (Minor)
+    expect(items[0].textContent).toContain("Tornado");
+    expect(items[1].textContent).toContain("Wind Advisory");
+    expect(items[2].textContent).toContain("Air Quality");
+  });
+
+  it("hides the headline when it duplicates the event string", () => {
+    render(
+      <WeatherAlertsBanner
+        alerts={[
+          makeAlert({
+            severity: "Severe",
+            event: "Red Flag Warning",
+            headline: "Red Flag Warning",
+          }),
+        ]}
+      />,
+    );
+    // event appears once in banner. headline (same text) is suppressed.
+    expect(screen.getAllByText("Red Flag Warning")).toHaveLength(1);
+  });
+
+  it("includes NWS attribution in the modal", async () => {
+    const user = userEvent.setup();
+    render(<WeatherAlertsBanner alerts={[makeAlert({ severity: "Severe" })]} />);
+    await user.click(screen.getByText(/View all alerts/));
+    // Radix may portal the dialog in both DOM and aria-hidden copies, so
+    // we accept >= 1 match for the attribution line.
+    expect(screen.getAllByText(/National Weather Service/).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Second of three E10 weather PRs. Adds a severe-weather banner at the top of the park detail page.

- New `<WeatherAlertsBanner />` renders only when an active NWS alert is **Severe** or **Extreme**. Highest-severity alert shown inline with expiry (\"until 6pm\"). \"View all alerts\" opens a Radix Dialog listing every active alert sorted by severity rank (Extreme → Minor).
- Banner sits above the existing operator-posted `ParkAlertsBanner` since weather is a life-safety surface.
- Server-fetched in `src/app/parks/[id]/page.tsx` via `getActiveAlerts` from the OP-52 lib (already cache-tagged per park, 10min TTL).

**Out of scope** (per E10 lock-in): park-closure indicators. Closures remain operator-controlled via OP-65; auto-closing on weather data is too high-stakes.

## Test plan
- [x] 9 new component tests cover severity gating, sort order, headline dedupe, modal open + content, attribution
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run test/components/parks/ test/lib/weather/` — 197/197 pass
- [ ] Manual: live park with no Severe+ alerts — banner hidden
- [ ] Manual: simulate a Severe alert — banner shows, modal opens, content correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)