### PR TITLE
feat(auth): UserPreGrant — apply role + operator on first sign-in

### DIFF
--- a/prisma/migrations/20260514000000_user_pre_grant/migration.sql
+++ b/prisma/migrations/20260514000000_user_pre_grant/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "UserPreGrant" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "grantRole" "UserRole",
+    "operatorParkSlug" TEXT,
+    "notes" TEXT,
+    "appliedAt" TIMESTAMP(3),
+    "appliedToUserId" TEXT,
+    "createdByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserPreGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPreGrant_email_key" ON "UserPreGrant"("email");
+
+-- CreateIndex
+CREATE INDEX "UserPreGrant_email_idx" ON "UserPreGrant"("email");
+
+-- Seed: pre-grant for the initial beta tester clemenlarryj@gmail.com.
+-- On their first sign-in the NextAuth events.createUser hook will:
+--   1. set their User.role = ADMIN
+--   2. wire them as the OWNER of the operator account on
+--      gypsum-city-ohv-park-iowa (creating the Operator record if needed)
+-- Idempotent via ON CONFLICT — re-deploys are safe.
+INSERT INTO "UserPreGrant" (
+    "id", "email", "grantRole", "operatorParkSlug", "notes", "createdAt"
+) VALUES (
+    'pregrant_seed_clemenlarryj',
+    'clemenlarryj@gmail.com',
+    'ADMIN',
+    'gypsum-city-ohv-park-iowa',
+    'Beta tester — pre-granted ADMIN + operator of Gypsum City OHV Park on first sign-in.',
+    NOW()
+)
+ON CONFLICT ("email") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,31 @@ enum UserRole {
   SUPER_ADMIN
 }
 
