### PR TITLE
feat(weather): rain-likelihood badge on park cards + close Sprint 6 (OP-55)

### DIFF
--- a/planning/SPRINT.md
+++ b/planning/SPRINT.md
@@ -4,10 +4,7 @@
 Ship weather integration end-to-end: NWS-backed forecast + current conditions on park detail, severe-alert banner, and rain-likelihood badge on park cards. All four E10 stories.
 
 ## In Progress
-- [ ] OP-52 — NWS Integration & Caching
-- [ ] OP-53 — Current & Forecast Weather Display
-- [ ] OP-54 — Weather Alerts & Warnings
-- [ ] OP-55 — Rain Likelihood on Park Cards
+*(none)*
 
 ## Up Next
 *(none — focused sprint on E10)*
@@ -15,9 +12,17 @@ Ship weather integration end-to-end: NWS-backed forecast + current conditions on
 ## Blocked
 *(none)*
 
+## Done This Sprint
+- [x] ~~OP-52~~ NWS Integration & Caching — PR #138 merged 2026-05-12. `src/lib/weather/` with grid resolution, forecast (6h cache), current obs (30m), alerts (10m); coord-edit handler busts the per-park tag. Identifiable User-Agent. Graceful null/empty on NWS 5xx. 32 tests.
+- [x] ~~OP-53~~ Current & Forecast Weather Display — PR #138 merged 2026-05-12. `<WeatherCard />` between TrailConditionsDisplay and ParkContactSidebar on the park detail sidebar. Self-hides on missing data. 9 component tests.
+- [x] ~~OP-54~~ Weather Alerts & Warnings — PR #139 merged 2026-05-12. `<WeatherAlertsBanner />` shows Severe+ NWS alerts at the top of the park detail page with a "View all alerts" Dialog listing every active alert by severity. Park-closure indicator dropped per E10 lock-in. 9 tests.
+- [x] ~~OP-55~~ Rain Likelihood on Park Cards — PR #140 merged 2026-05-12. `<RainBadge />` at `bottom-2 right-2` on `<ParkCard />`. Color thresholds green <20% / amber 20–60% / red >60%. Batched server-side fetch (`getBatchRainProbabilities`) with per-park 2s timeout + 12-way concurrency cap; subsequent renders cache-hit. 19 tests.
+
 ## Notes / Decisions
 - E20 OP-91 (Google Places) deferred: Google Maps Platform ToS prohibits caching photo Content; live-fetch alternative costs ~$840/mo at projected traffic. OP-90 map hero + OP-00D community CTA cover the gap acceptably.
 - New epic E21 (User Notifications) created. OP-93 (severe-weather email alerts) shelved behind OP-92 (preferences foundation) — explicit opt-in only, every channel toggleable from profile.
+- E10 caching: forecast 6h, current obs 30m, alerts 10m, grid indefinite; coord-edit handler revalidates the per-park weather tag. First-render cost on the parks-list page is bounded by a 2s per-park timeout + concurrency cap of 12.
+- OP-54 dropped the "park closure indicator" — closures stay operator-controlled via OP-65; auto-closing on weather data is too high-stakes.
 
 ---
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import UtvParksApp from "@/components/ui/OffroadParksApp";
 import { prisma } from "@/lib/prisma";
 import { resolveParkHeroImage } from "@/lib/park-hero";
 import { transformDbPark } from "@/lib/types";
+import { getBatchRainProbabilities } from "@/lib/weather";
 
 // Force dynamic rendering to always show fresh data
 export const dynamic = "force-dynamic";
@@ -59,10 +60,24 @@ export default async function Page() {
     },
   });
 
