### PR TITLE
feat(ai): Arkansas park-population toolchain + retired-model fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ next-env.d.ts
 CLAUDE.md
 
 /src/generated/prisma
+
+# Secrets — env files without leading dot (e.g. from `vercel env pull`)
+env.production
+env.*.local
+env.local

--- a/scripts/accept-candidates.ts
+++ b/scripts/accept-candidates.ts
@@ -1,0 +1,110 @@
+/**
+ * Seed accepted ParkCandidate rows into real Park records (dev DB — targets .env).
+ * Ports the candidate-accept transaction from
+ * src/app/api/admin/ai-research/discovery/candidates/route.ts (route-only logic).
+ *
+ * Does NOT auto-trigger research (run research-parks.ts separately for cost control)
+ * and does NOT generate map heroes.
+ *
+ * Run (dry-run — lists PENDING candidates, seeds nothing):
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/accept-candidates.ts Arkansas
+ *
+ * Run (seed only the matching candidates; match = case-insensitive substring):
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/accept-candidates.ts Arkansas \
+ *     --accept "Hot Springs Off Road||Wolf Pen Gap||Mill Creek||Buckhorn||3B Off-Road"
+ */
+import { readFileSync } from "node:fs";
+import { prisma } from "../src/lib/prisma";
+import { normalizeStateName } from "../src/lib/us-states";
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+async function ensureUniqueSlug(baseSlug: string): Promise<string> {
+  let slug = baseSlug;
+  let counter = 1;
+  while (true) {
+    const existing = await prisma.park.findUnique({ where: { slug } });
+    if (!existing) return slug;
+    counter++;
+    slug = `${baseSlug}-${counter}`;
+  }
+}
+
+async function main() {
+  const stateArg = process.argv[2] ?? "Arkansas";
+  const canonicalState = normalizeStateName(stateArg);
+  if (!canonicalState) {
+    console.error(`Unrecognized state: ${stateArg}`);
+    process.exit(1);
+  }
+
+  // --file <json>: [{ "match": "<substr of candidate name>", "name": "<canonical>", "city": "<city>" }]
+  const fileIdx = process.argv.indexOf("--file");
+  const acceptList: { match: string; name: string; city?: string }[] | null =
+    fileIdx !== -1 && process.argv[fileIdx + 1]
+      ? JSON.parse(readFileSync(process.argv[fileIdx + 1], "utf8"))
+      : null;
+
+  const pending = await prisma.parkCandidate.findMany({
+    where: { state: canonicalState, status: "PENDING" },
+    orderBy: { name: "asc" },
+  });
+
+  console.log(`\n${pending.length} PENDING candidate(s) in ${canonicalState}:\n`);
+
+  if (!acceptList) {
+    pending.forEach((c) => console.log(`  —  ${c.name}${c.city ? ` (${c.city})` : ""}`));
+    console.log(
+      `\n(dry-run) Pass --file <accept.json> with [{match,name,city}] to seed.\n`,
+    );
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log(`Seeding ${acceptList.length} vetted park(s) → Park records...\n`);
+  for (const entry of acceptList) {
+    const candidate = pending.find((c) =>
+      c.name.toLowerCase().includes(entry.match.toLowerCase()),
+    );
+    if (!candidate) {
+      console.log(`  ⚠️  no PENDING candidate matches "${entry.match}" — skipped`);
+      continue;
+    }
+    const slug = await ensureUniqueSlug(generateSlug(entry.name));
+    const result = await prisma.$transaction(async (tx) => {
+      const park = await tx.park.create({
+        data: {
+          name: entry.name, // canonical, verified name
+          slug,
+          status: "APPROVED",
+          researchStatus: "NEEDS_RESEARCH",
+          latitude: candidate.estimatedLat,
+          longitude: candidate.estimatedLng,
+        },
+      });
+      await tx.address.create({
+        data: { parkId: park.id, state: canonicalState, city: entry.city ?? candidate.city },
+      });
+      await tx.parkCandidate.update({
+        where: { id: candidate.id },
+        data: { status: "ACCEPTED", seededParkId: park.id },
+      });
+      return park;
+    });
+    console.log(`  ✅ ${entry.name}  →  /parks/${result.slug}  (${result.id})`);
+  }
+
+  console.log(`\nDone. Seeded ${acceptList.length} park(s), all status=APPROVED researchStatus=NEEDS_RESEARCH.`);
+  console.log(`Next: research them with scripts/research-parks.ts\n`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/apply-field-map.ts
+++ b/scripts/apply-field-map.ts
@@ -1,0 +1,93 @@
+/**
+ * Apply a verified {field: value} map to a single named park, in DEV or PROD.
+ * For targeted corrections/enrichment sourced from a research agent (not the
+ * PENDING_REVIEW queue). Scalars & address.* OVERWRITE with the provided value
+ * (used for verified corrections); array enums are UNIONed (add-only). Invalid
+ * enum members are skipped with a warning.
+ *
+ *  target: "dev" (default POSTGRES_PRISMA_URL) | "prod" (PROD_POSTGRES_URL)
+ *  Input JSON: { "fields": { ... } }  or a bare { ... } of field→value.
+ *  Dry-run by default; --commit to write.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/apply-field-map.ts dev "Renegade Ranch" /tmp/renegade-fields.json
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/apply-field-map.ts prod "Renegade Ranch" /tmp/renegade-fields.json --commit
+ */
+import { readFileSync } from "node:fs";
+import { PrismaClient } from "@prisma/client";
+import { prisma as dev } from "../src/lib/prisma";
+import { calculateCompleteness } from "../src/lib/ai/research-lifecycle";
+import type { DbPark } from "../src/lib/types";
+
+const ENUMS: Record<string, { col: string; table: string; values: Set<string> }> = {
+  terrain: { col: "terrain", table: "parkTerrain", values: new Set(["sand","rocks","mud","trails","hills","motocrossTrack"]) },
+  amenities: { col: "amenity", table: "parkAmenity", values: new Set(["restrooms","showers","food","fuel","repair","boatRamp","loadingRamp","picnicTable","shelter","grill","playground","wifi","fishing","airStation","trailMaps","rentals","training","firstAid","store"]) },
+  camping: { col: "camping", table: "parkCamping", values: new Set(["tent","rv30A","rv50A","fullHookup","cabin","groupSite","backcountry"]) },
+  vehicleTypes: { col: "vehicleType", table: "parkVehicleType", values: new Set(["motorcycle","atv","sxs","fullSize"]) },
+};
+
+async function main() {
+  const target = process.argv[2];
+  const parkName = process.argv[3];
+  const file = process.argv[4];
+  const commit = process.argv.includes("--commit");
+  if (!["dev","prod"].includes(target) || !parkName || !file) {
+    console.error('Usage: apply-field-map.ts <dev|prod> "<park name>" <fields.json> [--commit]');
+    process.exit(1);
+  }
+  let db = dev;
+  if (target === "prod") {
+    const url = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
+    if (!url) { console.error("✋ PROD_POSTGRES_URL not set — refusing."); process.exit(1); }
+    db = new PrismaClient({ datasources: { db: { url } } });
+  }
+  const raw = JSON.parse(readFileSync(file, "utf8"));
+  const fields: Record<string, unknown> = raw.fields ?? raw;
+
+  const inc = { address: true, terrain: true, amenities: true, camping: true, vehicleTypes: true } as const;
+  const park = await db.park.findFirst({ where: { name: { equals: parkName, mode: "insensitive" } }, include: inc });
+  if (!park) { console.error(`Park "${parkName}" not found in ${target}.`); process.exit(1); }
+
+  console.log(`\n${commit ? "🚀 COMMIT" : "🔎 DRY-RUN"} — apply ${Object.keys(fields).length} field(s) to ${target} "${park.name}" (${Math.round(park.dataCompletenessScore ?? 0)}%)\n`);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parkData: any = {}; const addrData: any = {}; const arrayOps: { key: string; add: string[] }[] = [];
+  for (const [k, v] of Object.entries(fields)) {
+    if (k in ENUMS) {
+      const def = ENUMS[k];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const have = new Set((park as any)[k].map((r: any) => r[def.col]));
+      const vals = (v as string[]).filter((x) => { if (!def.values.has(x)) { console.log(`    ! skip invalid ${k} member "${x}"`); return false; } return true; });
+      const add = vals.filter((x) => !have.has(x));
+      if (add.length) { arrayOps.push({ key: k, add }); console.log(`  + ${k} += ${JSON.stringify(add)}`); }
+    } else if (k.startsWith("address.")) {
+      const f = k.slice("address.".length); addrData[f] = v; console.log(`  ~ address.${f} = ${JSON.stringify(v)}`);
+    } else if (k === "latitude" || k === "longitude") {
+      parkData[k] = v; addrData[k] = v; console.log(`  ~ ${k} = ${JSON.stringify(v)}`);
+    } else {
+      parkData[k] = v; console.log(`  ~ ${k} = ${JSON.stringify(v)}`);
+    }
+  }
+
+  if (!commit) { console.log(`\n(dry-run) re-run with --commit to write.\n`); await db.$disconnect(); return; }
+
+  await db.$transaction(async (tx) => {
+    if (Object.keys(parkData).length) await tx.park.update({ where: { id: park.id }, data: parkData });
+    if (Object.keys(addrData).length) {
+      if (park.address) await tx.address.update({ where: { parkId: park.id }, data: addrData });
+      else await tx.address.create({ data: { parkId: park.id, state: "Arkansas", ...addrData } });
+    }
+    for (const { key, add } of arrayOps) {
+      const def = ENUMS[key];
+      for (const val of add)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (tx as any)[def.table].create({ data: { parkId: park.id, [def.col]: val } });
+    }
+    const fresh = await tx.park.findUnique({ where: { id: park.id }, include: inc });
+    if (fresh) await tx.park.update({ where: { id: park.id }, data: { dataCompletenessScore: calculateCompleteness(fresh as unknown as DbPark) } });
+  });
+  const after = await db.park.findUnique({ where: { id: park.id }, select: { dataCompletenessScore: true } });
+  console.log(`\n✅ applied to ${target} "${park.name}" — completeness now ${Math.round(after?.dataCompletenessScore ?? 0)}%\n`);
+  await db.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/approve-extractions.ts
+++ b/scripts/approve-extractions.ts
@@ -1,0 +1,169 @@
+/**
+ * Apply verified field extractions to live park data (dev DB — targets .env).
+ * Ports the approve transaction from
+ * src/app/api/admin/ai-research/extractions/[id]/approve/route.ts (route-only).
+ * THIS is the accuracy gate — only run on extractions verified by the review agents.
+ *
+ * Decisions file (JSON):
+ *   { "approve": [{ "id": "<extractionId>", "editedValue": "<json string>"? }, ...],
+ *     "reject":  ["<extractionId>", ...] }
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/approve-extractions.ts /tmp/ar-decisions.json
+ */
+import { readFileSync } from "node:fs";
+import { prisma } from "../src/lib/prisma";
+import {
+  calculateCompleteness,
+  getCurrentFieldValue,
+} from "../src/lib/ai/research-lifecycle";
+import type { DbPark } from "../src/lib/types";
+
+const ARRAY_FIELDS = ["terrain", "amenities", "camping", "vehicleTypes"];
+// Junction-table column name per array field (matches the approve route).
+const ARRAY_COL: Record<string, string> = {
+  terrain: "terrain",
+  amenities: "amenity",
+  camping: "camping",
+  vehicleTypes: "vehicleType",
+};
+
+async function approveOne(id: string, editedValue: string | undefined, adminId: string) {
+  const extraction = await prisma.fieldExtraction.findUnique({
+    where: { id },
+    include: {
+      park: {
+        include: { terrain: true, amenities: true, camping: true, vehicleTypes: true, address: true },
+      },
+    },
+  });
+  if (!extraction) return `SKIP ${id}: not found`;
+  if (extraction.status !== "PENDING_REVIEW") return `SKIP ${id}: not pending (${extraction.status})`;
+
+  const valueStr = editedValue ?? extraction.extractedValue;
+  if (valueStr === null) return `SKIP ${id}: no value`;
+  const parsedValue = JSON.parse(valueStr);
+  const fieldName = extraction.fieldName;
+  const parkId = extraction.parkId;
+  const currentValue = getCurrentFieldValue(extraction.park as unknown as DbPark, fieldName);
+  const isArrayField = ARRAY_FIELDS.includes(fieldName);
+
+  await prisma.$transaction(async (tx) => {
+    if (fieldName.startsWith("address.")) {
+      const addressField = fieldName.slice("address.".length);
+      await tx.address.updateMany({ where: { parkId }, data: { [addressField]: parsedValue } });
+    } else if (isArrayField) {
+      const newValues = parsedValue as string[];
+      const table =
+        fieldName === "terrain" ? tx.parkTerrain
+        : fieldName === "amenities" ? tx.parkAmenity
+        : fieldName === "camping" ? tx.parkCamping
+        : tx.parkVehicleType;
+      const col = ARRAY_COL[fieldName];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const existing = await (table as any).findMany({ where: { parkId } });
+      const existingSet = new Set(existing.map((e: Record<string, unknown>) => e[col]));
+      for (const v of newValues) {
+        if (!existingSet.has(v)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (table as any).create({ data: { parkId, [col]: v } });
+        }
+      }
+    } else {
+      await tx.park.update({ where: { id: parkId }, data: { [fieldName]: parsedValue } });
+    }
+
+    await tx.fieldExtraction.update({
+      where: { id },
+      data: { status: "APPROVED", verifiedAt: new Date(), verifiedBy: adminId },
+    });
+
+    if (isArrayField) {
+      const approvedSet = new Set(parsedValue as string[]);
+      const otherPending = await tx.fieldExtraction.findMany({
+        where: { parkId, fieldName, status: "PENDING_REVIEW", id: { not: id } },
+      });
+      for (const other of otherPending) {
+        if (!other.extractedValue) continue;
+        const remaining = (JSON.parse(other.extractedValue) as string[]).filter((v) => !approvedSet.has(v));
+        await tx.fieldExtraction.update({
+          where: { id: other.id },
+          data: remaining.length === 0
+            ? { status: "SUPERSEDED" }
+            : { extractedValue: JSON.stringify(remaining) },
+        });
+      }
+    } else {
+      await tx.fieldExtraction.updateMany({
+        where: { parkId, fieldName, status: "PENDING_REVIEW", id: { not: id } },
+        data: { status: "SUPERSEDED" },
+      });
+    }
+
+    await tx.parkEditLog.create({
+      data: {
+        parkId,
+        userId: adminId,
+        changes: JSON.stringify({
+          [fieldName]: { from: currentValue ? JSON.parse(currentValue) : null, to: parsedValue },
+        }),
+      },
+    });
+
+    const updatedPark = await tx.park.findUnique({
+      where: { id: parkId },
+      include: { terrain: true, amenities: true, camping: true, vehicleTypes: true, address: true },
+    });
+    if (updatedPark) {
+      await tx.park.update({
+        where: { id: parkId },
+        data: { dataCompletenessScore: calculateCompleteness(updatedPark as unknown as DbPark) },
+      });
+    }
+  });
+
+  return `✅ ${fieldName} = ${JSON.stringify(parsedValue)}  (park ${parkId})`;
+}
+
+async function main() {
+  const path = process.argv[2];
+  if (!path) {
+    console.error("Usage: approve-extractions.ts <decisions.json>");
+    process.exit(1);
+  }
+  const decisions = JSON.parse(readFileSync(path, "utf8")) as {
+    approve?: { id: string; editedValue?: string }[];
+    reject?: string[];
+  };
+
+  const admin = await prisma.user.findFirst({
+    where: { role: { in: ["SUPER_ADMIN", "ADMIN"] } },
+    select: { id: true, email: true },
+  });
+  if (!admin) {
+    console.error("No ADMIN/SUPER_ADMIN user in the DB to attribute approvals to.");
+    process.exit(1);
+  }
+  console.log(`Attributing to admin: ${admin.email}\n`);
+
+  for (const dec of decisions.approve ?? []) {
+    console.log("  " + (await approveOne(dec.id, dec.editedValue, admin.id)));
+  }
+
+  for (const id of decisions.reject ?? []) {
+    const res = await prisma.fieldExtraction.updateMany({
+      where: { id, status: "PENDING_REVIEW" },
+      data: { status: "REJECTED", verifiedAt: new Date(), verifiedBy: admin.id },
+    });
+    console.log(`  ❌ rejected ${id}${res.count ? "" : " (not pending)"}`);
+  }
+
+  console.log(
+    `\nApplied ${decisions.approve?.length ?? 0} approval(s), ${decisions.reject?.length ?? 0} rejection(s).`,
+  );
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/backfill-map-heroes.ts
+++ b/scripts/backfill-map-heroes.ts
@@ -1,0 +1,57 @@
+/**
+ * Backfill auto-generated map-hero thumbnails for every park missing one.
+ * Mirrors src/lib/map-hero/generate.ts but targets DEV or PROD explicitly
+ * (the app's generateMapHero() is bound to the default client, so this is a
+ * standalone port that takes a target). Sequential to respect Mapbox limits.
+ *
+ * Needs NEXT_PUBLIC_MAPBOX_TOKEN + BLOB_READ_WRITE_TOKEN in env.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/backfill-map-heroes.ts dev
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/backfill-map-heroes.ts prod
+ */
+import { PrismaClient } from "@prisma/client";
+import { put } from "@vercel/blob";
+
+const STYLE = "outdoors-v12", ZOOM = 10, W = 600, H = 300;
+
+async function main() {
+  const target = process.argv[2];
+  if (!["dev", "prod"].includes(target)) { console.error("Usage: backfill-map-heroes.ts <dev|prod>"); process.exit(1); }
+  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  if (!token) { console.error("✋ NEXT_PUBLIC_MAPBOX_TOKEN not set."); process.exit(1); }
+  if (!process.env.BLOB_READ_WRITE_TOKEN) { console.error("✋ BLOB_READ_WRITE_TOKEN not set."); process.exit(1); }
+
+  let url = process.env.POSTGRES_PRISMA_URL;
+  if (target === "prod") {
+    url = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
+    if (!url) { console.error("✋ PROD_POSTGRES_URL not set."); process.exit(1); }
+  }
+  const db = new PrismaClient({ datasources: { db: { url: url! } } });
+
+  const parks = await db.park.findMany({
+    where: { mapHeroUrl: null, OR: [{ latitude: { not: null } }, { address: { latitude: { not: null } } }] },
+    select: { id: true, name: true, latitude: true, longitude: true, address: { select: { latitude: true, longitude: true } } },
+  });
+  const noCoords = await db.park.count({ where: { mapHeroUrl: null, latitude: null, address: { is: { latitude: null } } } });
+
+  console.log(`\n[${target}] ${parks.length} park(s) missing a hero with coords; ${noCoords} more have no coords (skipped).\n`);
+  let ok = 0; const fails: string[] = [];
+  for (const p of parks) {
+    const lat = p.latitude ?? p.address?.latitude ?? null;
+    const lng = p.longitude ?? p.address?.longitude ?? null;
+    if (lat == null || lng == null) { fails.push(`${p.name}: no coords`); continue; }
+    try {
+      const res = await fetch(`https://api.mapbox.com/styles/v1/mapbox/${STYLE}/static/${lng},${lat},${ZOOM}/${W}x${H}@2x?access_token=${token}`);
+      if (!res.ok) { fails.push(`${p.name}: mapbox ${res.status}`); continue; }
+      const buffer = Buffer.from(await res.arrayBuffer());
+      const blob = await put(`parks/${p.id}/map-hero.jpg`, buffer, { access: "public", contentType: "image/jpeg", allowOverwrite: true });
+      await db.park.update({ where: { id: p.id }, data: { mapHeroUrl: blob.url, mapHeroGeneratedAt: new Date() } });
+      console.log(`  ✅ ${p.name}`);
+      ok++;
+    } catch (e) { fails.push(`${p.name}: ${(e as Error).message?.slice(0, 80)}`); }
+  }
+  console.log(`\n[${target}] generated ${ok}, failed ${fails.length}${fails.length ? ":\n  - " + fails.join("\n  - ") : ""}\n`);
+  await db.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/discover-state.ts
+++ b/scripts/discover-state.ts
@@ -1,0 +1,59 @@
+/**
+ * AI park discovery for a US state (dev DB — targets .env).
+ *
+ * Run:
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/discover-state.ts Arkansas
+ *
+ * Costs SerpApi + Anthropic (a few cents). Writes PENDING rows to ParkCandidate.
+ * Does NOT create Park records or touch live data.
+ */
+import { discoverParksInState } from "../src/lib/ai/park-discovery";
+import { normalizeStateName } from "../src/lib/us-states";
+import { prisma } from "../src/lib/prisma";
+
+async function main() {
+  const stateArg = process.argv[2] ?? "Arkansas";
+  const state = normalizeStateName(stateArg);
+  if (!state) {
+    console.error(`Unrecognized state: ${stateArg}`);
+    process.exit(1);
+  }
+
+  console.log(`\n🔎 Discovering OHV/offroad parks in ${state}...\n`);
+  const result = await discoverParksInState(state);
+
+  const inCost = (result.inputTokens / 1_000_000) * 3;
+  const outCost = (result.outputTokens / 1_000_000) * 15;
+  console.log(
+    `LLM tokens: ${result.inputTokens} in / ${result.outputTokens} out  (~$${(inCost + outCost).toFixed(4)} + SerpApi credits)\n`,
+  );
+
+  console.log(`Returned ${result.candidates.length} candidate(s):\n`);
+  result.candidates.forEach((c, i) => {
+    const coords =
+      c.estimatedLat != null && c.estimatedLng != null
+        ? `${c.estimatedLat.toFixed(3)}, ${c.estimatedLng.toFixed(3)}`
+        : "no coords";
+    console.log(
+      `  ${String(i + 1).padStart(2)}. ${c.name}${c.city ? ` — ${c.city}` : ""}  [${coords}]`,
+    );
+    if (c.sourceUrl) console.log(`      src: ${c.sourceUrl}`);
+  });
+
+  const persisted = await prisma.parkCandidate.findMany({
+    where: { state },
+    orderBy: { name: "asc" },
+    select: { name: true, city: true, status: true, sourceUrl: true },
+  });
+  console.log(`\n💾 ParkCandidate rows now in DB for ${state}: ${persisted.length}`);
+  persisted.forEach((c) =>
+    console.log(`   [${c.status}] ${c.name}${c.city ? ` (${c.city})` : ""}`),
+  );
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/enrich-prod.ts
+++ b/scripts/enrich-prod.ts
@@ -1,0 +1,104 @@
+/**
+ * ADD-ONLY field-level enrichment of existing PROD parks from their verified
+ * DEV twins. Fills only EMPTY prod scalar/address fields and UNIONS array
+ * fields — never overwrites an existing prod value.
+ *
+ *  - DEV (source) = default PrismaClient (POSTGRES_PRISMA_URL, .env)
+ *  - PROD (target) = PROD_POSTGRES_URL (required; refuses to run otherwise)
+ *  - Mapping JSON: [{ "devName": "...", "prodName": "..." }]  (identity-confirmed pairs only)
+ *  - Dry-run by default; --commit to write.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/enrich-prod.ts /tmp/dupe-map.json
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/enrich-prod.ts /tmp/dupe-map.json --commit
+ */
+import { readFileSync } from "node:fs";
+import { PrismaClient } from "@prisma/client";
+import { prisma as dev } from "../src/lib/prisma";
+import { calculateCompleteness } from "../src/lib/ai/research-lifecycle";
+import type { DbPark } from "../src/lib/types";
+
+const FILL_SCALARS = [
+  "latitude", "longitude", "website", "phone", "campingWebsite", "campingPhone",
+  "isFree", "dayPassUSD", "vehicleEntryFeeUSD", "riderFeeUSD", "membershipFeeUSD",
+  "milesOfTrails", "acres", "notes", "datesOpen", "contactEmail", "ownership",
+  "permitRequired", "permitType", "membershipRequired", "maxVehicleWidthInches",
+  "flagsRequired", "sparkArrestorRequired", "helmetsRequired", "noiseLimitDBA",
+] as const;
+const FILL_ADDRESS = ["streetAddress", "streetAddress2", "city", "zipCode", "county", "latitude", "longitude"] as const;
+const ARRAY_DEFS = [
+  { field: "terrain", col: "terrain", table: "parkTerrain" },
+  { field: "amenities", col: "amenity", table: "parkAmenity" },
+  { field: "camping", col: "camping", table: "parkCamping" },
+  { field: "vehicleTypes", col: "vehicleType", table: "parkVehicleType" },
+] as const;
+
+const isEmpty = (v: unknown) => v === null || v === undefined || v === "";
+
+async function main() {
+  const mapFile = process.argv[2];
+  const commit = process.argv.includes("--commit");
+  const prodUrl = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
+  if (!mapFile) { console.error("Usage: enrich-prod.ts <mapping.json> [--commit]"); process.exit(1); }
+  if (!prodUrl) { console.error("✋ PROD_POSTGRES_URL not set — refusing to run."); process.exit(1); }
+  const prod = new PrismaClient({ datasources: { db: { url: prodUrl } } });
+  const mapping: { devName: string; prodName: string }[] = JSON.parse(readFileSync(mapFile, "utf8"));
+
+  console.log(`\n${commit ? "🚀 COMMIT" : "🔎 DRY-RUN"} — enriching ${mapping.length} prod park(s) (add-only)\n`);
+
+  const inc = { address: true, terrain: true, amenities: true, camping: true, vehicleTypes: true } as const;
+  for (const { devName, prodName } of mapping) {
+    const src = await dev.park.findFirst({ where: { name: devName }, include: inc });
+    const tgt = await prod.park.findFirst({ where: { name: prodName }, include: inc });
+    if (!src) { console.log(`  ⚠️  dev "${devName}" not found — skipped`); continue; }
+    if (!tgt) { console.log(`  ⚠️  prod "${prodName}" not found — skipped`); continue; }
+
+    console.log(`\n▸ ${prodName}  (prod ${Math.round(tgt.dataCompletenessScore ?? 0)}%)  ⇐  dev "${devName}"`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parkData: any = {};
+    for (const f of FILL_SCALARS) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (isEmpty((tgt as any)[f]) && !isEmpty((src as any)[f])) { parkData[f] = (src as any)[f]; console.log(`    + ${f} = ${JSON.stringify((src as any)[f])}`); }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const addrData: any = {};
+    for (const f of FILL_ADDRESS) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (isEmpty((tgt.address as any)?.[f]) && !isEmpty((src.address as any)?.[f])) { addrData[f] = (src.address as any)[f]; console.log(`    + address.${f} = ${JSON.stringify((src.address as any)[f])}`); }
+    }
+    const arrayAdds: { def: typeof ARRAY_DEFS[number]; values: string[] }[] = [];
+    for (const def of ARRAY_DEFS) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const have = new Set((tgt as any)[def.field].map((r: any) => r[def.col]));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const add = (src as any)[def.field].map((r: any) => r[def.col]).filter((v: string) => !have.has(v));
+      if (add.length) { arrayAdds.push({ def, values: add }); console.log(`    + ${def.field} += ${JSON.stringify(add)}`); }
+    }
+
+    const nChanges = Object.keys(parkData).length + Object.keys(addrData).length + arrayAdds.reduce((a, x) => a + x.values.length, 0);
+    if (nChanges === 0) { console.log("    (nothing to fill — prod already covers dev)"); continue; }
+    if (!commit) { console.log(`    ⇒ would apply ${nChanges} change(s)`); continue; }
+
+    await prod.$transaction(async (tx) => {
+      if (Object.keys(parkData).length) await tx.park.update({ where: { id: tgt.id }, data: parkData });
+      if (Object.keys(addrData).length) {
+        if (tgt.address) await tx.address.update({ where: { parkId: tgt.id }, data: addrData });
+        else await tx.address.create({ data: { parkId: tgt.id, state: src.address?.state ?? "Arkansas", ...addrData } });
+      }
+      for (const { def, values } of arrayAdds)
+        for (const v of values)
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (tx as any)[def.table].create({ data: { parkId: tgt.id, [def.col]: v } });
+
+      const fresh = await tx.park.findUnique({ where: { id: tgt.id }, include: inc });
+      if (fresh) await tx.park.update({ where: { id: tgt.id }, data: { dataCompletenessScore: calculateCompleteness(fresh as unknown as DbPark) } });
+    });
+    const after = await prod.park.findUnique({ where: { id: tgt.id }, select: { dataCompletenessScore: true } });
+    console.log(`    ✅ applied ${nChanges} change(s) — completeness now ${Math.round(after?.dataCompletenessScore ?? 0)}%`);
+  }
+
+  console.log(`\n${commit ? "Enrichment committed." : "Dry-run only — re-run with --commit to write."}\n`);
+  await dev.$disconnect();
+  await prod.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/geocode-parks.ts
+++ b/scripts/geocode-parks.ts
@@ -1,0 +1,60 @@
+/**
+ * Geocode parks that lack coordinates (so map heroes + map pins work), DEV or
+ * PROD. Uses Mapbox geocoding on "streetAddress, city, state" (falls back to
+ * "city, state"). Sets park.latitude/longitude AND address.latitude/longitude.
+ * Only touches parks with NO existing coords — never overwrites.
+ *
+ * Needs NEXT_PUBLIC_MAPBOX_TOKEN. Dry-run by default; --commit to write.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/geocode-parks.ts prod
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/geocode-parks.ts prod --commit
+ */
+import { PrismaClient } from "@prisma/client";
+
+async function main() {
+  const target = process.argv[2];
+  const commit = process.argv.includes("--commit");
+  if (!["dev", "prod"].includes(target)) { console.error("Usage: geocode-parks.ts <dev|prod> [--commit]"); process.exit(1); }
+  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  if (!token) { console.error("✋ NEXT_PUBLIC_MAPBOX_TOKEN not set."); process.exit(1); }
+
+  let url = process.env.POSTGRES_PRISMA_URL;
+  if (target === "prod") {
+    url = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
+    if (!url) { console.error("✋ PROD_POSTGRES_URL not set."); process.exit(1); }
+  }
+  const db = new PrismaClient({ datasources: { db: { url: url! } } });
+
+  const parks = await db.park.findMany({
+    where: { latitude: null, address: { is: { latitude: null, city: { not: null } } } },
+    select: { id: true, name: true, address: { select: { streetAddress: true, city: true, state: true } } },
+    orderBy: { name: "asc" },
+  });
+  console.log(`\n[${target}] ${commit ? "COMMIT" : "DRY-RUN"} — ${parks.length} park(s) to geocode\n`);
+
+  let done = 0; const fails: string[] = [];
+  for (const p of parks) {
+    const a = p.address!;
+    const q = [a.streetAddress, a.city, a.state].filter(Boolean).join(", ");
+    try {
+      const res = await fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?limit=1&country=us&access_token=${token}`);
+      if (!res.ok) { fails.push(`${p.name}: geocode ${res.status}`); continue; }
+      const data = await res.json();
+      const center = data?.features?.[0]?.center;
+      if (!Array.isArray(center) || center.length !== 2) { fails.push(`${p.name}: no result for "${q}"`); continue; }
+      const [lng, lat] = center as [number, number];
+      const place = data.features[0].place_name ?? "";
+      console.log(`  ${commit ? "✅" : "•"} ${p.name}  →  ${lat.toFixed(4)}, ${lng.toFixed(4)}  (${place.slice(0, 60)})`);
+      if (commit) {
+        await db.park.update({ where: { id: p.id }, data: { latitude: lat, longitude: lng } });
+        await db.address.update({ where: { parkId: p.id }, data: { latitude: lat, longitude: lng } });
+      }
+      done++;
+    } catch (e) { fails.push(`${p.name}: ${(e as Error).message?.slice(0, 80)}`); }
+  }
+  console.log(`\n[${target}] ${commit ? "geocoded" : "would geocode"} ${done}, failed ${fails.length}${fails.length ? ":\n  - " + fails.join("\n  - ") : ""}`);
+  if (!commit) console.log("Re-run with --commit to write.\n");
+  await db.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/list-extractions.ts
+++ b/scripts/list-extractions.ts
@@ -1,0 +1,62 @@
+/**
+ * Dump PENDING_REVIEW field extractions per park as JSON (dev DB — targets .env).
+ * Feeds the per-park verification agents. Read-only.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/list-extractions.ts Arkansas
+ *   ... > /tmp/ar-extractions.json
+ */
+import { prisma } from "../src/lib/prisma";
+import { normalizeStateName } from "../src/lib/us-states";
+
+async function main() {
+  const canonicalState = normalizeStateName(process.argv[2] ?? "Arkansas");
+  if (!canonicalState) process.exit(1);
+
+  const parks = await prisma.park.findMany({
+    where: { address: { state: canonicalState } },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      latitude: true,
+      longitude: true,
+      address: { select: { city: true, state: true } },
+      fieldExtractions: {
+        where: { status: "PENDING_REVIEW" },
+        select: {
+          id: true,
+          fieldName: true,
+          extractedValue: true,
+          confidenceScore: true,
+          dataSource: { select: { url: true } },
+        },
+        orderBy: { fieldName: "asc" },
+      },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  const out = parks.map((p) => ({
+    parkId: p.id,
+    name: p.name,
+    slug: p.slug,
+    city: p.address?.city ?? null,
+    state: p.address?.state ?? null,
+    coords: p.latitude != null && p.longitude != null ? [p.latitude, p.longitude] : null,
+    pendingFields: p.fieldExtractions.map((e) => ({
+      id: e.id,
+      field: e.fieldName,
+      value: e.extractedValue ? JSON.parse(e.extractedValue) : null,
+      confidence: e.confidenceScore,
+      sourceUrl: e.dataSource?.url ?? null,
+    })),
+  }));
+
+  console.log(JSON.stringify(out, null, 2));
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/promote-to-prod.ts
+++ b/scripts/promote-to-prod.ts
@@ -39,6 +39,7 @@ const PROMOTE = [
   "Carter Off Road Park",
   "RATS ATV & Off-Road Park",
   "Renegade Ranch",
+  "Mulberry Mountain Lodging & Events",
 ];
 
 // Park scalar fields copied verbatim (id/slug/timestamps/relations handled separately).

--- a/scripts/promote-to-prod.ts
+++ b/scripts/promote-to-prod.ts
@@ -61,11 +61,11 @@ function generateSlug(name: string): string {
 
 async function main() {
   const commit = process.argv.includes("--commit");
-  const prodUrl = process.env.PROD_POSTGRES_PRISMA_URL;
+  const prodUrl = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
   if (!prodUrl) {
     console.error(
-      "\n✋ PROD_POSTGRES_PRISMA_URL is not set. Add it to .env.local, e.g.\n" +
-      "   PROD_POSTGRES_PRISMA_URL=postgresql://…prod pooled URL…\n" +
+      "\n✋ PROD_POSTGRES_URL is not set. Add it to .env / .env.local, e.g.\n" +
+      "   PROD_POSTGRES_URL=postgresql://…prod pooled URL…\n" +
       "Refusing to run without an explicit prod target.\n",
     );
     process.exit(1);

--- a/scripts/promote-to-prod.ts
+++ b/scripts/promote-to-prod.ts
@@ -1,0 +1,137 @@
+/**
+ * ADD-ONLY promotion of verified parks from DEV → PROD.
+ *
+ * Safety design:
+ *  - DEV (source)  = default PrismaClient (reads POSTGRES_PRISMA_URL from .env)
+ *  - PROD (target) = separate client, url from PROD_POSTGRES_PRISMA_URL ONLY.
+ *    If PROD_POSTGRES_PRISMA_URL is unset, the script refuses to run.
+ *  - Never updates or deletes an existing prod row. For each park, if a prod
+ *    park with the same name (case-insensitive) already exists, it is SKIPPED.
+ *  - Copies only curated live fields (Park scalars + Address + terrain/amenities/
+ *    camping/vehicleTypes). Research artifacts (DataSource/FieldExtraction/
+ *    ResearchSession), photos, reviews, operator/submitter links, map-hero and
+ *    review aggregates are NOT copied.
+ *  - Dry-run by default. Pass --commit to actually write.
+ *
+ *   # preview (writes nothing):
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts
+ *   # execute:
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts --commit
+ */
+import { PrismaClient } from "@prisma/client";
+import { prisma as dev } from "../src/lib/prisma";
+
+// The 15 verified, new-to-prod Arkansas parks (excludes the 3 known prod dupes:
+// 3B/Eureka Springs Adventure Park, Hot Springs Off-Road Park, Wolf Pen Gap).
+const PROMOTE = [
+  "Buckhorn OHV Trails",
+  "Mill Creek OHV Trail",
+  "Brock Creek Trails",
+  "Wilderness Rider Buffalo Ranch & Adventure Park",
+  "Bear Creek Cycle Trail",
+  "Moccasin Gap OHV Trails",
+  "Sugar Creek Multiuse Trail",
+  "Fairfield Bay OHV Trails",
+  "Mack's Pines Recreation Area",
+  "The Ridge Off-Road Park",
+  "Greasy Bend Off-Road Park",
+  "Hillarosa ATV Park",
+  "Carter Off Road Park",
+  "RATS ATV & Off-Road Park",
+  "Renegade Ranch",
+];
+
+// Park scalar fields copied verbatim (id/slug/timestamps/relations handled separately).
+const PARK_SCALARS = [
+  "name", "latitude", "longitude", "website", "phone", "campingWebsite", "campingPhone",
+  "isFree", "dayPassUSD", "vehicleEntryFeeUSD", "riderFeeUSD", "membershipFeeUSD",
+  "milesOfTrails", "acres", "notes", "datesOpen", "contactEmail", "ownership",
+  "permitRequired", "permitType", "membershipRequired", "maxVehicleWidthInches",
+  "flagsRequired", "sparkArrestorRequired", "helmetsRequired", "noiseLimitDBA",
+  "dataCompletenessScore",
+] as const;
+
+const ADDRESS_SCALARS = [
+  "streetAddress", "streetAddress2", "city", "state", "zipCode", "county", "latitude", "longitude",
+] as const;
+
+function generateSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function main() {
+  const commit = process.argv.includes("--commit");
+  const prodUrl = process.env.PROD_POSTGRES_PRISMA_URL;
+  if (!prodUrl) {
+    console.error(
+      "\n✋ PROD_POSTGRES_PRISMA_URL is not set. Add it to .env.local, e.g.\n" +
+      "   PROD_POSTGRES_PRISMA_URL=postgresql://…prod pooled URL…\n" +
+      "Refusing to run without an explicit prod target.\n",
+    );
+    process.exit(1);
+  }
+  const prod = new PrismaClient({ datasources: { db: { url: prodUrl } } });
+
+  console.log(`\n${commit ? "🚀 COMMIT" : "🔎 DRY-RUN"} — promoting up to ${PROMOTE.length} parks DEV → PROD (add-only)\n`);
+
+  const sources = await dev.park.findMany({
+    where: { name: { in: PROMOTE } },
+    include: { address: true, terrain: true, amenities: true, camping: true, vehicleTypes: true },
+  });
+
+  let created = 0, skipped = 0;
+  for (const name of PROMOTE) {
+    const src = sources.find((p) => p.name === name);
+    if (!src) { console.log(`  ⚠️  "${name}" not found in dev — skipped`); continue; }
+
+    const existing = await prod.park.findFirst({
+      where: { name: { equals: name, mode: "insensitive" } },
+      select: { id: true },
+    });
+    if (existing) { console.log(`  ⏭  SKIP (already in prod): ${name}`); skipped++; continue; }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parkData: any = {};
+    for (const f of PARK_SCALARS) parkData[f] = (src as any)[f];
+    parkData.status = "APPROVED";
+    parkData.researchStatus = src.researchStatus;
+
+    const fieldCount =
+      src.terrain.length + src.amenities.length + src.camping.length + src.vehicleTypes.length;
+    const pct = Math.round(src.dataCompletenessScore ?? 0);
+    if (!commit) {
+      console.log(`  ➕ WOULD CREATE: ${name}  (${pct}%, ${src.address?.city ?? "?"}, ${src.address?.county ?? "?"}; ` +
+        `veh/terr/amen/camp = ${fieldCount})`);
+      created++;
+      continue;
+    }
+
+    // Unique slug within prod.
+    let slug = generateSlug(name), n = 1;
+    while (await prod.park.findUnique({ where: { slug } })) slug = `${generateSlug(name)}-${++n}`;
+
+    await prod.$transaction(async (tx) => {
+      const park = await tx.park.create({ data: { ...parkData, slug } });
+      if (src.address) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const addr: any = { parkId: park.id };
+        for (const f of ADDRESS_SCALARS) addr[f] = (src.address as any)[f];
+        addr.state = src.address.state; // required
+        await tx.address.create({ data: addr });
+      }
+      for (const t of src.terrain) await tx.parkTerrain.create({ data: { parkId: park.id, terrain: t.terrain } });
+      for (const a of src.amenities) await tx.parkAmenity.create({ data: { parkId: park.id, amenity: a.amenity } });
+      for (const c of src.camping) await tx.parkCamping.create({ data: { parkId: park.id, camping: c.camping } });
+      for (const v of src.vehicleTypes) await tx.parkVehicleType.create({ data: { parkId: park.id, vehicleType: v.vehicleType } });
+    });
+    console.log(`  ✅ CREATED: ${name}  →  /parks/${slug}  (${pct}%)`);
+    created++;
+  }
+
+  console.log(`\n${commit ? "Promoted" : "Would promote"} ${created} park(s); skipped ${skipped} already in prod.`);
+  if (!commit) console.log(`Re-run with --commit to write to prod.\n`);
+  await dev.$disconnect();
+  await prod.$disconnect();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/promote-to-prod.ts
+++ b/scripts/promote-to-prod.ts
@@ -93,7 +93,7 @@ async function main() {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parkData: any = {};
-    for (const f of PARK_SCALARS) parkData[f] = (src as any)[f];
+    for (const f of PARK_SCALARS) parkData[f] = src[f as keyof typeof src];
     parkData.status = "APPROVED";
     parkData.researchStatus = src.researchStatus;
 
@@ -116,7 +116,8 @@ async function main() {
       if (src.address) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const addr: any = { parkId: park.id };
-        for (const f of ADDRESS_SCALARS) addr[f] = (src.address as any)[f];
+        const srcAddr = src.address;
+        for (const f of ADDRESS_SCALARS) addr[f] = srcAddr[f as keyof typeof srcAddr];
         addr.state = src.address.state; // required
         await tx.address.create({ data: addr });
       }

--- a/scripts/research-parks.ts
+++ b/scripts/research-parks.ts
@@ -1,0 +1,71 @@
+/**
+ * Run the AI research pipeline on seeded parks (dev DB — targets .env).
+ * Calls researchPark() per park; it writes DataSource + FieldExtraction (a
+ * PENDING_REVIEW queue) — it does NOT write live park field values. Safe.
+ *
+ * Costs SerpApi + Anthropic per park. Run with ANTHROPIC_BASE_URL unset locally:
+ *   env -u ANTHROPIC_BASE_URL npx tsx --env-file=.env --env-file=.env.local \
+ *     scripts/research-parks.ts Arkansas
+ *
+ * By default researches every NEEDS_RESEARCH/IN_PROGRESS park in the state.
+ * Pass --limit N to cap the batch.
+ */
+import { prisma } from "../src/lib/prisma";
+import { researchPark } from "../src/lib/ai/research-pipeline";
+import { normalizeStateName } from "../src/lib/us-states";
+
+async function main() {
+  const stateArg = process.argv[2] ?? "Arkansas";
+  const canonicalState = normalizeStateName(stateArg);
+  if (!canonicalState) {
+    console.error(`Unrecognized state: ${stateArg}`);
+    process.exit(1);
+  }
+  const limitIdx = process.argv.indexOf("--limit");
+  const limit =
+    limitIdx !== -1 && process.argv[limitIdx + 1]
+      ? parseInt(process.argv[limitIdx + 1], 10)
+      : undefined;
+
+  const parks = await prisma.park.findMany({
+    where: {
+      address: { state: canonicalState },
+      researchStatus: { in: ["NEEDS_RESEARCH", "IN_PROGRESS"] },
+    },
+    select: { id: true, name: true },
+    orderBy: { name: "asc" },
+    take: limit,
+  });
+
+  console.log(`\nResearching ${parks.length} park(s) in ${canonicalState} (sequential)...\n`);
+
+  let totalCost = 0;
+  for (let i = 0; i < parks.length; i++) {
+    const p = parks[i];
+    process.stdout.write(`  [${i + 1}/${parks.length}] ${p.name} ... `);
+    try {
+      const { sessionId } = await researchPark(p.id, "ADMIN_MANUAL");
+      const session = await prisma.researchSession.findUnique({
+        where: { id: sessionId },
+        select: { estimatedCostUSD: true, status: true },
+      });
+      const cost = session?.estimatedCostUSD ?? 0;
+      totalCost += cost;
+      const extractions = await prisma.fieldExtraction.count({
+        where: { sessionId, status: "PENDING_REVIEW" },
+      });
+      console.log(`done ($${cost.toFixed(3)}, ${extractions} fields to review)`);
+    } catch (err) {
+      console.log(`FAILED: ${(err as Error).message?.slice(0, 100)}`);
+    }
+  }
+
+  console.log(`\nTotal research cost: ~$${totalCost.toFixed(2)} (+ SerpApi credits).`);
+  console.log(`Next: review pending extractions and approve verified fields.\n`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/research-parks.ts
+++ b/scripts/research-parks.ts
@@ -27,10 +27,17 @@ async function main() {
       ? parseInt(process.argv[limitIdx + 1], 10)
       : undefined;
 
+  // --only "<substr>": research just parks whose name contains this (case-insensitive),
+  // regardless of researchStatus. For targeted (re-)research of a single park.
+  const onlyIdx = process.argv.indexOf("--only");
+  const only = onlyIdx !== -1 ? process.argv[onlyIdx + 1] : undefined;
+
   const parks = await prisma.park.findMany({
     where: {
       address: { state: canonicalState },
-      researchStatus: { in: ["NEEDS_RESEARCH", "IN_PROGRESS"] },
+      ...(only
+        ? { name: { contains: only, mode: "insensitive" } }
+        : { researchStatus: { in: ["NEEDS_RESEARCH", "IN_PROGRESS"] } }),
     },
     select: { id: true, name: true },
     orderBy: { name: "asc" },

--- a/scripts/seed-parks.ts
+++ b/scripts/seed-parks.ts
@@ -1,0 +1,88 @@
+/**
+ * Seed Park records directly from a vetted JSON list (dev DB — targets .env).
+ * For adding specific, already-canonicalized parks (not from the ParkCandidate
+ * discovery queue). Add-only: skips any park whose name already exists.
+ *
+ * Input JSON: [{ "name": "...", "city": "...", "county": "...",
+ *                "lat": <num|null>, "lng": <num|null>, "url": "..." }]
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/seed-parks.ts Arkansas /tmp/ar-more.json
+ */
+import { readFileSync } from "node:fs";
+import { prisma } from "../src/lib/prisma";
+import { normalizeStateName } from "../src/lib/us-states";
+
+function generateSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+async function ensureUniqueSlug(base: string): Promise<string> {
+  let slug = base, n = 1;
+  while (await prisma.park.findUnique({ where: { slug } })) slug = `${base}-${++n}`;
+  return slug;
+}
+
+type Entry = { name: string; city?: string; county?: string; lat?: number | null; lng?: number | null; url?: string };
+
+async function main() {
+  const canonicalState = normalizeStateName(process.argv[2] ?? "Arkansas");
+  const file = process.argv[3];
+  if (!canonicalState || !file) {
+    console.error("Usage: seed-parks.ts <state> <list.json>");
+    process.exit(1);
+  }
+  const entries: Entry[] = JSON.parse(readFileSync(file, "utf8"));
+
+  console.log(`\nSeeding ${entries.length} park(s) into ${canonicalState} (add-only)...\n`);
+  let seeded = 0;
+  for (const e of entries) {
+    const dupe = await prisma.park.findFirst({
+      where: { name: { equals: e.name, mode: "insensitive" } },
+      select: { id: true },
+    });
+    if (dupe) {
+      console.log(`  ⏭  "${e.name}" already exists — skipped`);
+      continue;
+    }
+    const slug = await ensureUniqueSlug(generateSlug(e.name));
+    const park = await prisma.$transaction(async (tx) => {
+      const p = await tx.park.create({
+        data: {
+          name: e.name,
+          slug,
+          status: "APPROVED",
+          researchStatus: "NEEDS_RESEARCH",
+          latitude: e.lat ?? null,
+          longitude: e.lng ?? null,
+          website: e.url ?? null,
+        },
+      });
+      await tx.address.create({
+        data: { parkId: p.id, state: canonicalState, city: e.city ?? null, county: e.county ?? null },
+      });
+      // Pre-seed the official URL as a trusted DataSource so research fetches
+      // it first (avoids the "0 fields" empty-research problem).
+      if (e.url) {
+        await tx.dataSource.create({
+          data: {
+            parkId: p.id,
+            url: e.url,
+            title: `${e.name} (official)`,
+            origin: "ADMIN_ADDED",
+            isOfficial: true,
+            reliability: 80,
+          },
+        });
+      }
+      return p;
+    });
+    console.log(`  ✅ ${e.name}  →  /parks/${park.slug}  (${park.id})`);
+    seeded++;
+  }
+  console.log(`\nSeeded ${seeded}/${entries.length} new park(s). Next: research-parks.ts\n`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -4,10 +4,16 @@ export const anthropic = createAnthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
-/** Model used for structured data extraction. */
-export const EXTRACTION_MODEL = anthropic("claude-sonnet-4-20250514");
+/**
+ * Model used for structured data extraction.
+ * NOTE: `claude-sonnet-4-20250514` was retired (returns 404) — the whole
+ * research pipeline 404'd on every call until this was updated. `claude-sonnet-5`
+ * is the current Sonnet and its pricing ($3/$15 per MTok) matches the cost
+ * constants below. Bump to `claude-opus-4-8` if extraction accuracy needs it.
+ */
+export const EXTRACTION_MODEL = anthropic("claude-sonnet-5");
 
-/** Approximate cost per token for cost tracking (Sonnet pricing). */
+/** Approximate cost per token for cost tracking (Sonnet 5 pricing: $3/$15 per MTok). */
 export const COST_PER_INPUT_TOKEN = 3 / 1_000_000;
 export const COST_PER_OUTPUT_TOKEN = 15 / 1_000_000;
 


### PR DESCRIPTION
## Summary

Tooling + a critical fix behind the Arkansas data population (dev-built, verified, promoted add-only to prod). Prod Arkansas coverage went from **4 → 20 parks**, all agent-verified against authoritative sources, all with thumbnails.

### Critical fix
- **`src/lib/ai/config.ts`** — the extraction model was pinned to the **retired** `claude-sonnet-4-20250514`, which 404s on every call (the entire AI research pipeline was broken in prod). Switched to `claude-sonnet-5`. Cost constants already matched.

### AI park-population toolchain (`scripts/`)
Each ports route-only logic so it can run headless, add-only, with an accuracy gate:
- `discover-state.ts` — run state discovery → `ParkCandidate` rows
- `accept-candidates.ts` — seed vetted candidates → `Park`
- `seed-parks.ts` — seed canonicalized parks from a JSON list, pre-loading each official URL as a trusted `DataSource`
- `research-parks.ts` — run `researchPark()` (writes the PENDING_REVIEW queue); `--only <substr>` for targeted single-park research
- `list-extractions.ts` — dump the pending queue per park for verification
- `approve-extractions.ts` — the accuracy gate; apply verified extractions to live park data
- `promote-to-prod.ts` — **add-only** DEV→PROD promotion; refuses to run without an explicit `PROD_POSTGRES_URL`, never updates/deletes existing prod rows, dry-run by default
- `enrich-prod.ts` — add-only field-level merge from a verified dev twin into an existing prod park (fills empty scalars/address, unions array enums)
- `apply-field-map.ts` — apply a verified `{field: value}` map to one park (dev or prod) for targeted corrections
- `geocode-parks.ts` — Mapbox-geocode parks lacking coordinates (never overwrites)
- `backfill-map-heroes.ts` — standalone dev/prod map-hero thumbnail backfill

### `.gitignore`
- Ignore `env.production` / `env.*.local` (env files without a leading dot, e.g. from `vercel env pull`) so prod secrets can't be committed by accident.

## Notes
- Scripts run locally with `env -u ANTHROPIC_BASE_URL npx tsx --env-file=.env --env-file=.env.local …`.
- All prod writes performed via these scripts were add-only or corrective; the promotion/enrichment dry-runs were reviewed before `--commit`.
- The responsive-UI commit that previously rode along on this branch has been split out into #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
