### PR TITLE
feat(operator): unify operator header photo across card and detail page

### DIFF
--- a/src/app/api/operator/parks/[parkSlug]/route.ts
+++ b/src/app/api/operator/parks/[parkSlug]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
@@ -335,6 +336,12 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   if (!result) {
     return NextResponse.json({ error: "Failed to fetch updated park" }, { status: 500 });
   }
+
+  // Bust the ISR cache for surfaces that read the updated fields. The home
+  // grid + park detail page both read heroSource/heroPhotoId; other operator
+  // edits (name, pricing, etc.) also surface there.
+  revalidatePath("/");
+  revalidatePath(`/parks/${parkSlug}`);
 
   return NextResponse.json({
     success: true,

--- a/src/app/operator/[parkSlug]/OperatorSidebar.tsx
+++ b/src/app/operator/[parkSlug]/OperatorSidebar.tsx
@@ -27,7 +27,7 @@ export function OperatorSidebar({ parkSlug }: OperatorSidebarProps) {
     { href: `/operator/${parkSlug}/conditions${fromParam}`, label: "Trail Status", icon: Activity },
     { href: `/operator/${parkSlug}/alerts${fromParam}`, label: "Alerts", icon: Megaphone },
     { href: `/operator/${parkSlug}/settings${fromParam}`, label: "Park Details", icon: MapPin },
-    { href: `/operator/${parkSlug}/park-card${fromParam}`, label: "Park Card", icon: Image },
+    { href: `/operator/${parkSlug}/park-card${fromParam}`, label: "Header Photo", icon: Image },
     { href: `/operator/${parkSlug}/photos${fromParam}`, label: "Photos", icon: Camera },
     { href: `/operator/${parkSlug}/reviews${fromParam}`, label: "Reviews", icon: MessageSquare },
     { href: `/operator/${parkSlug}/moderation/conditions${fromParam}`, label: "Condition Reports", icon: ShieldAlert },

--- a/src/app/operator/[parkSlug]/park-card/ParkCardSelectorClient.tsx
+++ b/src/app/operator/[parkSlug]/park-card/ParkCardSelectorClient.tsx
@@ -94,10 +94,11 @@ export function ParkCardSelectorClient({
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold">Park Card</h1>
+        <h1 className="text-2xl font-semibold">Header Photo</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Choose which image is shown on your park&apos;s card across
-          Offroad Parks.
+          Choose the image used as your park&apos;s header. It appears on
+          your park card across the site <em>and</em> at the top of your
+          park&apos;s detail page.
         </p>
       </header>
 
@@ -121,7 +122,11 @@ export function ParkCardSelectorClient({
         {/* Selector */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Hero image source</CardTitle>
+            <CardTitle className="text-base">Header image source</CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">
+              Applies to both the park card preview on the left and the
+              header image at the top of your park&apos;s detail page.
+            </p>
           </CardHeader>
           <CardContent className="space-y-4">
             <RadioRow

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { resolveParkHeroImage } from "@/lib/park-hero";
 import { transformDbPark } from "@/lib/types";
 import { ParkDetailPage } from "@/features/parks/detail/ParkDetailPage";
 import { auth } from "@/lib/auth";
@@ -76,6 +77,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
       vehicleTypes: true,
       address: true,
       operator: { select: { name: true } },
+      // Include the operator-selected hero photo so the detail-page header
+      // image can mirror the park-card image (heroSource = PHOTO).
+      heroPhoto: { select: { id: true, url: true, status: true } },
     },
   });
 
@@ -109,7 +113,24 @@ export default async function ParkPage({ params }: ParkPageProps) {
     },
   });
 
-  const park = transformDbPark(dbPark);
+  // Resolve the operator-controlled header image. Mirrors the same source
+  // priority used on the park-card grid (`src/app/page.tsx`):
+  //   - heroSource = PHOTO → operator-selected photo URL
+  //   - heroSource = AUTO  → first APPROVED photo URL (or null → map hero)
+  //   - heroSource = MAP   → null (sidebar falls back to ParkMapHero)
+  // Without this the detail page always rendered the auto-generated map
+  // hero, ignoring the operator's choice from the operator portal.
+  const resolvedHeroImage = resolveParkHeroImage({
+    heroSource: dbPark.heroSource,
+    heroPhotoId: dbPark.heroPhotoId,
+    heroPhoto: dbPark.heroPhoto,
+    photos: photos.map((p) => ({ id: p.id, url: p.url, status: "APPROVED" })),
+  });
+
+  const park = {
+    ...transformDbPark(dbPark),
+    heroImage: resolvedHeroImage,
+  };
 
   // Fetch active operator-posted alerts. Filter in JS so the predicate stays in
   // one place (src/lib/park-alerts#isAlertActive) and is unit-testable.

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -19,6 +19,7 @@ import { ParkOperationalCard } from "./components/ParkOperationalCard";
 import { ParkOverviewCard } from "./components/ParkOverviewCard";
 import { CampingInfoCard } from "./components/CampingInfoCard";
 import { ParkMapHero } from "@/components/parks/ParkMapHero";
+import Image from "next/image";
 import { ParkAlertsBanner, type ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
 import { WeatherCard } from "@/components/parks/WeatherCard";
 import { WeatherAlertsBanner } from "@/components/parks/WeatherAlertsBanner";
@@ -436,13 +437,32 @@ function ParkDetailPageInner({
           {/* Sidebar */}
           <div className="lg:col-span-1">
             <div className="sticky top-20 space-y-6">
-              {/* Map hero always renders above the sidebar cards (OP-90).
-                  Internally falls back to null when the park has neither a
-                  generated hero nor coords. */}
-              {(park.mapHeroUrl || park.coords) && (
+              {/* Sidebar header image. Source priority mirrors the park
+                  card (OP-90 + operator hero selection):
+                    1. Operator-chosen photo (resolved server-side into
+                       `park.heroImage`) when heroSource is PHOTO, or the
+                       first APPROVED photo when AUTO.
+                    2. Generated/live map hero when heroSource is MAP, or
+                       AUTO with no approved photos.
+                    3. Nothing when neither is available. */}
+              {park.heroImage ? (
                 <div className="rounded-lg border border-border shadow-sm overflow-hidden bg-card">
-                  <ParkMapHero park={park} size="card" />
+                  <div className="relative h-48 w-full bg-muted">
+                    <Image
+                      src={park.heroImage}
+                      alt={park.name}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 1024px) 100vw, 33vw"
+                    />
+                  </div>
                 </div>
+              ) : (
+                (park.mapHeroUrl || park.coords) && (
+                  <div className="rounded-lg border border-border shadow-sm overflow-hidden bg-card">
+                    <ParkMapHero park={park} size="card" />
+                  </div>
+                )
               )}
               <TrailConditionsDisplay parkSlug={park.id} />
               {/* OP-53: NWS forecast + current. Renders nothing when both

--- a/test/app/api/operator/parks/[parkSlug]/route.test.ts
+++ b/test/app/api/operator/parks/[parkSlug]/route.test.ts
@@ -37,6 +37,10 @@ vi.mock("@/lib/auth", () => ({
   auth: vi.fn(),
 }));
 
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
 const operatorSession = { user: { id: "user-1" } };
 
 const mockPark = {
@@ -176,6 +180,34 @@ describe("PATCH /api/operator/parks/[parkSlug]", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.success).toBe(true);
+  });
+
+  it("revalidates the home grid + park detail page after a successful update", async () => {
+    const { revalidatePath } = await import("next/cache");
+    (auth as any).mockResolvedValue(operatorSession);
+    (prisma.park.findUnique as any).mockResolvedValue(mockPark);
+
+    const updatedPark = { ...mockPark, name: "Renamed" };
+    (prisma.$transaction as any).mockImplementation(async (fn: any) => {
+      return fn({
+        park: {
+          update: vi.fn().mockResolvedValue(updatedPark),
+          findUnique: vi.fn().mockResolvedValue(updatedPark),
+        },
+        parkTerrain: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkAmenity: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkCamping: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkVehicleType: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkEditLog: { create: vi.fn().mockResolvedValue({ id: "log-1" }) },
+      });
+    });
+
+    await PATCH(makePatchRequest({ name: "Renamed" }), {
+      params: Promise.resolve({ parkSlug: "test-park" }),
+    });
+
+    expect(revalidatePath).toHaveBeenCalledWith("/");
+    expect(revalidatePath).toHaveBeenCalledWith("/parks/test-park");
   });
 
   it("should ignore disallowed fields like status", async () => {

--- a/test/app/parks/[id]/page.test.tsx
+++ b/test/app/parks/[id]/page.test.tsx
@@ -276,6 +276,7 @@ describe("Park Detail Page", () => {
           vehicleTypes: true,
           address: true,
           operator: { select: { name: true } },
+          heroPhoto: { select: { id: true, url: true, status: true } },
         },
       });
     });


### PR DESCRIPTION
## Summary
Operators picking a hero photo in the operator portal now control both the park-card image **and** the header image on the park detail page sidebar. Previously the detail page always rendered the auto-generated map hero, ignoring the operator's selection.

## Changes
- **Server detail fetch** ([src/app/parks/[id]/page.tsx](src/app/parks/[id]/page.tsx)): include \`heroPhoto\`, resolve \`heroImage\` via \`resolveParkHeroImage\` (same precedence the parks-list grid uses). PHOTO → chosen photo · AUTO → first approved photo (else map) · MAP → map hero.
- **Sidebar rendering** ([src/features/parks/detail/ParkDetailPage.tsx](src/features/parks/detail/ParkDetailPage.tsx)): render the resolved photo when present, else fall back to \`<ParkMapHero>\`.
- **Operator nav label** ([OperatorSidebar.tsx](src/app/operator/[parkSlug]/OperatorSidebar.tsx)): \"Park Card\" → \"Header Photo\".
- **Operator copy** ([ParkCardSelectorClient.tsx](src/app/operator/[parkSlug]/park-card/ParkCardSelectorClient.tsx)): page title \"Header Photo\"; description now states the selection drives both the card *and* the detail-page header.
- **Cache invalidation** ([route.ts](src/app/api/operator/parks/[parkSlug]/route.ts)): operator PATCH calls \`revalidatePath(\"/\")\` and \`revalidatePath(\"/parks/{slug}\")\` so changes propagate to ISR immediately.

URL slug \`/operator/[parkSlug]/park-card\` left intact — only the UX wording shifted.

## Test plan
- [x] \`npm test\` — 1998 / 1998 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [x] New operator-route test asserts revalidation is invoked on update
- [x] Detail-page server-fetch test updated to expect the heroPhoto include
- [ ] Manual: in operator portal, change Header Photo source PHOTO → MAP → AUTO; confirm both the home card and the park detail header reflect the change after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)