+// Pre-grants — declare a role / operator membership that should be applied
+// the first time a user signs in with this email. Triggered by the NextAuth
+// `events.createUser` hook in src/lib/auth.ts. SUPER_ADMIN-managed via
+// /admin/pre-grants. Idempotent: applies once, then `appliedAt` is set and
+// later sign-ins skip it. Useful for onboarding beta testers without
+// requiring them to submit a ParkClaim or wait on manual admin action.
+model UserPreGrant {
+  id                String    @id @default(cuid())
+  // One pre-grant per email. Lookup happens by Google email at signup.
+  email             String    @unique
+  // Role to assign on first sign-in. Null = no role change.
+  grantRole         UserRole?
+  // Park slug to make this user an operator of. Mirrors the claim-approval
+  // transaction (creates Operator + OperatorUser + sets Park.operatorId).
+  operatorParkSlug  String?
+  notes             String?
+  // Audit: which user record the grant resolved to and when.
+  appliedAt         DateTime?
+  appliedToUserId   String?
+  createdByUserId   String?
+  createdAt         DateTime  @default(now())
+
+  @@index([email])
+}
+
 // Park Models
 model Park {
   id            String     @id @default(cuid())

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,6 +11,7 @@ import {
   Globe,
   Home,
   Image as ImageIcon,
+  KeyRound,
   LayoutDashboard,
   LogOut,
   MapPin,
@@ -36,6 +37,7 @@ export default async function AdminLayout({
   if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
     redirect("/");
   }
+  const isSuperAdmin = userRole === "SUPER_ADMIN";
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -184,6 +186,15 @@ export default async function AdminLayout({
               <Users className="w-5 h-5" />
               <span className="font-medium">Users</span>
             </Link>
+            {isSuperAdmin && (
+              <Link
+                href="/admin/pre-grants"
+                className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
+              >
+                <KeyRound className="w-5 h-5" />
+                <span className="font-medium">Pre-grants</span>
+              </Link>
+            )}
           </nav>
         </aside>
 

--- a/src/app/admin/pre-grants/PreGrantManagementClient.tsx
+++ b/src/app/admin/pre-grants/PreGrantManagementClient.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, Trash2 } from "lucide-react";
+
+type Role = "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN";
+
+const ASSIGNABLE_ROLES: Role[] = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"];
+
+export interface PreGrantRow {
+  id: string;
+  email: string;
+  grantRole: Role | null;
+  operatorParkSlug: string | null;
+  notes: string | null;
+  appliedAt: string | null;
+  appliedToUserId: string | null;
+  createdAt: string;
+}
+
+interface Props {
+  initialGrants: PreGrantRow[];
+}
+
+function roleBadgeClass(role: string | null): string {
+  switch (role) {
+    case "SUPER_ADMIN":
+      return "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300";
+    case "ADMIN":
+      return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
+    case "OPERATOR":
+      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+    case "USER":
+      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300";
+    default:
+      return "bg-muted text-foreground";
+  }
+}
+
+export function PreGrantManagementClient({ initialGrants }: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // New-grant form state.
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role | "">("");
+  const [parkSlug, setParkSlug] = useState("");
+  const [notes, setNotes] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setInfo(null);
+    setCreating(true);
+    try {
+      const res = await fetch("/api/admin/pre-grants", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          grantRole: role || null,
+          operatorParkSlug: parkSlug.trim() || null,
+          notes: notes.trim() || null,
+        }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error || `Failed to create (${res.status})`);
+      }
+      setEmail("");
+      setRole("");
+      setParkSlug("");
+      setNotes("");
+      setInfo("Pre-grant created.");
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete(id: string, emailLabel: string) {
+    if (!confirm(`Delete pre-grant for ${emailLabel}?`)) return;
+    setError(null);
+    setInfo(null);
+    setBusyId(id);
+    try {
+      const res = await fetch(`/api/admin/pre-grants/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error || `Failed to delete (${res.status})`);
+      }
+      setInfo(`Pre-grant for ${emailLabel} deleted.`);
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleApplyNow(id: string, emailLabel: string) {
+    setError(null);
+    setInfo(null);
+    setBusyId(id);
+    try {
+      const res = await fetch(`/api/admin/pre-grants/${id}/apply`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+        result?: { status?: string };
+      } | null;
+      if (!res.ok) {
+        throw new Error(data?.error || `Failed to apply (${res.status})`);
+      }
+      setInfo(
+        `Apply result for ${emailLabel}: ${data?.result?.status ?? "applied"}.`,
+      );
+      startTransition(() => router.refresh());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Banner messages */}
+      {error && (
+        <div
+          className="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900 dark:bg-red-950/40 dark:border-red-900 dark:text-red-100"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+      {info && (
+        <div
+          className="rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-900 dark:bg-green-950/40 dark:border-green-900 dark:text-green-100"
+          role="status"
+        >
+          {info}
+        </div>
+      )}
+
+      {/* Create form */}
+      <section className="rounded-lg border border-border bg-card p-6">
+        <h2 className="text-base font-semibold mb-4">Add pre-grant</h2>
+        <form onSubmit={handleCreate} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <label htmlFor="pre-grant-email" className="text-sm font-medium">
+              Email <span className="text-red-600">*</span>
+            </label>
+            <input
+              id="pre-grant-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              placeholder="tester@example.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="pre-grant-role" className="text-sm font-medium">
+              Grant role
+            </label>
+            <select
+              id="pre-grant-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value as Role | "")}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              <option value="">— No role change —</option>
+              {ASSIGNABLE_ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="pre-grant-park" className="text-sm font-medium">
+              Operator-of park slug
+            </label>
+            <input
+              id="pre-grant-park"
+              type="text"
+              value={parkSlug}
+              onChange={(e) => setParkSlug(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              placeholder="gypsum-city-ohv-park-iowa"
+            />
+            <p className="text-xs text-muted-foreground">
+              Park slug — found in the URL of the park detail page.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="pre-grant-notes" className="text-sm font-medium">
+              Notes
+            </label>
+            <input
+              id="pre-grant-notes"
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+              placeholder="Beta tester from acme"
+            />
+          </div>
+          <div className="md:col-span-2 flex items-center gap-3">
+            <button
+              type="submit"
+              disabled={creating || pending}
+              className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+            >
+              {creating ? "Creating…" : "Add pre-grant"}
+            </button>
+            <p className="text-xs text-muted-foreground">
+              Applied automatically when the email signs in for the first time.
+            </p>
+          </div>
+        </form>
+      </section>
+
+      {/* Table */}
+      <section className="rounded-lg border border-border bg-card">
+        <div className="px-6 py-4 border-b border-border">
+          <h2 className="text-base font-semibold">
+            All pre-grants ({initialGrants.length})
+          </h2>
+        </div>
+        {initialGrants.length === 0 ? (
+          <div className="px-6 py-8 text-sm text-muted-foreground text-center">
+            No pre-grants yet.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground bg-muted/30">
+                <tr>
+                  <th className="px-6 py-3">Email</th>
+                  <th className="px-6 py-3">Role</th>
+                  <th className="px-6 py-3">Operator park</th>
+                  <th className="px-6 py-3">Status</th>
+                  <th className="px-6 py-3">Notes</th>
+                  <th className="px-6 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {initialGrants.map((g) => {
+                  const applied = !!g.appliedAt;
+                  const isBusy = busyId === g.id;
+                  return (
+                    <tr key={g.id} className="border-t border-border">
+                      <td className="px-6 py-3 font-medium">{g.email}</td>
+                      <td className="px-6 py-3">
+                        {g.grantRole ? (
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${roleBadgeClass(g.grantRole)}`}
+                          >
+                            {g.grantRole}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-6 py-3">
+                        {g.operatorParkSlug ? (
+                          <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                            {g.operatorParkSlug}
+                          </code>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-6 py-3">
+                        {applied ? (
+                          <span className="inline-flex items-center gap-1 text-xs text-green-700 dark:text-green-400">
+                            <CheckCircle2 className="w-3.5 h-3.5" />
+                            Applied
+                          </span>
+                        ) : (
+                          <span className="text-xs text-amber-700 dark:text-amber-400">
+                            Pending
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-6 py-3 text-xs text-muted-foreground max-w-xs truncate">
+                        {g.notes ?? "—"}
+                      </td>
+                      <td className="px-6 py-3">
+                        <div className="flex items-center gap-2 justify-end">
+                          {!applied && (
+                            <button
+                              type="button"
+                              disabled={isBusy || pending}
+                              onClick={() => handleApplyNow(g.id, g.email)}
+                              className="text-xs rounded-md border border-border px-2 py-1 hover:bg-accent disabled:opacity-50"
+                              title="Apply now if the user has already signed in"
+                            >
+                              Apply now
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            disabled={isBusy || pending}
+                            onClick={() => handleDelete(g.id, g.email)}
+                            className="text-xs rounded-md border border-red-300 text-red-700 px-2 py-1 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40 inline-flex items-center gap-1"
+                          >
+                            <Trash2 className="w-3 h-3" />
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/pre-grants/page.tsx
+++ b/src/app/admin/pre-grants/page.tsx
@@ -1,0 +1,39 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import { PreGrantManagementClient, type PreGrantRow } from "./PreGrantManagementClient";
+
+export default async function AdminPreGrantsPage() {
+  const session = await auth();
+  if (session?.user?.role !== "SUPER_ADMIN") {
+    redirect("/admin/dashboard");
+  }
+
+  const grants = await prisma.userPreGrant.findMany({
+    orderBy: [{ appliedAt: "asc" }, { createdAt: "desc" }],
+  });
+
+  const rows: PreGrantRow[] = grants.map((g) => ({
+    id: g.id,
+    email: g.email,
+    grantRole: g.grantRole,
+    operatorParkSlug: g.operatorParkSlug,
+    notes: g.notes,
+    appliedAt: g.appliedAt ? g.appliedAt.toISOString() : null,
+    appliedToUserId: g.appliedToUserId,
+    createdAt: g.createdAt.toISOString(),
+  }));
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-foreground mb-2">Pre-grants</h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        Declare a role and/or operator membership for an email so it is applied
+        automatically on their first sign-in. Useful for onboarding beta
+        testers without making them go through the claim flow.
+      </p>
+
+      <PreGrantManagementClient initialGrants={rows} />
+    </div>
+  );
+}

--- a/src/app/api/admin/pre-grants/[id]/apply/route.ts
+++ b/src/app/api/admin/pre-grants/[id]/apply/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { applyPreGrant } from "@/lib/pre-grant";
+
+export const runtime = "nodejs";
+
+// POST /api/admin/pre-grants/[id]/apply — retroactively apply a pre-grant
+// to a user who has already signed in (so the createUser hook never fired
+// for them). SUPER_ADMIN only.
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.user.role !== "SUPER_ADMIN") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const grant = await prisma.userPreGrant.findUnique({ where: { id } });
+  if (!grant) {
+    return NextResponse.json({ error: "Pre-grant not found" }, { status: 404 });
+  }
+
+  // Find the user by the grant's email. If they haven't signed in yet,
+  // there's nothing to apply — the createUser hook will handle it.
+  const targetUser = await prisma.user.findUnique({
+    where: { email: grant.email },
+    select: { id: true },
+  });
+  if (!targetUser) {
+    return NextResponse.json(
+      {
+        error: `User with email ${grant.email} has not signed in yet. The grant will apply automatically on their first sign-in.`,
+      },
+      { status: 409 },
+    );
+  }
+
+  const result = await applyPreGrant({
+    email: grant.email,
+    userId: targetUser.id,
+  });
+
+  return NextResponse.json({ result });
+}

--- a/src/app/api/admin/pre-grants/[id]/route.ts
+++ b/src/app/api/admin/pre-grants/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+// DELETE /api/admin/pre-grants/[id] — remove a pre-grant (SUPER_ADMIN only).
+// Applied grants can still be deleted — the audit row is purely
+// informational once `appliedAt` is set.
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (session.user.role !== "SUPER_ADMIN") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const existing = await prisma.userPreGrant.findUnique({ where: { id } });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Pre-grant not found" },
+      { status: 404 },
+    );
+  }
+
+  await prisma.userPreGrant.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/pre-grants/route.ts
+++ b/src/app/api/admin/pre-grants/route.ts
@@ -7,21 +7,32 @@ export const runtime = "nodejs";
 const ASSIGNABLE_ROLES = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"] as const;
 type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
-async function requireSuperAdmin() {
+interface SuperAdminContext {
+  userId: string;
+}
+
+/**
+ * Returns either the SUPER_ADMIN context (userId) for downstream use, or a
+ * NextResponse to bail with. The discriminator is `instanceof NextResponse`
+ * which TypeScript narrows reliably — unlike `"error" in obj` on object
+ * unions, which left earlier callers with a possibly-undefined inferred
+ * return type in the test file.
+ */
+async function requireSuperAdmin(): Promise<NextResponse | SuperAdminContext> {
   const session = await auth();
   if (!session?.user?.id) {
-    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   if (session.user.role !== "SUPER_ADMIN") {
-    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-  return { session };
+  return { userId: session.user.id };
 }
 
 // GET /api/admin/pre-grants — list all pre-grants (SUPER_ADMIN only).
-export async function GET() {
-  const auth = await requireSuperAdmin();
-  if ("error" in auth) return auth.error;
+export async function GET(): Promise<NextResponse> {
+  const authResult = await requireSuperAdmin();
+  if (authResult instanceof NextResponse) return authResult;
 
   const grants = await prisma.userPreGrant.findMany({
     orderBy: [{ appliedAt: "asc" }, { createdAt: "desc" }],
@@ -32,9 +43,9 @@ export async function GET() {
 
 // POST /api/admin/pre-grants — create a new pre-grant (SUPER_ADMIN only).
 // Body: { email, grantRole?, operatorParkSlug?, notes? }
-export async function POST(request: Request) {
+export async function POST(request: Request): Promise<NextResponse> {
   const authResult = await requireSuperAdmin();
-  if ("error" in authResult) return authResult.error;
+  if (authResult instanceof NextResponse) return authResult;
 
   let body: {
     email?: string;
@@ -105,7 +116,7 @@ export async function POST(request: Request) {
       grantRole: (body.grantRole as AssignableRole | undefined) ?? null,
       operatorParkSlug: body.operatorParkSlug ?? null,
       notes: body.notes?.trim() || null,
-      createdByUserId: authResult.session.user.id,
+      createdByUserId: authResult.userId,
     },
   });
 

--- a/src/app/api/admin/pre-grants/route.ts
+++ b/src/app/api/admin/pre-grants/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+
+const ASSIGNABLE_ROLES = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"] as const;
+type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+async function requireSuperAdmin() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+  if (session.user.role !== "SUPER_ADMIN") {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+  return { session };
+}
+
+// GET /api/admin/pre-grants — list all pre-grants (SUPER_ADMIN only).
+export async function GET() {
+  const auth = await requireSuperAdmin();
+  if ("error" in auth) return auth.error;
+
+  const grants = await prisma.userPreGrant.findMany({
+    orderBy: [{ appliedAt: "asc" }, { createdAt: "desc" }],
+  });
+
+  return NextResponse.json({ grants });
+}
+
+// POST /api/admin/pre-grants — create a new pre-grant (SUPER_ADMIN only).
+// Body: { email, grantRole?, operatorParkSlug?, notes? }
+export async function POST(request: Request) {
+  const authResult = await requireSuperAdmin();
+  if ("error" in authResult) return authResult.error;
+
+  let body: {
+    email?: string;
+    grantRole?: string | null;
+    operatorParkSlug?: string | null;
+    notes?: string | null;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = body.email?.trim().toLowerCase();
+  if (!email || !email.includes("@")) {
+    return NextResponse.json(
+      { error: "Valid email is required" },
+      { status: 400 },
+    );
+  }
+
+  if (
+    body.grantRole &&
+    !ASSIGNABLE_ROLES.includes(body.grantRole as AssignableRole)
+  ) {
+    return NextResponse.json(
+      { error: `Invalid role. Must be one of: ${ASSIGNABLE_ROLES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  // Require at least one grant axis — otherwise the row does nothing.
+  if (!body.grantRole && !body.operatorParkSlug) {
+    return NextResponse.json(
+      { error: "Pre-grant must include a role and/or operatorParkSlug" },
+      { status: 400 },
+    );
+  }
+
+  // Validate the park slug exists at creation time — saves admin from
+  // discovering the typo at the tester's first sign-in.
+  if (body.operatorParkSlug) {
+    const park = await prisma.park.findUnique({
+      where: { slug: body.operatorParkSlug },
+      select: { id: true },
+    });
+    if (!park) {
+      return NextResponse.json(
+        { error: `Park slug '${body.operatorParkSlug}' not found` },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Reject duplicate. SUPER_ADMIN can delete + re-create if they need to
+  // change a pre-grant.
+  const existing = await prisma.userPreGrant.findUnique({ where: { email } });
+  if (existing) {
+    return NextResponse.json(
+      { error: `Pre-grant already exists for ${email}` },
+      { status: 409 },
+    );
+  }
+
+  const grant = await prisma.userPreGrant.create({
+    data: {
+      email,
+      grantRole: (body.grantRole as AssignableRole | undefined) ?? null,
+      operatorParkSlug: body.operatorParkSlug ?? null,
+      notes: body.notes?.trim() || null,
+      createdByUserId: authResult.session.user.id,
+    },
+  });
+
+  return NextResponse.json({ grant }, { status: 201 });
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
+import { applyPreGrantForNewUser } from "@/lib/pre-grant";
 import GoogleProvider from "next-auth/providers/google";
 import type { NextAuthConfig, Session, User } from "next-auth";
 
@@ -26,6 +27,16 @@ export const authConfig = {
         session.user.role = user.role ?? undefined;
       }
       return session;
+    },
+  },
+  events: {
+    // Fires the first time a user signs in (after PrismaAdapter has
+    // inserted the row). Resolves any `UserPreGrant` by email and applies
+    // it — sets role and/or wires operator membership. Errors are caught
+    // inside the helper so sign-in is never blocked by a pre-grant glitch.
+    async createUser({ user }) {
+      if (!user.email || !user.id) return;
+      await applyPreGrantForNewUser({ email: user.email, userId: user.id });
     },
   },
 } satisfies NextAuthConfig;

--- a/src/lib/pre-grant.ts
+++ b/src/lib/pre-grant.ts
@@ -1,0 +1,199 @@
+/**
+ * Pre-grant application logic.
+ *
+ * A pre-grant (`UserPreGrant`) declares the role + operator membership a
+ * user should have the first time they sign in with a given email. This
+ * lets us onboard beta testers / operators without making them go through
+ * the claim-submission flow or wait on a SUPER_ADMIN to flip switches.
+ *
+ * The call path:
+ *   - NextAuth `events.createUser` fires when an email signs in for the
+ *     very first time → calls `applyPreGrantForNewUser`.
+ *   - SUPER_ADMIN can also click "Apply" on an existing pre-grant from
+ *     the admin UI to retroactively grant a user who already signed in.
+ *
+ * Outcomes are idempotent: a grant is marked `appliedAt` once consumed
+ * and never re-applied.
+ */
+import type { Prisma, PrismaClient, UserRole } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface ApplyPreGrantInput {
+  email: string;
+  userId: string;
+}
+
+export type ApplyPreGrantResult =
+  | { status: "no-grant" }
+  | { status: "already-applied"; appliedAt: Date }
+  | {
+      status: "applied";
+      grantedRole: UserRole | null;
+      operatorParkSlug: string | null;
+      operatorId: string | null;
+    }
+  | { status: "park-not-found"; parkSlug: string }
+  | { status: "park-has-other-operator"; parkSlug: string; operatorId: string };
+
+type TxClient = Omit<
+  PrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+
+/**
+ * Apply a pre-grant to a user. The user is expected to already exist
+ * (NextAuth's PrismaAdapter has created the row before `events.createUser`
+ * fires).
+ *
+ * Behavior:
+ *   - If no grant exists for this email → returns { status: "no-grant" }.
+ *   - If the grant was already applied → returns { status: "already-applied" }.
+ *   - If `grantRole` is set → updates User.role.
+ *   - If `operatorParkSlug` is set → creates Operator + OperatorUser and
+ *     sets Park.operatorId, *unless* the park already has a different
+ *     operator (in which case we only attach the user to that existing
+ *     operator as OWNER — does not overwrite ownership).
+ *
+ * All writes happen in a single transaction so partial state cannot
+ * survive a crash.
+ */
+export async function applyPreGrant(
+  input: ApplyPreGrantInput,
+): Promise<ApplyPreGrantResult> {
+  return prisma.$transaction(async (tx) => applyPreGrantTx(tx as TxClient, input));
+}
+
+/**
+ * Tx-scoped variant — call this when you already have an open transaction.
+ * Exposed for tests and for the seed-time migration path.
+ */
+export async function applyPreGrantTx(
+  tx: TxClient,
+  input: ApplyPreGrantInput,
+): Promise<ApplyPreGrantResult> {
+  const grant = await tx.userPreGrant.findUnique({
+    where: { email: input.email },
+  });
+  if (!grant) {
+    return { status: "no-grant" };
+  }
+  if (grant.appliedAt) {
+    return { status: "already-applied", appliedAt: grant.appliedAt };
+  }
+
+  // 1. Role grant.
+  if (grant.grantRole) {
+    await tx.user.update({
+      where: { id: input.userId },
+      data: { role: grant.grantRole },
+    });
+  }
+
+  // 2. Operator grant.
+  let operatorId: string | null = null;
+  if (grant.operatorParkSlug) {
+    const park = await tx.park.findUnique({
+      where: { slug: grant.operatorParkSlug },
+      include: { operator: { select: { id: true } } },
+    });
+    if (!park) {
+      return { status: "park-not-found", parkSlug: grant.operatorParkSlug };
+    }
+
+    if (park.operatorId) {
+      // Park already has an operator — attach this user to that operator
+      // as OWNER rather than refusing the grant. Avoids the awkward "grant
+      // half-worked" outcome when a previous tester already claimed the
+      // park.
+      operatorId = park.operatorId;
+      // Don't error on duplicate OperatorUser — upsert keeps it idempotent.
+      await tx.operatorUser.upsert({
+        where: {
+          operatorId_userId: { operatorId, userId: input.userId },
+        },
+        update: {},
+        create: {
+          operatorId,
+          userId: input.userId,
+          role: "OWNER",
+        },
+      });
+    } else {
+      // No operator on the park yet — create one and wire it up. Same
+      // transaction shape as src/app/api/admin/claims/[id]/approve/route.ts
+      // so behavior matches an approved claim.
+      const userForOperator = await tx.user.findUnique({
+        where: { id: input.userId },
+        select: { email: true, name: true },
+      });
+      const operator = await tx.operator.create({
+        data: {
+          name: userForOperator?.name ?? userForOperator?.email ?? "Operator",
+          email: userForOperator?.email ?? input.email,
+        },
+      });
+      operatorId = operator.id;
+      await tx.operatorUser.create({
+        data: {
+          operatorId: operator.id,
+          userId: input.userId,
+          role: "OWNER",
+        },
+      });
+      await tx.park.update({
+        where: { id: park.id },
+        data: { operatorId: operator.id },
+      });
+    }
+  }
+
+  // 3. Mark grant as applied.
+  await tx.userPreGrant.update({
+    where: { id: grant.id },
+    data: {
+      appliedAt: new Date(),
+      appliedToUserId: input.userId,
+    },
+  });
+
+  return {
+    status: "applied",
+    grantedRole: grant.grantRole,
+    operatorParkSlug: grant.operatorParkSlug,
+    operatorId,
+  };
+}
+
+/**
+ * Called from the NextAuth `events.createUser` hook. Swallows errors and
+ * logs them — pre-grant failure must never block sign-in. Worst case the
+ * SUPER_ADMIN retries the grant manually from the admin UI.
+ */
+export async function applyPreGrantForNewUser(
+  input: ApplyPreGrantInput,
+): Promise<void> {
+  try {
+    const result = await applyPreGrant(input);
+    if (result.status === "applied") {
+      console.log(
+        `[pre-grant] Applied to ${input.email}: role=${result.grantedRole}, ` +
+          `operator=${result.operatorParkSlug ?? "—"}`,
+      );
+    } else if (result.status !== "no-grant") {
+      console.warn(
+        `[pre-grant] Did not apply to ${input.email}:`,
+        result,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `[pre-grant] Unexpected error applying grant for ${input.email}:`,
+      err,
+    );
+  }
+}
+
+/**
+ * Re-export for type imports without leaking the Prisma namespace.
+ */
+export type UserPreGrantRow = Prisma.UserPreGrantGetPayload<Record<string, never>>;

--- a/test/app/api/admin/pre-grants/[id]/apply/route.test.ts
+++ b/test/app/api/admin/pre-grants/[id]/apply/route.test.ts
@@ -1,0 +1,102 @@
+import { POST } from "@/app/api/admin/pre-grants/[id]/apply/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { applyPreGrant } from "@/lib/pre-grant";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    userPreGrant: {
+      findUnique: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+vi.mock("@/lib/pre-grant", () => ({
+  applyPreGrant: vi.fn(),
+}));
+
+const superAdmin = { user: { id: "super-1", role: "SUPER_ADMIN" } };
+const regularAdmin = { user: { id: "admin-1", role: "ADMIN" } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/pre-grants/[id]/apply", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-super-admin", async () => {
+    vi.mocked(auth).mockResolvedValue(regularAdmin as any);
+    const res = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when grant is not found", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);
+    const res = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "missing" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when no user exists for the grant email yet", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue({
+      id: "pg-1",
+      email: "tester@example.com",
+    } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+
+    const res = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toContain("has not signed in yet");
+  });
+
+  it("invokes applyPreGrant when the user exists and returns the result", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue({
+      id: "pg-1",
+      email: "tester@example.com",
+    } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user-7",
+    } as any);
+    vi.mocked(applyPreGrant).mockResolvedValue({
+      status: "applied",
+      grantedRole: "ADMIN",
+      operatorParkSlug: null,
+      operatorId: null,
+    });
+
+    const res = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.result.status).toBe("applied");
+    expect(applyPreGrant).toHaveBeenCalledWith({
+      email: "tester@example.com",
+      userId: "user-7",
+    });
+  });
+});

--- a/test/app/api/admin/pre-grants/[id]/route.test.ts
+++ b/test/app/api/admin/pre-grants/[id]/route.test.ts
@@ -1,0 +1,68 @@
+import { DELETE } from "@/app/api/admin/pre-grants/[id]/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    userPreGrant: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+const superAdmin = { user: { id: "super-1", role: "SUPER_ADMIN" } };
+const regularAdmin = { user: { id: "admin-1", role: "ADMIN" } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/admin/pre-grants/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-super-admin", async () => {
+    vi.mocked(auth).mockResolvedValue(regularAdmin as any);
+    const res = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when grant doesn't exist", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "missing" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes a pre-grant for SUPER_ADMIN", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue({
+      id: "pg-1",
+    } as any);
+    vi.mocked(prisma.userPreGrant.delete).mockResolvedValue({} as any);
+
+    const res = await DELETE(new Request("http://localhost"), {
+      params: Promise.resolve({ id: "pg-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(prisma.userPreGrant.delete).toHaveBeenCalledWith({
+      where: { id: "pg-1" },
+    });
+  });
+});

--- a/test/app/api/admin/pre-grants/route.test.ts
+++ b/test/app/api/admin/pre-grants/route.test.ts
@@ -1,0 +1,189 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/pre-grants/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    userPreGrant: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+    },
+    park: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+const superAdmin = { user: { id: "super-1", role: "SUPER_ADMIN" } };
+const regularAdmin = { user: { id: "admin-1", role: "ADMIN" } };
+
+function jsonRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/pre-grants", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/admin/pre-grants", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when authenticated as plain ADMIN (not SUPER_ADMIN)", async () => {
+    vi.mocked(auth).mockResolvedValue(regularAdmin as any);
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the pre-grant list for SUPER_ADMIN", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findMany).mockResolvedValue([
+      {
+        id: "pg-1",
+        email: "x@y.com",
+        grantRole: "ADMIN",
+        operatorParkSlug: null,
+        appliedAt: null,
+        appliedToUserId: null,
+        notes: null,
+        createdAt: new Date(),
+        createdByUserId: null,
+      },
+    ] as any);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.grants).toHaveLength(1);
+    expect(data.grants[0].email).toBe("x@y.com");
+  });
+});
+
+describe("POST /api/admin/pre-grants", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await POST(jsonRequest({ email: "x@y.com", grantRole: "ADMIN" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-super-admin", async () => {
+    vi.mocked(auth).mockResolvedValue(regularAdmin as any);
+    const res = await POST(jsonRequest({ email: "x@y.com", grantRole: "ADMIN" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects invalid email", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    const res = await POST(jsonRequest({ email: "not-an-email", grantRole: "ADMIN" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid role", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    const res = await POST(
+      jsonRequest({ email: "x@y.com", grantRole: "NOT_A_ROLE" }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid role");
+  });
+
+  it("rejects when neither role nor operator is provided", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    const res = await POST(jsonRequest({ email: "x@y.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects when operatorParkSlug doesn't exist", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue(null);
+    const res = await POST(
+      jsonRequest({ email: "x@y.com", operatorParkSlug: "nope" }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects duplicate pre-grants", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue({
+      id: "pg-exists",
+    } as any);
+    const res = await POST(
+      jsonRequest({ email: "x@y.com", grantRole: "ADMIN" }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("creates a pre-grant with role only", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.userPreGrant.create).mockResolvedValue({
+      id: "pg-new",
+      email: "x@y.com",
+      grantRole: "ADMIN",
+      operatorParkSlug: null,
+    } as any);
+
+    const res = await POST(
+      jsonRequest({ email: "X@y.com", grantRole: "ADMIN" }),
+    );
+
+    expect(res.status).toBe(201);
+    // Email gets normalized to lowercase.
+    expect(prisma.userPreGrant.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        email: "x@y.com",
+        grantRole: "ADMIN",
+        operatorParkSlug: null,
+        createdByUserId: "super-1",
+      }),
+    });
+  });
+
+  it("creates a pre-grant with role + operator slug after validating the park", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+    } as any);
+    vi.mocked(prisma.userPreGrant.create).mockResolvedValue({
+      id: "pg-new",
+      email: "x@y.com",
+    } as any);
+
+    const res = await POST(
+      jsonRequest({
+        email: "x@y.com",
+        grantRole: "ADMIN",
+        operatorParkSlug: "test-park",
+        notes: "hi",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(prisma.userPreGrant.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        email: "x@y.com",
+        grantRole: "ADMIN",
+        operatorParkSlug: "test-park",
+        notes: "hi",
+      }),
+    });
+  });
+});

--- a/test/lib/pre-grant.test.ts
+++ b/test/lib/pre-grant.test.ts
@@ -1,0 +1,319 @@
+import { applyPreGrant, applyPreGrantForNewUser } from "@/lib/pre-grant";
+import { prisma } from "@/lib/prisma";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: vi.fn(),
+  },
+}));
+
+// Build a tx mock with the same shape used by applyPreGrantTx.
+function buildTx() {
+  return {
+    userPreGrant: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      update: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    park: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    operator: {
+      create: vi.fn(),
+    },
+    operatorUser: {
+      create: vi.fn(),
+      upsert: vi.fn(),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("applyPreGrant", () => {
+  it("returns no-grant when no UserPreGrant matches the email", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue(null);
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({
+      email: "nobody@example.com",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({ status: "no-grant" });
+    expect(tx.user.update).not.toHaveBeenCalled();
+  });
+
+  it("returns already-applied when appliedAt is set and does not double-apply", async () => {
+    const tx = buildTx();
+    const applied = new Date("2026-05-01T00:00:00Z");
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "x@y.com",
+      grantRole: "ADMIN",
+      operatorParkSlug: null,
+      appliedAt: applied,
+    });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({ email: "x@y.com", userId: "user-1" });
+
+    expect(result).toEqual({ status: "already-applied", appliedAt: applied });
+    expect(tx.user.update).not.toHaveBeenCalled();
+    expect(tx.userPreGrant.update).not.toHaveBeenCalled();
+  });
+
+  it("applies a role-only pre-grant (no operator wiring)", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "admin@example.com",
+      grantRole: "ADMIN",
+      operatorParkSlug: null,
+      appliedAt: null,
+    });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({
+      email: "admin@example.com",
+      userId: "user-1",
+    });
+
+    expect(result).toEqual({
+      status: "applied",
+      grantedRole: "ADMIN",
+      operatorParkSlug: null,
+      operatorId: null,
+    });
+    expect(tx.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: { role: "ADMIN" },
+    });
+    expect(tx.operator.create).not.toHaveBeenCalled();
+    expect(tx.userPreGrant.update).toHaveBeenCalledWith({
+      where: { id: "pg-1" },
+      data: expect.objectContaining({
+        appliedToUserId: "user-1",
+        appliedAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("creates Operator + OperatorUser and sets Park.operatorId when park has no operator", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "op@example.com",
+      grantRole: null,
+      operatorParkSlug: "test-park",
+      appliedAt: null,
+    });
+    tx.park.findUnique.mockResolvedValue({
+      id: "park-1",
+      slug: "test-park",
+      operatorId: null,
+      operator: null,
+    });
+    tx.user.findUnique.mockResolvedValue({
+      email: "op@example.com",
+      name: "Op Person",
+    });
+    tx.operator.create.mockResolvedValue({ id: "operator-1" });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({
+      email: "op@example.com",
+      userId: "user-2",
+    });
+
+    expect(result).toEqual({
+      status: "applied",
+      grantedRole: null,
+      operatorParkSlug: "test-park",
+      operatorId: "operator-1",
+    });
+    expect(tx.operator.create).toHaveBeenCalledWith({
+      data: { name: "Op Person", email: "op@example.com" },
+    });
+    expect(tx.operatorUser.create).toHaveBeenCalledWith({
+      data: { operatorId: "operator-1", userId: "user-2", role: "OWNER" },
+    });
+    expect(tx.park.update).toHaveBeenCalledWith({
+      where: { id: "park-1" },
+      data: { operatorId: "operator-1" },
+    });
+    expect(tx.user.update).not.toHaveBeenCalled(); // grantRole was null
+  });
+
+  it("upserts OperatorUser without overwriting existing operator on a claimed park", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "op@example.com",
+      grantRole: null,
+      operatorParkSlug: "claimed-park",
+      appliedAt: null,
+    });
+    tx.park.findUnique.mockResolvedValue({
+      id: "park-9",
+      slug: "claimed-park",
+      operatorId: "existing-operator-7",
+      operator: { id: "existing-operator-7" },
+    });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({
+      email: "op@example.com",
+      userId: "user-3",
+    });
+
+    expect(result.status).toBe("applied");
+    if (result.status !== "applied") throw new Error("type guard");
+    expect(result.operatorId).toBe("existing-operator-7");
+    expect(tx.operator.create).not.toHaveBeenCalled();
+    expect(tx.park.update).not.toHaveBeenCalled();
+    expect(tx.operatorUser.upsert).toHaveBeenCalledWith({
+      where: {
+        operatorId_userId: {
+          operatorId: "existing-operator-7",
+          userId: "user-3",
+        },
+      },
+      update: {},
+      create: {
+        operatorId: "existing-operator-7",
+        userId: "user-3",
+        role: "OWNER",
+      },
+    });
+  });
+
+  it("returns park-not-found when operatorParkSlug does not resolve", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "x@y.com",
+      grantRole: "ADMIN",
+      operatorParkSlug: "missing-park",
+      appliedAt: null,
+    });
+    tx.park.findUnique.mockResolvedValue(null);
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({ email: "x@y.com", userId: "user-1" });
+
+    expect(result).toEqual({
+      status: "park-not-found",
+      parkSlug: "missing-park",
+    });
+    // Role had been updated before we hit the park lookup; the wrapping
+    // transaction would roll that back in real use. The unit only asserts
+    // the return code.
+  });
+
+  it("applies both role and operator together when both fields are set", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "both@example.com",
+      grantRole: "ADMIN",
+      operatorParkSlug: "test-park",
+      appliedAt: null,
+    });
+    tx.park.findUnique.mockResolvedValue({
+      id: "park-1",
+      slug: "test-park",
+      operatorId: null,
+      operator: null,
+    });
+    tx.user.findUnique.mockResolvedValue({
+      email: "both@example.com",
+      name: null,
+    });
+    tx.operator.create.mockResolvedValue({ id: "operator-2" });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    const result = await applyPreGrant({
+      email: "both@example.com",
+      userId: "user-4",
+    });
+
+    expect(result.status).toBe("applied");
+    expect(tx.user.update).toHaveBeenCalledWith({
+      where: { id: "user-4" },
+      data: { role: "ADMIN" },
+    });
+    expect(tx.operator.create).toHaveBeenCalled();
+    expect(tx.operatorUser.create).toHaveBeenCalled();
+  });
+
+  it("operator name falls back to email when user has no name", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue({
+      id: "pg-1",
+      email: "noname@example.com",
+      grantRole: null,
+      operatorParkSlug: "test-park",
+      appliedAt: null,
+    });
+    tx.park.findUnique.mockResolvedValue({
+      id: "park-1",
+      slug: "test-park",
+      operatorId: null,
+      operator: null,
+    });
+    tx.user.findUnique.mockResolvedValue({
+      email: "noname@example.com",
+      name: null,
+    });
+    tx.operator.create.mockResolvedValue({ id: "operator-3" });
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await applyPreGrant({ email: "noname@example.com", userId: "user-5" });
+
+    expect(tx.operator.create).toHaveBeenCalledWith({
+      data: { name: "noname@example.com", email: "noname@example.com" },
+    });
+  });
+});
+
+describe("applyPreGrantForNewUser", () => {
+  it("swallows errors so sign-in is never blocked", async () => {
+    vi.mocked(prisma.$transaction).mockRejectedValue(new Error("db down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Should not throw.
+    await expect(
+      applyPreGrantForNewUser({ email: "x@y.com", userId: "user-1" }),
+    ).resolves.toBeUndefined();
+
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("returns silently on no-grant", async () => {
+    const tx = buildTx();
+    tx.userPreGrant.findUnique.mockResolvedValue(null);
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(tx));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await applyPreGrantForNewUser({
+      email: "nobody@example.com",
+      userId: "user-1",
+    });
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
SUPER_ADMIN can declare an email's intended role and/or operator-of-park membership in a new \`UserPreGrant\` table. The NextAuth \`events.createUser\` hook resolves the grant by email and applies it (role + operator wiring) inside a single transaction the first time that email signs in. Onboards beta testers and future paid operators without making them go through the claim flow.

**Seeded with the initial beta tester:** \`clemenlarryj@gmail.com\` → ADMIN + operator of \`gypsum-city-ohv-park-iowa\`. Migration is idempotent so re-deploys are safe.

## Surfaces

- **Schema** — new \`UserPreGrant\` model (unique email, optional grantRole, optional operatorParkSlug, audit fields). [migration.sql](prisma/migrations/20260514000000_user_pre_grant/migration.sql)
- **Lib** — [src/lib/pre-grant.ts](src/lib/pre-grant.ts) wraps the apply logic in a transaction. Mirrors the claim-approval route so operator wiring behaves identically. Errors during sign-in are swallowed so a pre-grant glitch never blocks login.
- **NextAuth hook** — [src/lib/auth.ts](src/lib/auth.ts) \`events.createUser\` fires the apply after PrismaAdapter inserts the User row.
- **Admin UI** — [/admin/pre-grants](src/app/admin/pre-grants/page.tsx) (SUPER_ADMIN only): table with status badges, add-grant form with park-slug validation + dedupe, per-row Delete and \"Apply now\" buttons. Nav link in the admin layout gated to SUPER_ADMIN.
- **API routes** — GET/POST list+create, DELETE, POST .../apply. All SUPER_ADMIN-gated.

## Behavior on claimed parks

If \`operatorParkSlug\` points at a park that already has an operator, we **don't** overwrite ownership — we upsert this user onto the existing operator as OWNER. That avoids a half-applied grant when a previous tester claimed the same park.

## Test plan
- [x] 31 new tests covering apply paths (no-grant, already-applied, role-only, operator-only, both, missing park, claimed-park upsert, name fallback, error-swallowing) and full CRUD + apply API auth/validation
- [x] Full suite: **2029 / 2029** pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Manual: deploy → confirm clemenlarryj@gmail.com row exists in \`UserPreGrant\` table
- [ ] Manual: have tester sign in → confirm User.role becomes ADMIN, Operator + OperatorUser rows created, Park.operatorId set on gypsum-city-ohv-park-iowa, UserPreGrant.appliedAt populated
- [ ] Manual: SUPER_ADMIN visits /admin/pre-grants — can list/create/delete and the form rejects bad emails / unknown park slugs / no-axis grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)