### PR TITLE
feat(admin): Park Operators tab — CRUD + member + park management

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import {
   Activity,
   BrainCircuit,
+  Building2,
   Camera,
   ClipboardCheck,
   ClipboardList,
@@ -142,6 +143,13 @@ export default async function AdminLayout({
             >
               <ClipboardList className="w-5 h-5" />
               <span className="font-medium">Park Claims</span>
+            </Link>
+            <Link
+              href="/admin/operators"
+              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
+            >
+              <Building2 className="w-5 h-5" />
+              <span className="font-medium">Park Operators</span>
             </Link>
             <Link
               href="/admin/map-heroes"

--- a/src/app/admin/operators/OperatorManagementClient.tsx
+++ b/src/app/admin/operators/OperatorManagementClient.tsx
@@ -1,0 +1,668 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Mail,
+  Phone,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+export interface AdminOperatorRow {
+  id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  website: string | null;
+  subscriptionStatus: string;
+  subscriptionTier: string;
+  createdAt: string;
+  parks: Array<{ id: string; slug: string; name: string }>;
+  users: Array<{
+    id: string;
+    role: string;
+    createdAt: string;
+    user: {
+      id: string;
+      email: string | null;
+      name: string | null;
+      image: string | null;
+    };
+  }>;
+}
+
+interface Props {
+  initialOperators: AdminOperatorRow[];
+}
+
+export function OperatorManagementClient({ initialOperators }: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggleExpanded(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function refresh() {
+    startTransition(() => router.refresh());
+  }
+
+  async function call(path: string, init: RequestInit): Promise<unknown> {
+    const res = await fetch(path, init);
+    const data = (await res.json().catch(() => null)) as
+      | { error?: string }
+      | null;
+    if (!res.ok) {
+      throw new Error(data?.error || `Request failed (${res.status})`);
+    }
+    return data;
+  }
+
+  // --- Create operator form state ---
+  const [newName, setNewName] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [newPhone, setNewPhone] = useState("");
+  const [newWebsite, setNewWebsite] = useState("");
+  const [newParkSlug, setNewParkSlug] = useState("");
+  const [newOwnerEmail, setNewOwnerEmail] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setInfo(null);
+    setCreating(true);
+    try {
+      const data = (await call("/api/admin/operators", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: newName.trim(),
+          email: newEmail.trim(),
+          phone: newPhone.trim() || null,
+          website: newWebsite.trim() || null,
+          initialParkSlug: newParkSlug.trim() || null,
+          initialOwnerEmail: newOwnerEmail.trim() || null,
+        }),
+      })) as { hints?: { ownerEmailSkipped?: string | null } } | null;
+      setNewName("");
+      setNewEmail("");
+      setNewPhone("");
+      setNewWebsite("");
+      setNewParkSlug("");
+      setNewOwnerEmail("");
+      setInfo(data?.hints?.ownerEmailSkipped || "Operator created.");
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDeleteOperator(op: AdminOperatorRow) {
+    const parkCount = op.parks.length;
+    const userCount = op.users.length;
+    const warning =
+      parkCount + userCount > 0
+        ? `Delete operator '${op.name}'? ${parkCount} park(s) will be detached and ${userCount} user membership(s) will be removed.`
+        : `Delete operator '${op.name}'?`;
+    if (!confirm(warning)) return;
+    setError(null);
+    setInfo(null);
+    setBusyId(op.id);
+    try {
+      await call(`/api/admin/operators/${op.id}`, { method: "DELETE" });
+      setInfo(`Operator '${op.name}' deleted.`);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleRemoveUser(opId: string, userId: string, label: string) {
+    if (!confirm(`Remove ${label} from this operator?`)) return;
+    setError(null);
+    setInfo(null);
+    setBusyId(opId);
+    try {
+      await call(`/api/admin/operators/${opId}/users/${userId}`, {
+        method: "DELETE",
+      });
+      setInfo(`${label} removed.`);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove user");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleAddUser(opId: string, email: string, role: string) {
+    setError(null);
+    setInfo(null);
+    setBusyId(opId);
+    try {
+      await call(`/api/admin/operators/${opId}/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, role }),
+      });
+      setInfo(`Added ${email} as ${role}.`);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add user");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleDetachPark(opId: string, parkId: string, label: string) {
+    if (!confirm(`Detach park '${label}' from this operator?`)) return;
+    setError(null);
+    setInfo(null);
+    setBusyId(opId);
+    try {
+      await call(`/api/admin/operators/${opId}/parks/${parkId}`, {
+        method: "DELETE",
+      });
+      setInfo(`Detached '${label}'.`);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to detach park");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleAttachPark(opId: string, slug: string) {
+    setError(null);
+    setInfo(null);
+    setBusyId(opId);
+    try {
+      await call(`/api/admin/operators/${opId}/parks`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ parkSlug: slug }),
+      });
+      setInfo(`Attached '${slug}'.`);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to attach park");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div
+          className="rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900 dark:bg-red-950/40 dark:border-red-900 dark:text-red-100"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+      {info && (
+        <div
+          className="rounded-md border border-green-300 bg-green-50 px-4 py-3 text-sm text-green-900 dark:bg-green-950/40 dark:border-green-900 dark:text-green-100"
+          role="status"
+        >
+          {info}
+        </div>
+      )}
+
+      {/* Create form */}
+      <section className="rounded-lg border border-border bg-card p-6">
+        <h2 className="text-base font-semibold mb-4">Create operator</h2>
+        <form onSubmit={handleCreate} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Input
+            id="op-name"
+            label="Org name"
+            required
+            value={newName}
+            onChange={setNewName}
+            placeholder="Acme Trails LLC"
+          />
+          <Input
+            id="op-email"
+            label="Contact email"
+            required
+            type="email"
+            value={newEmail}
+            onChange={setNewEmail}
+            placeholder="contact@acme.com"
+          />
+          <Input
+            id="op-phone"
+            label="Phone"
+            value={newPhone}
+            onChange={setNewPhone}
+            placeholder="+1 555-0123"
+          />
+          <Input
+            id="op-website"
+            label="Website"
+            value={newWebsite}
+            onChange={setNewWebsite}
+            placeholder="https://acme.com"
+          />
+          <Input
+            id="op-park"
+            label="Initial park slug (optional)"
+            value={newParkSlug}
+            onChange={setNewParkSlug}
+            placeholder="gypsum-city-ohv-park-iowa"
+            hint="Attach a park at creation time."
+          />
+          <Input
+            id="op-owner"
+            label="Initial owner email (optional)"
+            value={newOwnerEmail}
+            onChange={setNewOwnerEmail}
+            placeholder="owner@acme.com"
+            hint="User must already exist. If not, use Pre-grants."
+          />
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              disabled={creating || pending}
+              className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50 inline-flex items-center gap-1"
+            >
+              <Plus className="w-4 h-4" />
+              {creating ? "Creating…" : "Create operator"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      {/* Operator list */}
+      <section className="space-y-3">
+        <h2 className="text-base font-semibold">
+          All operators ({initialOperators.length})
+        </h2>
+        {initialOperators.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card px-6 py-8 text-sm text-muted-foreground text-center">
+            No operators yet.
+          </div>
+        ) : (
+          initialOperators.map((op) => (
+            <OperatorRow
+              key={op.id}
+              op={op}
+              expanded={expanded.has(op.id)}
+              onToggle={() => toggleExpanded(op.id)}
+              busy={busyId === op.id || pending}
+              onDeleteOperator={() => handleDeleteOperator(op)}
+              onRemoveUser={(uid, label) => handleRemoveUser(op.id, uid, label)}
+              onAddUser={(email, role) => handleAddUser(op.id, email, role)}
+              onDetachPark={(pid, label) => handleDetachPark(op.id, pid, label)}
+              onAttachPark={(slug) => handleAttachPark(op.id, slug)}
+              onSavedEdit={refresh}
+              onError={(msg) => setError(msg)}
+            />
+          ))
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Input({
+  id,
+  label,
+  required,
+  type,
+  value,
+  onChange,
+  placeholder,
+  hint,
+}: {
+  id: string;
+  label: string;
+  required?: boolean;
+  type?: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  hint?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      <label htmlFor={id} className="text-sm font-medium">
+        {label}
+        {required && <span className="text-red-600"> *</span>}
+      </label>
+      <input
+        id={id}
+        type={type ?? "text"}
+        required={required}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+      />
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+function OperatorRow({
+  op,
+  expanded,
+  onToggle,
+  busy,
+  onDeleteOperator,
+  onRemoveUser,
+  onAddUser,
+  onDetachPark,
+  onAttachPark,
+  onSavedEdit,
+  onError,
+}: {
+  op: AdminOperatorRow;
+  expanded: boolean;
+  onToggle: () => void;
+  busy: boolean;
+  onDeleteOperator: () => void;
+  onRemoveUser: (userId: string, label: string) => void;
+  onAddUser: (email: string, role: string) => void;
+  onDetachPark: (parkId: string, label: string) => void;
+  onAttachPark: (slug: string) => void;
+  onSavedEdit: () => void;
+  onError: (msg: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(op.name);
+  const [email, setEmail] = useState(op.email);
+  const [phone, setPhone] = useState(op.phone ?? "");
+  const [website, setWebsite] = useState(op.website ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const [addUserEmail, setAddUserEmail] = useState("");
+  const [addUserRole, setAddUserRole] = useState("OWNER");
+  const [attachSlug, setAttachSlug] = useState("");
+
+  async function saveEdit() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/operators/${op.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          email: email.trim(),
+          phone: phone.trim() || null,
+          website: website.trim() || null,
+        }),
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (!res.ok) throw new Error(data?.error || `Failed (${res.status})`);
+      setEditing(false);
+      onSavedEdit();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-start gap-3 px-6 py-4">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="mt-1 text-muted-foreground hover:text-foreground"
+          aria-label={expanded ? "Collapse" : "Expand"}
+        >
+          {expanded ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
+        </button>
+        <div className="flex-1 min-w-0">
+          {editing ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <Input id={`edit-name-${op.id}`} label="Org name" required value={name} onChange={setName} />
+              <Input id={`edit-email-${op.id}`} label="Email" required type="email" value={email} onChange={setEmail} />
+              <Input id={`edit-phone-${op.id}`} label="Phone" value={phone} onChange={setPhone} />
+              <Input id={`edit-website-${op.id}`} label="Website" value={website} onChange={setWebsite} />
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center flex-wrap gap-2">
+                <h3 className="font-semibold">{op.name}</h3>
+                <span className="text-xs text-muted-foreground">
+                  {op.subscriptionStatus} · {op.subscriptionTier}
+                </span>
+              </div>
+              <div className="text-xs text-muted-foreground mt-1 flex flex-wrap items-center gap-3">
+                <span className="inline-flex items-center gap-1">
+                  <Mail className="w-3 h-3" />
+                  {op.email}
+                </span>
+                {op.phone && (
+                  <span className="inline-flex items-center gap-1">
+                    <Phone className="w-3 h-3" />
+                    {op.phone}
+                  </span>
+                )}
+                {op.website && (
+                  <a
+                    href={op.website}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 hover:underline"
+                  >
+                    <ExternalLink className="w-3 h-3" />
+                    {op.website}
+                  </a>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {op.parks.length} park{op.parks.length === 1 ? "" : "s"} ·{" "}
+                {op.users.length} user{op.users.length === 1 ? "" : "s"}
+              </div>
+            </>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {editing ? (
+            <>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={saveEdit}
+                className="text-xs rounded-md bg-primary text-primary-foreground px-3 py-1 hover:bg-primary/90 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setEditing(false);
+                  setName(op.name);
+                  setEmail(op.email);
+                  setPhone(op.phone ?? "");
+                  setWebsite(op.website ?? "");
+                }}
+                className="text-xs rounded-md border border-border px-3 py-1 hover:bg-accent"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => setEditing(true)}
+                className="text-xs rounded-md border border-border px-3 py-1 hover:bg-accent disabled:opacity-50"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onDeleteOperator}
+                className="text-xs rounded-md border border-red-300 text-red-700 px-2 py-1 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40 inline-flex items-center gap-1"
+              >
+                <Trash2 className="w-3 h-3" />
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-border px-6 py-4 grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Parks panel */}
+          <div>
+            <h4 className="text-sm font-semibold mb-2">Parks</h4>
+            {op.parks.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No parks attached.</p>
+            ) : (
+              <ul className="space-y-1">
+                {op.parks.map((p) => (
+                  <li
+                    key={p.id}
+                    className="flex items-center justify-between gap-2 rounded border border-border px-3 py-1.5"
+                  >
+                    <Link href={`/parks/${p.slug}`} className="text-sm hover:underline">
+                      {p.name}
+                    </Link>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => onDetachPark(p.id, p.name)}
+                      className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
+                      title="Detach park"
+                    >
+                      <X className="w-3 h-3" />
+                      Detach
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (attachSlug.trim()) {
+                  onAttachPark(attachSlug.trim());
+                  setAttachSlug("");
+                }
+              }}
+              className="mt-3 flex gap-2"
+            >
+              <input
+                value={attachSlug}
+                onChange={(e) => setAttachSlug(e.target.value)}
+                placeholder="park-slug-to-attach"
+                className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+              />
+              <button
+                type="submit"
+                disabled={busy || !attachSlug.trim()}
+                className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
+              >
+                Attach
+              </button>
+            </form>
+          </div>
+
+          {/* Users panel */}
+          <div>
+            <h4 className="text-sm font-semibold mb-2">Users</h4>
+            {op.users.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No users on this operator.</p>
+            ) : (
+              <ul className="space-y-1">
+                {op.users.map((m) => {
+                  const label = m.user.email || m.user.name || m.user.id;
+                  return (
+                    <li
+                      key={m.id}
+                      className="flex items-center justify-between gap-2 rounded border border-border px-3 py-1.5"
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-sm truncate">{label}</span>
+                        <span className="text-[10px] uppercase tracking-wide rounded bg-muted px-1.5 py-0.5">
+                          {m.role}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => onRemoveUser(m.user.id, label)}
+                        className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
+                        title="Remove user"
+                      >
+                        <X className="w-3 h-3" />
+                        Remove
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (addUserEmail.trim()) {
+                  onAddUser(addUserEmail.trim(), addUserRole);
+                  setAddUserEmail("");
+                }
+              }}
+              className="mt-3 flex gap-2"
+            >
+              <input
+                type="email"
+                value={addUserEmail}
+                onChange={(e) => setAddUserEmail(e.target.value)}
+                placeholder="user@example.com"
+                className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
+              />
+              <select
+                value={addUserRole}
+                onChange={(e) => setAddUserRole(e.target.value)}
+                className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+              >
+                <option value="OWNER">OWNER</option>
+                <option value="MEMBER">MEMBER</option>
+              </select>
+              <button
+                type="submit"
+                disabled={busy || !addUserEmail.trim()}
+                className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
+              >
+                Add
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/operators/page.tsx
+++ b/src/app/admin/operators/page.tsx
@@ -1,0 +1,72 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { redirect } from "next/navigation";
+import {
+  OperatorManagementClient,
+  type AdminOperatorRow,
+} from "./OperatorManagementClient";
+
+export default async function AdminOperatorsPage() {
+  const session = await auth();
+  const role = (session?.user as { role?: string })?.role;
+  if (role !== "ADMIN" && role !== "SUPER_ADMIN") {
+    redirect("/");
+  }
+
+  const operators = await prisma.operator.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      parks: {
+        select: { id: true, slug: true, name: true },
+        orderBy: { name: "asc" },
+      },
+      users: {
+        select: {
+          id: true,
+          role: true,
+          createdAt: true,
+          user: {
+            select: { id: true, email: true, name: true, image: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  const rows: AdminOperatorRow[] = operators.map((o) => ({
+    id: o.id,
+    name: o.name,
+    email: o.email,
+    phone: o.phone,
+    website: o.website,
+    subscriptionStatus: o.subscriptionStatus,
+    subscriptionTier: o.subscriptionTier,
+    createdAt: o.createdAt.toISOString(),
+    parks: o.parks.map((p) => ({ id: p.id, slug: p.slug, name: p.name })),
+    users: o.users.map((u) => ({
+      id: u.id,
+      role: u.role,
+      createdAt: u.createdAt.toISOString(),
+      user: {
+        id: u.user.id,
+        email: u.user.email,
+        name: u.user.name,
+        image: u.user.image,
+      },
+    })),
+  }));
+
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-foreground mb-2">Park Operators</h1>
+      <p className="text-sm text-muted-foreground mb-8">
+        Manage operator accounts: create operators, attach/detach parks, and
+        add or remove users. Normally operators are created through the
+        Park Claims flow — this surface is for direct maintenance.
+      </p>
+
+      <OperatorManagementClient initialOperators={rows} />
+    </div>
+  );
+}

--- a/src/app/api/admin/operators/[id]/parks/[parkId]/route.ts
+++ b/src/app/api/admin/operators/[id]/parks/[parkId]/route.ts
@@ -1,0 +1,44 @@
+/**
+ * DELETE — detach a park from an operator. Sets Park.operatorId to null;
+ * the park is preserved.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+import { revalidatePath } from "next/cache";
+
+export const runtime = "nodejs";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; parkId: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id: operatorId, parkId } = await params;
+
+  const park = await prisma.park.findUnique({
+    where: { id: parkId },
+    select: { id: true, slug: true, operatorId: true },
+  });
+  if (!park) {
+    return NextResponse.json({ error: "Park not found" }, { status: 404 });
+  }
+  if (park.operatorId !== operatorId) {
+    return NextResponse.json(
+      { error: "Park is not attached to this operator" },
+      { status: 409 },
+    );
+  }
+
+  await prisma.park.update({
+    where: { id: parkId },
+    data: { operatorId: null },
+  });
+
+  revalidatePath("/");
+  revalidatePath(`/parks/${park.slug}`);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/operators/[id]/parks/route.ts
+++ b/src/app/api/admin/operators/[id]/parks/route.ts
@@ -1,0 +1,84 @@
+/**
+ * POST — attach a park (by slug) to an operator account. Fails if the
+ * park already has a different operator.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+import { revalidatePath } from "next/cache";
+
+export const runtime = "nodejs";
+
+interface AttachParkBody {
+  parkSlug?: string;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id: operatorId } = await params;
+
+  let body: AttachParkBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const slug = body.parkSlug?.trim();
+  if (!slug) {
+    return NextResponse.json(
+      { error: "parkSlug is required" },
+      { status: 400 },
+    );
+  }
+
+  const operator = await prisma.operator.findUnique({
+    where: { id: operatorId },
+    select: { id: true },
+  });
+  if (!operator) {
+    return NextResponse.json({ error: "Operator not found" }, { status: 404 });
+  }
+
+  const park = await prisma.park.findUnique({
+    where: { slug },
+    select: { id: true, slug: true, name: true, operatorId: true },
+  });
+  if (!park) {
+    return NextResponse.json(
+      { error: `Park '${slug}' not found` },
+      { status: 404 },
+    );
+  }
+
+  if (park.operatorId === operatorId) {
+    // Already attached — idempotent.
+    return NextResponse.json({ park });
+  }
+
+  if (park.operatorId) {
+    return NextResponse.json(
+      {
+        error: `Park '${slug}' is already owned by another operator. Detach it from that operator first.`,
+      },
+      { status: 409 },
+    );
+  }
+
+  const updated = await prisma.park.update({
+    where: { id: park.id },
+    data: { operatorId },
+    select: { id: true, slug: true, name: true, operatorId: true },
+  });
+
+  // ISR bust — park detail header rendering reads operator.
+  revalidatePath("/");
+  revalidatePath(`/parks/${slug}`);
+
+  return NextResponse.json({ park: updated }, { status: 201 });
+}

--- a/src/app/api/admin/operators/[id]/route.ts
+++ b/src/app/api/admin/operators/[id]/route.ts
@@ -1,0 +1,117 @@
+/**
+ * PATCH / DELETE for a single operator.
+ *
+ * DELETE behavior:
+ *   - OperatorUser rows cascade (FK ON DELETE CASCADE).
+ *   - Park.operatorId nulls (FK ON DELETE SET NULL) — parks survive,
+ *     they just become unowned.
+ */
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+
+export const runtime = "nodejs";
+
+const EDITABLE_FIELDS = ["name", "email", "phone", "website"] as const;
+type EditableField = (typeof EDITABLE_FIELDS)[number];
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id } = await params;
+
+  let body: Partial<Record<EditableField, string | null>>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const existing = await prisma.operator.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Operator not found" }, { status: 404 });
+  }
+
+  const data: Record<string, string | null> = {};
+  for (const field of EDITABLE_FIELDS) {
+    if (field in body) {
+      const value = body[field];
+      if (field === "name") {
+        const trimmed = typeof value === "string" ? value.trim() : "";
+        if (!trimmed) {
+          return NextResponse.json(
+            { error: "Name cannot be empty" },
+            { status: 400 },
+          );
+        }
+        data.name = trimmed;
+      } else if (field === "email") {
+        const trimmed =
+          typeof value === "string" ? value.trim().toLowerCase() : "";
+        if (!trimmed || !trimmed.includes("@")) {
+          return NextResponse.json(
+            { error: "Valid email is required" },
+            { status: 400 },
+          );
+        }
+        data.email = trimmed;
+      } else {
+        data[field] =
+          typeof value === "string" ? value.trim() || null : null;
+      }
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json(
+      { error: "No editable fields provided" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const operator = await prisma.operator.update({
+      where: { id },
+      data,
+    });
+    return NextResponse.json({ operator });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      return NextResponse.json(
+        { error: "Email is already used by another operator" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id } = await params;
+
+  const existing = await prisma.operator.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Operator not found" }, { status: 404 });
+  }
+
+  await prisma.operator.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/operators/[id]/users/[userId]/route.ts
+++ b/src/app/api/admin/operators/[id]/users/[userId]/route.ts
@@ -1,0 +1,39 @@
+/**
+ * DELETE — remove a user (by userId) from an operator account.
+ *
+ * Note: this only severs the OperatorUser link. The User's USER/role
+ * field is untouched. Use /admin/users to demote the user from OPERATOR
+ * back to USER if appropriate.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+
+export const runtime = "nodejs";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; userId: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id: operatorId, userId } = await params;
+
+  const membership = await prisma.operatorUser.findUnique({
+    where: { operatorId_userId: { operatorId, userId } },
+    select: { id: true },
+  });
+  if (!membership) {
+    return NextResponse.json(
+      { error: "Membership not found" },
+      { status: 404 },
+    );
+  }
+
+  await prisma.operatorUser.delete({
+    where: { operatorId_userId: { operatorId, userId } },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/operators/[id]/users/route.ts
+++ b/src/app/api/admin/operators/[id]/users/route.ts
@@ -1,0 +1,97 @@
+/**
+ * POST — add a user (by email) to an operator account.
+ *
+ * The user must already exist in `User`. If they haven't signed in yet,
+ * use the Pre-grant flow (/admin/pre-grants) so they get auto-wired on
+ * their first sign-in.
+ */
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+
+export const runtime = "nodejs";
+
+const OPERATOR_USER_ROLES = ["OWNER", "MEMBER"] as const;
+type OperatorUserRole = (typeof OPERATOR_USER_ROLES)[number];
+
+interface AddOperatorUserBody {
+  email?: string;
+  role?: string;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { id: operatorId } = await params;
+
+  let body: AddOperatorUserBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = body.email?.trim().toLowerCase();
+  if (!email || !email.includes("@")) {
+    return NextResponse.json(
+      { error: "Valid email is required" },
+      { status: 400 },
+    );
+  }
+
+  const role = (body.role ?? "OWNER") as OperatorUserRole;
+  if (!OPERATOR_USER_ROLES.includes(role)) {
+    return NextResponse.json(
+      { error: `Role must be one of: ${OPERATOR_USER_ROLES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  const operator = await prisma.operator.findUnique({
+    where: { id: operatorId },
+    select: { id: true },
+  });
+  if (!operator) {
+    return NextResponse.json({ error: "Operator not found" }, { status: 404 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+  if (!user) {
+    return NextResponse.json(
+      {
+        error: `No user with email '${email}' has signed in yet. Use Pre-grants to wire them up at first sign-in.`,
+      },
+      { status: 404 },
+    );
+  }
+
+  try {
+    const operatorUser = await prisma.operatorUser.create({
+      data: {
+        operatorId,
+        userId: user.id,
+        role,
+      },
+      include: {
+        user: { select: { id: true, email: true, name: true, image: true } },
+      },
+    });
+    return NextResponse.json({ operatorUser }, { status: 201 });
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      return NextResponse.json(
+        { error: "User is already a member of this operator" },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}

--- a/src/app/api/admin/operators/route.ts
+++ b/src/app/api/admin/operators/route.ts
@@ -1,0 +1,201 @@
+/**
+ * Admin endpoints for park-operator management (ADMIN + SUPER_ADMIN).
+ *
+ * Operators are normally created via the ParkClaim approval flow. This
+ * surface is for direct admin maintenance — onboarding a paid operator
+ * without a claim, fixing data, transferring parks, etc.
+ */
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAdmin } from "@/lib/api-helpers";
+
+export const runtime = "nodejs";
+
+// GET /api/admin/operators — list all operators with their parks + users.
+export async function GET(): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const operators = await prisma.operator.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      parks: {
+        select: { id: true, slug: true, name: true },
+        orderBy: { name: "asc" },
+      },
+      users: {
+        select: {
+          id: true,
+          role: true,
+          createdAt: true,
+          user: {
+            select: { id: true, email: true, name: true, image: true },
+          },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  return NextResponse.json({ operators });
+}
+
+interface CreateOperatorBody {
+  name?: string;
+  email?: string;
+  phone?: string | null;
+  website?: string | null;
+  // Optional convenience: attach an initial park + initial OWNER in the
+  // same call so the admin doesn't have to fire 3 requests in a row.
+  initialParkSlug?: string | null;
+  initialOwnerEmail?: string | null;
+}
+
+// POST /api/admin/operators — create a new operator.
+//
+// Body: { name, email, phone?, website?, initialParkSlug?, initialOwnerEmail? }
+//   - initialParkSlug, when set, attaches the park to the new operator
+//     (only valid if the park has no operator yet; 409 otherwise).
+//   - initialOwnerEmail, when set, creates an OperatorUser as OWNER for
+//     the existing User with that email. If no User exists yet, the call
+//     succeeds but skips the user grant (a pre-grant is the better
+//     mechanism for that case — see /admin/pre-grants).
+export async function POST(request: Request): Promise<NextResponse> {
+  const authResult = await requireAdmin();
+  if (authResult instanceof NextResponse) return authResult;
+
+  let body: CreateOperatorBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const name = body.name?.trim();
+  const email = body.email?.trim().toLowerCase();
+  if (!name) {
+    return NextResponse.json({ error: "Name is required" }, { status: 400 });
+  }
+  if (!email || !email.includes("@")) {
+    return NextResponse.json(
+      { error: "Valid email is required" },
+      { status: 400 },
+    );
+  }
+
+  // Validate park if provided.
+  let parkId: string | null = null;
+  if (body.initialParkSlug) {
+    const park = await prisma.park.findUnique({
+      where: { slug: body.initialParkSlug },
+      select: { id: true, operatorId: true },
+    });
+    if (!park) {
+      return NextResponse.json(
+        { error: `Park '${body.initialParkSlug}' not found` },
+        { status: 400 },
+      );
+    }
+    if (park.operatorId) {
+      return NextResponse.json(
+        {
+          error: `Park '${body.initialParkSlug}' already has an operator. Detach it first or pick a different park.`,
+        },
+        { status: 409 },
+      );
+    }
+    parkId = park.id;
+  }
+
+  // Resolve initial owner user if provided.
+  let ownerUserId: string | null = null;
+  if (body.initialOwnerEmail) {
+    const user = await prisma.user.findUnique({
+      where: { email: body.initialOwnerEmail.trim().toLowerCase() },
+      select: { id: true },
+    });
+    if (user) {
+      ownerUserId = user.id;
+    }
+    // If user doesn't exist, we silently skip — admin can use Pre-grants
+    // to wire them up at first sign-in. We return a hint in the response
+    // so the UI can surface this.
+  }
+
+  let operatorId: string;
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const operator = await tx.operator.create({
+        data: {
+          name,
+          email,
+          phone: body.phone?.trim() || null,
+          website: body.website?.trim() || null,
+        },
+      });
+
+      if (ownerUserId) {
+        await tx.operatorUser.create({
+          data: {
+            operatorId: operator.id,
+            userId: ownerUserId,
+            role: "OWNER",
+          },
+        });
+      }
+
+      if (parkId) {
+        await tx.park.update({
+          where: { id: parkId },
+          data: { operatorId: operator.id },
+        });
+      }
+
+      return operator;
+    });
+    operatorId = result.id;
+  } catch (err) {
+    // Unique constraint on Operator.email.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      return NextResponse.json(
+        { error: `An operator with email '${email}' already exists.` },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+
+  const operator = await prisma.operator.findUnique({
+    where: { id: operatorId },
+    include: {
+      parks: {
+        select: { id: true, slug: true, name: true },
+        orderBy: { name: "asc" },
+      },
+      users: {
+        select: {
+          id: true,
+          role: true,
+          createdAt: true,
+          user: {
+            select: { id: true, email: true, name: true, image: true },
+          },
+        },
+      },
+    },
+  });
+
+  return NextResponse.json(
+    {
+      operator,
+      hints: {
+        ownerEmailSkipped:
+          !!body.initialOwnerEmail && !ownerUserId
+            ? `User with email '${body.initialOwnerEmail}' does not exist yet. Create a Pre-grant if you want operator access wired automatically on their first sign-in.`
+            : null,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/test/app/api/admin/operators/[id]/parks/[parkId]/route.test.ts
+++ b/test/app/api/admin/operators/[id]/parks/[parkId]/route.test.ts
@@ -1,0 +1,68 @@
+import { DELETE } from "@/app/api/admin/operators/[id]/parks/[parkId]/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    park: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+const params = {
+  params: Promise.resolve({ id: "op-1", parkId: "park-1" }),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/admin/operators/[id]/parks/[parkId]", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when park not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when park is owned by a different operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      operatorId: "other-op",
+    } as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(409);
+  });
+
+  it("detaches the park when it belongs to this operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      operatorId: "op-1",
+    } as any);
+    vi.mocked(prisma.park.update).mockResolvedValue({} as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(200);
+    expect(prisma.park.update).toHaveBeenCalledWith({
+      where: { id: "park-1" },
+      data: { operatorId: null },
+    });
+  });
+});

--- a/test/app/api/admin/operators/[id]/parks/route.test.ts
+++ b/test/app/api/admin/operators/[id]/parks/route.test.ts
@@ -1,0 +1,117 @@
+import { POST } from "@/app/api/admin/operators/[id]/parks/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    operator: { findUnique: vi.fn() },
+    park: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/admin/operators/op-1/parks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = { params: Promise.resolve({ id: "op-1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/operators/[id]/parks", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await POST(makeRequest({ parkSlug: "p" }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when parkSlug is missing", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const res = await POST(makeRequest({}), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when operator not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue(null);
+    const res = await POST(makeRequest({ parkSlug: "p" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when park not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue(null);
+    const res = await POST(makeRequest({ parkSlug: "missing" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 idempotently when park is already attached to this operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      name: "P",
+      operatorId: "op-1",
+    } as any);
+    const res = await POST(makeRequest({ parkSlug: "p" }), params);
+    expect(res.status).toBe(200);
+    expect(prisma.park.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when park is owned by a different operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      name: "P",
+      operatorId: "other-op",
+    } as any);
+    const res = await POST(makeRequest({ parkSlug: "p" }), params);
+    expect(res.status).toBe(409);
+  });
+
+  it("attaches the park when it has no operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      name: "P",
+      operatorId: null,
+    } as any);
+    vi.mocked(prisma.park.update).mockResolvedValue({
+      id: "park-1",
+      slug: "p",
+      name: "P",
+      operatorId: "op-1",
+    } as any);
+
+    const res = await POST(makeRequest({ parkSlug: "p" }), params);
+    expect(res.status).toBe(201);
+    expect(prisma.park.update).toHaveBeenCalledWith({
+      where: { id: "park-1" },
+      data: { operatorId: "op-1" },
+      select: expect.any(Object),
+    });
+  });
+});

--- a/test/app/api/admin/operators/[id]/route.test.ts
+++ b/test/app/api/admin/operators/[id]/route.test.ts
@@ -1,0 +1,141 @@
+import { PATCH, DELETE } from "@/app/api/admin/operators/[id]/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    operator: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+
+function patchReq(body: unknown) {
+  return new Request("http://localhost/api/admin/operators/op-1", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = { params: Promise.resolve({ id: "op-1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PATCH /api/admin/operators/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await PATCH(patchReq({ name: "X" }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin", async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: "u", role: "USER" } } as any);
+    const res = await PATCH(patchReq({ name: "X" }), params);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when operator not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue(null);
+    const res = await PATCH(patchReq({ name: "X" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when no editable fields are present", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    const res = await PATCH(patchReq({ unrelated: "x" }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty name", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    const res = await PATCH(patchReq({ name: "   " }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid email", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    const res = await PATCH(patchReq({ email: "not-email" }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 on email uniqueness conflict (P2002)", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.operator.update).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("dup", {
+        code: "P2002",
+        clientVersion: "x",
+      }),
+    );
+    const res = await PATCH(patchReq({ email: "taken@example.com" }), params);
+    expect(res.status).toBe(409);
+  });
+
+  it("updates valid fields", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.operator.update).mockResolvedValue({
+      id: "op-1",
+      name: "New Name",
+      email: "new@e.com",
+    } as any);
+    const res = await PATCH(
+      patchReq({
+        name: "New Name",
+        email: "NEW@e.com",
+        phone: "555",
+        website: "",
+      }),
+      params,
+    );
+    expect(res.status).toBe(200);
+    expect(prisma.operator.update).toHaveBeenCalledWith({
+      where: { id: "op-1" },
+      data: {
+        name: "New Name",
+        email: "new@e.com",
+        phone: "555",
+        website: null,
+      },
+    });
+  });
+});
+
+describe("DELETE /api/admin/operators/[id]", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when operator not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes the operator for ADMIN", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.operator.delete).mockResolvedValue({} as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(200);
+    expect(prisma.operator.delete).toHaveBeenCalledWith({ where: { id: "op-1" } });
+  });
+});

--- a/test/app/api/admin/operators/[id]/users/[userId]/route.test.ts
+++ b/test/app/api/admin/operators/[id]/users/[userId]/route.test.ts
@@ -1,0 +1,50 @@
+import { DELETE } from "@/app/api/admin/operators/[id]/users/[userId]/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    operatorUser: {
+      findUnique: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+const params = {
+  params: Promise.resolve({ id: "op-1", userId: "u-1" }),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/admin/operators/[id]/users/[userId]", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when membership not found", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operatorUser.findUnique).mockResolvedValue(null);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes the membership for ADMIN", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operatorUser.findUnique).mockResolvedValue({ id: "ou-1" } as any);
+    vi.mocked(prisma.operatorUser.delete).mockResolvedValue({} as any);
+    const res = await DELETE(new Request("http://localhost"), params);
+    expect(res.status).toBe(200);
+    expect(prisma.operatorUser.delete).toHaveBeenCalledWith({
+      where: { operatorId_userId: { operatorId: "op-1", userId: "u-1" } },
+    });
+  });
+});

--- a/test/app/api/admin/operators/[id]/users/route.test.ts
+++ b/test/app/api/admin/operators/[id]/users/route.test.ts
@@ -1,0 +1,124 @@
+import { POST } from "@/app/api/admin/operators/[id]/users/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    operator: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn() },
+    operatorUser: { create: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/admin/operators/op-1/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const params = { params: Promise.resolve({ id: "op-1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/operators/[id]/users", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await POST(makeRequest({ email: "x@y.com" }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const res = await POST(makeRequest({ email: "nope" }), params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when role is not OWNER/MEMBER", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const res = await POST(
+      makeRequest({ email: "x@y.com", role: "ADMIN" }),
+      params,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when operator does not exist", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "x@y.com" }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 with helpful message when user hasn't signed in yet", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "new@user.com" }), params);
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toMatch(/pre-grant/i);
+  });
+
+  it("returns 409 when user is already a member (P2002)", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "u-1" } as any);
+    vi.mocked(prisma.operatorUser.create).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("dup", {
+        code: "P2002",
+        clientVersion: "x",
+      }),
+    );
+    const res = await POST(makeRequest({ email: "x@y.com" }), params);
+    expect(res.status).toBe(409);
+  });
+
+  it("creates OperatorUser with role OWNER by default", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "u-1" } as any);
+    vi.mocked(prisma.operatorUser.create).mockResolvedValue({
+      id: "ou-1",
+      role: "OWNER",
+      user: { id: "u-1", email: "x@y.com", name: null, image: null },
+    } as any);
+    const res = await POST(makeRequest({ email: "x@y.com" }), params);
+    expect(res.status).toBe(201);
+    expect(prisma.operatorUser.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { operatorId: "op-1", userId: "u-1", role: "OWNER" },
+      }),
+    );
+  });
+
+  it("creates OperatorUser with explicit MEMBER role when provided", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-1" } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "u-1" } as any);
+    vi.mocked(prisma.operatorUser.create).mockResolvedValue({
+      id: "ou-2",
+      role: "MEMBER",
+      user: { id: "u-1", email: "x@y.com", name: null, image: null },
+    } as any);
+    const res = await POST(
+      makeRequest({ email: "x@y.com", role: "MEMBER" }),
+      params,
+    );
+    expect(res.status).toBe(201);
+    expect(prisma.operatorUser.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { operatorId: "op-1", userId: "u-1", role: "MEMBER" },
+      }),
+    );
+  });
+});

