### PR TITLE
fix(admin): hide TRIALING · STANDARD subscription chip on operator rows

### DIFF
--- a/src/app/admin/operators/OperatorManagementClient.tsx
+++ b/src/app/admin/operators/OperatorManagementClient.tsx
@@ -450,11 +450,14 @@ function OperatorRow({
             </div>
           ) : (
             <>
+              {/* subscriptionStatus + subscriptionTier are Stripe-billing
+                  scaffolding (E14, not yet shipped). Every operator stays
+                  on the TRIALING · STANDARD defaults until Stripe webhooks
+                  cycle them, so showing them is just noise today. The
+                  fields are still returned in the API + kept on the row
+                  type — easy to unhide once OP-67/68 ship. */}
               <div className="flex items-center flex-wrap gap-2">
                 <h3 className="font-semibold">{op.name}</h3>
-                <span className="text-xs text-muted-foreground">
-                  {op.subscriptionStatus} · {op.subscriptionTier}
-                </span>
               </div>
               <div className="text-xs text-muted-foreground mt-1 flex flex-wrap items-center gap-3">
                 <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## Summary
The \"TRIALING · STANDARD\" text next to each operator's name in [/admin/operators](src/app/admin/operators/OperatorManagementClient.tsx) is Stripe-billing scaffolding from OP-61 — the values only become meaningful once E14 (OP-67/68) ships and Stripe webhooks start cycling them. Today every operator stays on the defaults, so the chip is decorative noise.

Hide it for now. Fields stay on the API response + row type so we can unhide trivially when billing actually means something.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: visit /admin/operators — operator rows no longer show \"TRIALING · STANDARD\" after the org name

🤖 Generated with [Claude Code](https://claude.com/claude-code)