+  // OP-55: batched fetch of today's rain probability for each park. Uses
+  // the same forecast cache as OP-53 (6h TTL), so warm requests are
+  // basically free. Per-park 2s timeout + concurrency cap bound the
+  // first-render cost; parks that don't respond in time simply omit the
+  // badge until the next render.
+  const rainByParkId = await getBatchRainProbabilities(
+    dbParks.map((p) => ({
+      parkId: p.id,
+      latitude: p.latitude ?? p.address?.latitude ?? null,
+      longitude: p.longitude ?? p.address?.longitude ?? null,
+    })),
+  );
+
   // Transform to client format with hero images (respects operator selection)
   const parks = dbParks.map((park) => ({
     ...transformDbPark(park),
     heroImage: resolveParkHeroImage(park),
+    todaysRainChance: rainByParkId.get(park.id) ?? null,
   }));
 
   return <UtvParksApp parks={parks} />;

--- a/src/components/parks/ParkCard.tsx
+++ b/src/components/parks/ParkCard.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { ParkMapHero } from "@/components/parks/ParkMapHero";
 import { ConditionBadge } from "@/features/trail-conditions/ConditionBadge";
+import { RainBadge } from "@/components/parks/RainBadge";
 import type { TrailConditionStatus } from "@/lib/trail-conditions";
 import { isConditionFresh } from "@/lib/trail-conditions";
 
@@ -91,6 +92,11 @@ export function ParkCard({
                 />
               </div>
             )}