--- a/test/app/api/admin/operators/route.test.ts
+++ b/test/app/api/admin/operators/route.test.ts
@@ -1,0 +1,218 @@
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/admin/operators/route";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    operator: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    park: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+    operatorUser: {
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+
+const admin = { user: { id: "admin-1", role: "ADMIN" } };
+
+function jsonRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/admin/operators", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/admin/operators", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin", async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: "u1", role: "USER" } } as any);
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns operator list for ADMIN", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.operator.findMany).mockResolvedValue([
+      { id: "op-1", name: "Acme", email: "a@b.com" } as any,
+    ]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.operators).toHaveLength(1);
+  });
+});
+
+describe("POST /api/admin/operators", () => {
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null as any);
+    const res = await POST(jsonRequest({ name: "A", email: "a@b.com" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const res = await POST(jsonRequest({ email: "a@b.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const res = await POST(jsonRequest({ name: "A", email: "not-email" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when initialParkSlug doesn't exist", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue(null);
+    const res = await POST(
+      jsonRequest({
+        name: "A",
+        email: "a@b.com",
+        initialParkSlug: "missing",
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when initialParkSlug already has an operator", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      operatorId: "existing-op",
+    } as any);
+    const res = await POST(
+      jsonRequest({
+        name: "A",
+        email: "a@b.com",
+        initialParkSlug: "claimed",
+      }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 409 when email is already used by another operator (P2002)", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.$transaction).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("duplicate", {
+        code: "P2002",
+        clientVersion: "x",
+      }),
+    );
+    const res = await POST(
+      jsonRequest({ name: "A", email: "dupe@b.com" }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it("creates operator + attaches park + creates OperatorUser when all provided", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.park.findUnique).mockResolvedValue({
+      id: "park-1",
+      operatorId: null,
+    } as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ id: "user-7" } as any);
+
+    const txMocks = {
+      operator: { create: vi.fn().mockResolvedValue({ id: "op-new" }) },
+      operatorUser: { create: vi.fn() },
+      park: { update: vi.fn() },
+    };
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(txMocks));
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({
+      id: "op-new",
+      parks: [],
+      users: [],
+    } as any);
+
+    const res = await POST(
+      jsonRequest({
+        name: "Acme",
+        email: "owner@acme.com",
+        initialParkSlug: "test-park",
+        initialOwnerEmail: "owner@acme.com",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(txMocks.operator.create).toHaveBeenCalledWith({
+      data: { name: "Acme", email: "owner@acme.com", phone: null, website: null },
+    });
+    expect(txMocks.operatorUser.create).toHaveBeenCalledWith({
+      data: { operatorId: "op-new", userId: "user-7", role: "OWNER" },
+    });
+    expect(txMocks.park.update).toHaveBeenCalledWith({
+      where: { id: "park-1" },
+      data: { operatorId: "op-new" },
+    });
+  });
+
+  it("creates operator with no park/user when neither is provided", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    const txMocks = {
+      operator: { create: vi.fn().mockResolvedValue({ id: "op-new" }) },
+      operatorUser: { create: vi.fn() },
+      park: { update: vi.fn() },
+    };
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(txMocks));
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({
+      id: "op-new",
+      parks: [],
+      users: [],
+    } as any);
+
+    const res = await POST(jsonRequest({ name: "A", email: "a@b.com" }));
+
+    expect(res.status).toBe(201);
+    expect(txMocks.operatorUser.create).not.toHaveBeenCalled();
+    expect(txMocks.park.update).not.toHaveBeenCalled();
+  });
+
+  it("returns hint when initialOwnerEmail user doesn't exist (no error)", async () => {
+    vi.mocked(auth).mockResolvedValue(admin as any);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    const txMocks = {
+      operator: { create: vi.fn().mockResolvedValue({ id: "op-new" }) },
+      operatorUser: { create: vi.fn() },
+      park: { update: vi.fn() },
+    };
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(txMocks));
+    vi.mocked(prisma.operator.findUnique).mockResolvedValue({ id: "op-new" } as any);
+
+    const res = await POST(
+      jsonRequest({
+        name: "A",
+        email: "a@b.com",
+        initialOwnerEmail: "future@user.com",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.hints.ownerEmailSkipped).toContain("future@user.com");
+    expect(txMocks.operatorUser.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
New \`/admin/operators\` admin tab (ADMIN + SUPER_ADMIN) for direct operator maintenance. Normally operators are created via the Park Claims approval flow — this tab handles the cases that flow doesn't cover.

## What you can do
- **Create operators** with optional initial park + initial owner email in one shot
- **Edit org fields** (name, email, phone, website) inline
- **Delete operators** — cascades \`OperatorUser\`; nulls \`Park.operatorId\` via existing FK SetNull
- **Attach / detach parks** to/from an operator
- **Add / remove users** on an operator (by email; role OWNER or MEMBER)

## Where it lives
- Page: [/admin/operators](src/app/admin/operators/page.tsx) — collapsible per-operator cards with create form at top
- Nav: \"Park Operators\" link added to the admin sidebar between Park Claims and Map Heroes ([layout.tsx](src/app/admin/layout.tsx))
- API: 6 new route files under \`src/app/api/admin/operators/\`

## API surface (all ADMIN-gated via \`requireAdmin\`)
- \`GET\` / \`POST /api/admin/operators\`
- \`PATCH\` / \`DELETE /api/admin/operators/[id]\`
- \`POST /api/admin/operators/[id]/users\` · \`DELETE .../users/[userId]\`
- \`POST /api/admin/operators/[id]/parks\` · \`DELETE .../parks/[parkId]\`

## Out of scope (per agreed cut)
- Changing a user's role within an operator after add (OWNER ↔ MEMBER) — defer until MEMBER tier actually matters
- Single-step \"move operator between parks\" — use detach + attach
- Stripe / billing field editing — read-only in the table for now

## Behavior notes
- \`POST /operators\` with \`initialOwnerEmail\` for a user who hasn't signed in yet returns 201 with a hint pointing to Pre-grants (the right tool for first-login wiring). No silent failure.
- \`POST /operators/[id]/parks\` is idempotent if the park is already on this operator. Returns 409 only if it belongs to a *different* operator.
- DELETE on an operator with parks/users warns in the UI before firing.
- Park attach/detach calls \`revalidatePath('/parks/{slug}')\` so detail-page header updates immediately.

## Test plan
- [x] 45 new tests across 6 route files covering auth gates, body validation, not-found, conflict handling, P2002 uniqueness, transaction shape, idempotency
- [x] Full suite: 2074 / 2074 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx eslint\` clean
- [ ] Manual: visit /admin/operators after deploy — create an operator with name+email only, expand its card, attach a park, add a user, detach the park, delete the operator
- [ ] Manual: confirm sidebar nav shows \"Park Operators\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)