### PR TITLE
feat(ui): responsive layout for wide screens + mobile nav/filters

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  --breakpoint-3xl: 120rem;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,7 +1,16 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, CircleUser, MessageSquare, PlusCircle } from "lucide-react";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { ArrowLeft, CircleUser, MessageSquare, Menu, PlusCircle } from "lucide-react";
 import Link from "next/link";
 import { UserMenu } from "./UserMenu";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -20,13 +29,26 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ user, showBackButton }: AppHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close the mobile menu if the viewport grows to desktop, where its trigger
+  // is hidden and the links render inline.
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const closeIfDesktop = () => {
+      if (mq.matches) setMenuOpen(false);
+    };
+    mq.addEventListener("change", closeIfDesktop);
+    return () => mq.removeEventListener("change", closeIfDesktop);
+  }, []);
+
   const handleSignOut = async () => {
     await signOut({ callbackUrl: "/" });
   };
 
   return (
     <header className="bg-card/95 backdrop-blur-sm border-b border-border shadow-sm z-20">
-      <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-3">
+      <div className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-6 py-3 flex items-center gap-3">
         {showBackButton && (
           <Button asChild variant="ghost" size="sm" className="mr-2">
             <Link href="/" className="flex items-center gap-2">
@@ -44,7 +66,8 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
         <span className="ml-1 inline-flex items-center text-[10px] px-2 py-0.5 rounded-md bg-primary/15 text-primary border border-primary/25 font-bold uppercase tracking-wider">
           beta
         </span>
-        <div className="ml-auto flex items-center gap-3">
+        {/* Desktop nav — hidden on mobile, moved into the sheet below */}
+        <nav className="ml-auto hidden items-center gap-3 lg:flex">
           <Button asChild variant="ghost" size="sm">
             <Link href="/reviews" className="flex items-center gap-2">
               <MessageSquare className="w-4 h-4" />
@@ -67,16 +90,62 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
               </Link>
             </Button>
           )}
-        </div>
+        </nav>
 
-        <ThemeToggle />
+        {/* Right-side controls: theme + auth stay visible at every size. On
+            mobile the ml-auto lives here since the desktop nav is hidden. */}
+        <div className="ml-auto flex items-center gap-2 lg:ml-4">
+          <ThemeToggle />
 
-        <div className="ml-4">
           {user ? (
             <UserMenu user={user} onSignOut={handleSignOut} />
           ) : (
             <LoginDialog />
           )}
+
+          {/* Mobile menu — surfaces the nav links hidden above */}
+          <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+            <SheetTrigger asChild className="lg:hidden">
+              <Button variant="ghost" size="icon-sm" aria-label="Open menu">
+                <Menu className="h-5 w-5" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-72">
+              <SheetHeader>
+                <SheetTitle>Menu</SheetTitle>
+              </SheetHeader>
+              <nav className="flex flex-col gap-1 px-2">
+                <SheetClose asChild>
+                  <Button asChild variant="ghost" className="justify-start">
+                    <Link href="/reviews" className="flex items-center gap-2">
+                      <MessageSquare className="w-4 h-4" />
+                      Park Reviews
+                    </Link>
+                  </Button>
+                </SheetClose>
+
+                <SheetClose asChild>
+                  <Button asChild variant="ghost" className="justify-start">
+                    <Link href="/submit" className="flex items-center gap-2">
+                      <PlusCircle className="w-4 h-4" />
+                      Submit Park
+                    </Link>
+                  </Button>
+                </SheetClose>
+
+                {user && (
+                  <SheetClose asChild>
+                    <Button asChild variant="ghost" className="justify-start">
+                      <Link href="/profile" className="flex items-center gap-2">
+                        <CircleUser className="w-4 h-4" />
+                        My Profile
+                      </Link>
+                    </Button>
+                  </SheetClose>
+                )}
+              </nav>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </header>

--- a/src/components/layout/SearchHeader.tsx
+++ b/src/components/layout/SearchHeader.tsx
@@ -21,6 +21,8 @@ interface SearchHeaderProps {
   locationLoading?: boolean;
   onUseMyLocation?: () => void;
   onClearLocation?: () => void;
+  /** Opens the filters sheet (mobile only — the sidebar is inline on desktop). */
+  onOpenFilters?: () => void;
 }
 
 export function SearchHeader({
@@ -32,14 +34,15 @@ export function SearchHeader({
   locationLoading = false,
   onUseMyLocation,
   onClearLocation,
+  onOpenFilters,
 }: SearchHeaderProps) {
   const handleSortChange = (value: string) => {
     onSortChange(value as SortOption);
   };
 
   return (
-    <div className="max-w-7xl mx-auto px-6 py-4">
-      <div className="bg-card p-3 rounded-lg shadow-sm border flex items-center gap-4">
+    <div className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-6 py-4">
+      <div className="bg-card p-3 rounded-lg shadow-sm border flex items-center gap-2 sm:gap-4">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
@@ -76,9 +79,21 @@ export function SearchHeader({
               </span>
             </Button>
           )}
-          <Filter className="w-4 h-4 text-muted-foreground" />
+          {/* Mobile filters trigger — the sidebar is inline on desktop, so this
+              only appears below lg. Opens the shared filters sheet. */}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOpenFilters}
+            className="flex h-9 items-center gap-1.5 text-xs lg:hidden"
+            aria-label="Open filters"
+            title="Filters"
+          >
+            <Filter className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">Filters</span>
+          </Button>
           <Select onValueChange={handleSortChange} value={sortOption}>
-            <SelectTrigger className="w-40">
+            <SelectTrigger className="w-32 sm:w-40">
               <SelectValue placeholder="Sort" />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/parks/SearchFiltersPanel.tsx
+++ b/src/components/parks/SearchFiltersPanel.tsx
@@ -211,7 +211,7 @@ export function SearchFiltersPanel({
     (sparkArrestorRequired ? 1 : 0);
 
   return (
-    <div className="md:col-span-1 bg-card p-4 rounded-lg shadow-sm border divide-y divide-border/60">
+    <div className="w-full bg-card p-4 rounded-lg shadow-sm border divide-y divide-border/60">
       {/* Header */}
       <div className="flex items-center justify-between pb-3">
         <h2 className="text-sm font-bold uppercase tracking-widest text-foreground">

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -17,6 +17,12 @@ import { ParkCard } from "@/components/parks/ParkCard";
 import { RouteList } from "@/features/route-planner/RouteList";
 import { MyRoutesOverlayPanel } from "@/features/route-planner/MyRoutesOverlayPanel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { LayoutGrid, Map } from "lucide-react";
 
 // Dynamically import MapView to avoid SSR issues with Leaflet
@@ -208,6 +214,59 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
       }
     : null;
 
+  // Mobile filters live in a slide-in sheet; on desktop the sidebar is inline.
+  // Close the sheet if the viewport grows to desktop so it can't linger open
+  // behind the (now hidden) trigger.
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const closeIfDesktop = () => {
+      if (mq.matches) setFiltersOpen(false);
+    };
+    mq.addEventListener("change", closeIfDesktop);
+    return () => mq.removeEventListener("change", closeIfDesktop);
+  }, []);
+
+  const filtersPanel = (
+    <SearchFiltersPanel
+      selectedState={selectedState}
+      onStateChange={setSelectedState}
+      availableStates={availableStates}
+      selectedTerrains={selectedTerrains}
+      onTerrainsChange={setSelectedTerrains}
+      selectedAmenities={selectedAmenities}
+      onAmenitiesChange={setSelectedAmenities}
+      selectedCamping={selectedCamping}
+      onCampingChange={setSelectedCamping}
+      selectedVehicleTypes={selectedVehicleTypes}
+      onVehicleTypesChange={setSelectedVehicleTypes}
+      minTrailMiles={minTrailMiles}
+      onMinTrailMilesChange={setMinTrailMiles}
+      maxTrailMiles={maxTrailMiles}
+      minAcres={minAcres}
+      onMinAcresChange={setMinAcres}
+      maxAcres={maxAcres}
+      minRating={minRating}
+      onMinRatingChange={setMinRating}
+      selectedOwnership={selectedOwnership}
+      onOwnershipChange={setSelectedOwnership}
+      permitRequired={permitRequired}
+      onPermitRequiredChange={setPermitRequired}
+      membershipRequired={membershipRequired}
+      onMembershipRequiredChange={setMembershipRequired}
+      flagsRequired={flagsRequired}
+      onFlagsRequiredChange={setFlagsRequired}
+      sparkArrestorRequired={sparkArrestorRequired}
+      onSparkArrestorRequiredChange={setSparkArrestorRequired}
+      onClearFilters={clearAllFilters}
+      showSavedDefaultsControls={isAuthenticated}
+      hasSavedDefault={hasPreference}
+      isSavingDefault={isSavingPreference}
+      onSaveAsDefault={handleSaveAsDefault}
+      onResetToDefault={handleResetToDefault}
+    />
+  );
+
   return (
     <div className="min-h-screen bg-background">
       {/* Sticky header */}
@@ -225,49 +284,30 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
         locationLoading={locationLoading}
         onUseMyLocation={handleUseMyLocation}
         onClearLocation={handleClearLocation}
+        onOpenFilters={() => setFiltersOpen(true)}
       />
 
-      <main className="max-w-7xl mx-auto px-6 pb-8">
-        <div className="grid lg:grid-cols-5 gap-6 items-start">
-          <SearchFiltersPanel
-            selectedState={selectedState}
-            onStateChange={setSelectedState}
-            availableStates={availableStates}
-            selectedTerrains={selectedTerrains}
-            onTerrainsChange={setSelectedTerrains}
-            selectedAmenities={selectedAmenities}
-            onAmenitiesChange={setSelectedAmenities}
-            selectedCamping={selectedCamping}
-            onCampingChange={setSelectedCamping}
-            selectedVehicleTypes={selectedVehicleTypes}
-            onVehicleTypesChange={setSelectedVehicleTypes}
-            minTrailMiles={minTrailMiles}
-            onMinTrailMilesChange={setMinTrailMiles}
-            maxTrailMiles={maxTrailMiles}
-            minAcres={minAcres}
-            onMinAcresChange={setMinAcres}
-            maxAcres={maxAcres}
-            minRating={minRating}
-            onMinRatingChange={setMinRating}
-            selectedOwnership={selectedOwnership}
-            onOwnershipChange={setSelectedOwnership}
-            permitRequired={permitRequired}
-            onPermitRequiredChange={setPermitRequired}
-            membershipRequired={membershipRequired}
-            onMembershipRequiredChange={setMembershipRequired}
-            flagsRequired={flagsRequired}
-            onFlagsRequiredChange={setFlagsRequired}
-            sparkArrestorRequired={sparkArrestorRequired}
-            onSparkArrestorRequiredChange={setSparkArrestorRequired}
-            onClearFilters={clearAllFilters}
-            showSavedDefaultsControls={isAuthenticated}
-            hasSavedDefault={hasPreference}
-            isSavingDefault={isSavingPreference}
-            onSaveAsDefault={handleSaveAsDefault}
-            onResetToDefault={handleResetToDefault}
-          />
+      <main className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-6 pb-8">
+        {/* Mobile filters — opened by the funnel button in the search bar.
+            Rendered in a slide-in sheet so it doesn't stack a full-height wall
+            above the results. On desktop the sidebar below shows inline. */}
+        <Sheet open={filtersOpen} onOpenChange={setFiltersOpen}>
+          <SheetContent
+            side="left"
+            className="w-[85vw] max-w-sm gap-0 overflow-y-auto p-4"
+          >
+            <SheetHeader className="px-0 pt-0">
+              <SheetTitle>Filters</SheetTitle>
+            </SheetHeader>
+            {filtersPanel}
+          </SheetContent>
+        </Sheet>
 
-          <div className="lg:col-span-4">
+        <div className="flex flex-col lg:flex-row gap-6 items-start">
+          {/* Desktop sidebar — hidden on mobile, shown in the sheet above */}
+          <div className="hidden w-72 shrink-0 lg:block">{filtersPanel}</div>
+
+          <div className="flex-1 min-w-0 w-full">
             <Tabs
               value={activeView}
               onValueChange={(v) => setActiveView(v as "list" | "map")}
@@ -284,7 +324,7 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
               </TabsList>
 
               <TabsContent value="list" className="mt-0">
-                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 gap-5">
                   {filteredParks.map((park) => (
                     <ParkCard
                       key={park.id}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const sheetVariants = cva(
+  "bg-background fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  },
+);
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> &
+  VariantProps<typeof sheetVariants> & {
+    showCloseButton?: boolean;
+  }) {
+  return (
+    <SheetPortal data-slot="sheet-portal">
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            className="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -27,6 +27,23 @@ vi.mock("next/navigation", () => ({
 // Mock Next.js server-only
 vi.mock("server-only", () => ({}));
 
+// jsdom doesn't implement matchMedia; provide a minimal stub so components that
+// read viewport media queries (responsive nav in AppHeader/OffroadParksApp) can
+// mount in tests. Defaults to no match (desktop-first render).
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }),
+});
+
 // Mock environment variables
 process.env.NEXTAUTH_URL = "http://localhost:3000";
 process.env.NEXTAUTH_SECRET = "test-secret";


### PR DESCRIPTION
## Summary

Responsive layout pass for the parks app — makes the UI work across wide desktop screens and mobile.

- **`AppHeader`** — nav links collapse into a mobile sheet menu; theme + auth controls stay visible at every breakpoint.
- **`SearchHeader` / `SearchFiltersPanel`** — responsive filter layout.
- **`OffroadParksApp`** — wide-screen (`2xl`/`3xl`) max-width handling and layout adjustments.
- **`ui/sheet.tsx`** — new slide-out sheet primitive used by the mobile nav.
- **`globals.css`** — supporting style.

Split out of #148 (Arkansas data toolchain) so the data work and this UI change review and merge independently. No functional/data overlap with that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