+            {park.todaysRainChance != null && (
+              <div className="absolute bottom-2 right-2 z-10">
+                <RainBadge probability={park.todaysRainChance} />
+              </div>
+            )}
           </div>
         ) : hasMapHero ? (
           <div className="relative">
@@ -117,6 +123,11 @@ export function ParkCard({
                 />
               </div>
             )}
+            {park.todaysRainChance != null && (
+              <div className="absolute bottom-2 right-2 z-10">
+                <RainBadge probability={park.todaysRainChance} />
+              </div>
+            )}
           </div>
         ) : (
           <div className="relative h-48 w-full bg-gradient-to-br from-muted to-muted/50 flex items-center justify-center">
@@ -141,6 +152,11 @@ export function ParkCard({
                   status={freshCondition.status as TrailConditionStatus}
                   size="xs"
                 />
+              </div>
+            )}
+            {park.todaysRainChance != null && (
+              <div className="absolute bottom-2 right-2 z-10">
+                <RainBadge probability={park.todaysRainChance} />
               </div>
             )}
           </div>

--- a/src/components/parks/RainBadge.tsx
+++ b/src/components/parks/RainBadge.tsx
@@ -1,0 +1,57 @@
+/**
+ * Today's rain-likelihood badge on park cards (OP-55). Color-coded by
+ * probability: green < 20%, amber 20–60%, red > 60%. Hidden when the
+ * probability is null (no forecast yet / outside NWS coverage / timed out).
+ */
+import { Droplets } from "lucide-react";
+
+interface RainBadgeProps {
+  /** 0–100, or null to hide. */
+  probability: number | null | undefined;
+}
+
+function colorFor(p: number): {
+  bg: string;
+  text: string;
+  ring: string;
+  iconColor: string;
+} {
+  if (p < 20) {
+    return {
+      bg: "bg-green-100 dark:bg-green-900/60",
+      text: "text-green-900 dark:text-green-100",
+      ring: "ring-green-200/60 dark:ring-green-800/60",
+      iconColor: "text-green-700 dark:text-green-300",
+    };
+  }
+  if (p <= 60) {
+    return {
+      bg: "bg-amber-100 dark:bg-amber-900/60",
+      text: "text-amber-900 dark:text-amber-100",
+      ring: "ring-amber-200/60 dark:ring-amber-800/60",
+      iconColor: "text-amber-700 dark:text-amber-300",
+    };
+  }
+  return {
+    bg: "bg-red-100 dark:bg-red-900/60",
+    text: "text-red-900 dark:text-red-100",
+    ring: "ring-red-200/60 dark:ring-red-800/60",
+    iconColor: "text-red-700 dark:text-red-300",
+  };
+}
+
+export function RainBadge({ probability }: RainBadgeProps) {
+  if (probability == null) return null;
+  const c = colorFor(probability);
+  return (
+    <div
+      data-testid="rain-badge"
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shadow-sm ring-1 ${c.bg} ${c.text} ${c.ring}`}
+      aria-label={`${probability}% chance of rain today`}
+      title={`${probability}% chance of rain today`}
+    >
+      <Droplets className={`w-3 h-3 ${c.iconColor}`} aria-hidden="true" />
+      <span className="tabular-nums">{probability}%</span>
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -235,6 +235,10 @@ export type Park = {
     status: string;
     createdAt: string;
   };
+  // OP-55: today's max precipitation probability (0–100), populated by the
+  // parks-list server page via NWS forecast. Null when no forecast is
+  // available (no coords / outside coverage / fetch timeout).
+  todaysRainChance?: number | null;
   // Operator
   hasOperator?: boolean;
 };

--- a/src/lib/weather/batch.ts
+++ b/src/lib/weather/batch.ts
@@ -1,0 +1,62 @@
+/**
+ * Batch helpers for OP-55 — page-grid rain badges fetched per visible card.
+ *
+ * NWS does not expose a multi-point endpoint, so the parks-list page fans
+ * out one `getForecast` call per park. To keep first-render latency
+ * bounded we cap concurrency *and* apply a per-park timeout — late
+ * responses return null and the badge simply doesn't render. Subsequent
+ * page loads hit the 6h forecast cache and resolve immediately.
+ */
+import { getForecast } from "./nws-client";
+
+interface BatchInput {
+  parkId: string;
+  latitude: number | null | undefined;
+  longitude: number | null | undefined;
+}
+
+interface BatchOptions {
+  /** Max parallel NWS calls. Default 12. */
+  concurrency?: number;
+  /** Per-park timeout in ms. Default 2000. */
+  timeoutMs?: number;
+}
+
+/**
+ * Fetch today's max precipitation probability for each park. Returns a
+ * Map<parkId, probability | null>. Parks without coords, parks whose call
+ * exceeded the per-park timeout, and parks outside NWS coverage all map
+ * to null (the consuming UI hides the badge in that case).
+ */
+export async function getBatchRainProbabilities(
+  parks: readonly BatchInput[],
+  opts: BatchOptions = {},
+): Promise<Map<string, number | null>> {
+  const concurrency = opts.concurrency ?? 12;
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  const results = new Map<string, number | null>();
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < parks.length) {
+      const i = cursor++;
+      const park = parks[i];
+      if (park.latitude == null || park.longitude == null) {
+        results.set(park.parkId, null);
+        continue;
+      }
+      const fetched = getForecast(park.parkId, park.latitude, park.longitude)
+        .then((f) => f[0]?.precipProbability ?? null)
+        .catch(() => null);
+      const timed = new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), timeoutMs),
+      );
+      const value = await Promise.race([fetched, timed]);
+      results.set(park.parkId, value);
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(concurrency, parks.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/src/lib/weather/index.ts
+++ b/src/lib/weather/index.ts
@@ -5,6 +5,7 @@ export {
   getActiveAlerts,
   getParkWeather,
 } from "./nws-client";
+export { getBatchRainProbabilities } from "./batch";
 export { weatherIconKey, type WeatherIconKey } from "./icons";
 export type {
   CurrentConditions,

--- a/test/components/parks/RainBadge.test.tsx
+++ b/test/components/parks/RainBadge.test.tsx
@@ -1,0 +1,71 @@
+import { RainBadge } from "@/components/parks/RainBadge";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+describe("RainBadge", () => {
+  it("renders nothing when probability is null", () => {
+    const { container } = render(<RainBadge probability={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when probability is undefined", () => {
+    const { container } = render(<RainBadge probability={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the probability value with a percent sign", () => {
+    render(<RainBadge probability={45} />);
+    expect(screen.getByText("45%")).toBeInTheDocument();
+  });
+
+  it("renders 0% (edge case — explicit dry forecast)", () => {
+    render(<RainBadge probability={0} />);
+    expect(screen.getByText("0%")).toBeInTheDocument();
+  });
+
+  it("uses green styling for low probability (< 20%)", () => {
+    render(<RainBadge probability={10} />);
+    const badge = screen.getByTestId("rain-badge");
+    expect(badge.className).toMatch(/bg-green-/);
+    expect(badge.className).not.toMatch(/bg-amber-/);
+    expect(badge.className).not.toMatch(/bg-red-/);
+  });
+
+  it("uses amber styling for moderate probability (20–60%)", () => {
+    render(<RainBadge probability={40} />);
+    const badge = screen.getByTestId("rain-badge");
+    expect(badge.className).toMatch(/bg-amber-/);
+    expect(badge.className).not.toMatch(/bg-green-/);
+    expect(badge.className).not.toMatch(/bg-red-/);
+  });
+
+  it("uses red styling for high probability (> 60%)", () => {
+    render(<RainBadge probability={75} />);
+    const badge = screen.getByTestId("rain-badge");
+    expect(badge.className).toMatch(/bg-red-/);
+    expect(badge.className).not.toMatch(/bg-green-/);
+    expect(badge.className).not.toMatch(/bg-amber-/);
+  });
+
+  it("uses amber at the exact 20% boundary", () => {
+    render(<RainBadge probability={20} />);
+    expect(screen.getByTestId("rain-badge").className).toMatch(/bg-amber-/);
+  });
+
+  it("uses amber at the exact 60% boundary", () => {
+    render(<RainBadge probability={60} />);
+    expect(screen.getByTestId("rain-badge").className).toMatch(/bg-amber-/);
+  });
+
+  it("uses red just above the 60% boundary", () => {
+    render(<RainBadge probability={61} />);
+    expect(screen.getByTestId("rain-badge").className).toMatch(/bg-red-/);
+  });
+
+  it("provides an accessible label and title with the probability", () => {
+    render(<RainBadge probability={45} />);
+    const badge = screen.getByTestId("rain-badge");
+    expect(badge).toHaveAttribute("aria-label", "45% chance of rain today");
+    expect(badge).toHaveAttribute("title", "45% chance of rain today");
+  });
+});

--- a/test/lib/weather/batch.test.ts
+++ b/test/lib/weather/batch.test.ts
@@ -1,0 +1,142 @@
+import { getBatchRainProbabilities } from "@/lib/weather/batch";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub the nws-client module — batch.ts delegates to getForecast.
+vi.mock("@/lib/weather/nws-client", () => ({
+  getForecast: vi.fn(),
+}));
+
+import { getForecast } from "@/lib/weather/nws-client";
+const mockGetForecast = vi.mocked(getForecast);
+
+function forecastWithRain(probability: number | null) {
+  return [
+    {
+      date: "2026-05-12",
+      dayName: "Mon",
+      highF: 75,
+      lowF: 52,
+      precipProbability: probability,
+      shortForecast: "Partly Sunny",
+      iconCode: null,
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getBatchRainProbabilities", () => {
+  it("returns a Map keyed by parkId with today's precip probability", async () => {
+    mockGetForecast
+      .mockResolvedValueOnce(forecastWithRain(20))
+      .mockResolvedValueOnce(forecastWithRain(80));
+
+    const result = await getBatchRainProbabilities([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+      { parkId: "p2", latitude: 40, longitude: -105 },
+    ]);
+
+    expect(result.get("p1")).toBe(20);
+    expect(result.get("p2")).toBe(80);
+  });
+
+  it("maps parks without coordinates to null without calling getForecast", async () => {
+    const result = await getBatchRainProbabilities([
+      { parkId: "no-coords", latitude: null, longitude: null },
+      { parkId: "no-lat", latitude: null, longitude: -104 },
+      { parkId: "no-lng", latitude: 39, longitude: null },
+    ]);
+
+    expect(result.get("no-coords")).toBeNull();
+    expect(result.get("no-lat")).toBeNull();
+    expect(result.get("no-lng")).toBeNull();
+    expect(mockGetForecast).not.toHaveBeenCalled();
+  });
+
+  it("maps parks whose forecast returned no precip probability to null", async () => {
+    mockGetForecast.mockResolvedValueOnce(forecastWithRain(null));
+
+    const result = await getBatchRainProbabilities([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toBeNull();
+  });
+
+  it("maps parks with empty forecast to null", async () => {
+    mockGetForecast.mockResolvedValueOnce([]);
+
+    const result = await getBatchRainProbabilities([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toBeNull();
+  });
+
+  it("maps parks whose getForecast call rejects to null (does not propagate)", async () => {
+    mockGetForecast.mockRejectedValueOnce(new Error("nws 500"));
+
+    const result = await getBatchRainProbabilities([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toBeNull();
+  });
+
+  it("times out slow forecast calls to null", async () => {
+    mockGetForecast.mockImplementation(
+      () => new Promise(() => {
+        // never resolves
+      }),
+    );
+
+    const result = await getBatchRainProbabilities(
+      [{ parkId: "slow", latitude: 39, longitude: -104 }],
+      { timeoutMs: 25 },
+    );
+
+    expect(result.get("slow")).toBeNull();
+  });
+
+  it("limits concurrency to the configured cap", async () => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    mockGetForecast.mockImplementation(async () => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 20));
+      inFlight--;
+      return forecastWithRain(30);
+    });
+
+    const parks = Array.from({ length: 20 }, (_, i) => ({
+      parkId: `p${i}`,
+      latitude: 39,
+      longitude: -104,
+    }));
+    await getBatchRainProbabilities(parks, { concurrency: 3, timeoutMs: 5000 });
+
+    expect(peakInFlight).toBeLessThanOrEqual(3);
+  });
+
+  it("returns a result for every input park (even when timeouts and errors mix)", async () => {
+    mockGetForecast
+      .mockResolvedValueOnce(forecastWithRain(40))
+      .mockRejectedValueOnce(new Error("nws"))
+      .mockResolvedValueOnce(forecastWithRain(70));
+
+    const parks = [
+      { parkId: "a", latitude: 39, longitude: -104 },
+      { parkId: "b", latitude: 40, longitude: -105 },
+      { parkId: "c", latitude: 41, longitude: -106 },
+    ];
+    const result = await getBatchRainProbabilities(parks, { concurrency: 1 });
+
+    expect(result.size).toBe(3);
+    expect(result.get("a")).toBe(40);
+    expect(result.get("b")).toBeNull();
+    expect(result.get("c")).toBe(70);
+  });
+});


### PR DESCRIPTION
## Summary
Third and final E10 weather PR. Adds the rain badge to the parks list grid and marks Sprint 6 complete in planning.

- `<RainBadge probability>` at bottom-right of the park-card hero. Color thresholds: **green** <20% · **amber** 20–60% · **red** >60%. Hides on null.
- New `getBatchRainProbabilities` helper: fans out one cached `getForecast` per park, with per-park 2s timeout + 12-way concurrency cap to bound first-render cost. Subsequent renders hit the 6h forecast cache and resolve in ~ms.
- `Park.todaysRainChance` added to the client type; populated server-side by `src/app/page.tsx`. Coord fallback precedence matches map-hero generation (park root → address).
- planning/SPRINT.md: Sprint 6 closed — OP-52/53/54/55 all done.

## Test plan
- [x] 11 RainBadge component tests (color thresholds at exact boundaries, a11y attrs, null/undefined handling)
- [x] 8 batch helper tests (mapping, missing coords, timeout, error propagation, concurrency cap)
- [x] `npm test` — 1997 / 1997 pass (all suites green pre-rebase)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [ ] Manual: visit `/`, verify rain badges appear on parks within NWS coverage; observe first-render under 2s
- [ ] Manual: re-visit `/` within 6h; verify all badges appear (cache hit)

## After merge
E10 is complete. Next likely candidates (not in this PR):
- OP-92 / OP-93 (user notification preferences + severe-weather email alerts) — new epic E21
- Returning to E18/E19 quality work on the AI Data Context Engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)