### PR TITLE
feat(auth): Google-only sign-in with standard Google button

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -16,10 +16,49 @@ import { LogIn, Mail } from "lucide-react";
 
 const CALLBACK_URL = "/";
 
+// Passwordless email magic-link sign-in (OP-97) is temporarily hidden while
+// we go Google-only. The UI, state, and handler below are kept intact behind
+// this flag so email sign-in can be restored by flipping it back to `true`.
+const EMAIL_LOGIN_ENABLED = false;
+
 /**
- * Sign-in dialog offering both Google OAuth and passwordless email
- * magic-link (OP-97). The email path calls the Auth.js "resend" provider,
- * which sends the link through our shared sender (dev fallback logs it).
+ * Google "G" logo mark, inline SVG (no network request) so the button looks
+ * like a standard Google sign-in button in both light and dark mode.
+ */
+function GoogleLogo() {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      width="18"
+      height="18"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fill="#FFC107"
+        d="M43.6 20.5H42V20H24v8h11.3c-1.6 4.7-6.1 8-11.3 8-6.6 0-12-5.4-12-12s5.4-12 12-12c3.1 0 5.8 1.1 8 3l6-6C34.5 5.1 29.5 3 24 3 12.4 3 3 12.4 3 24s9.4 21 21 21 21-9.4 21-21c0-1.3-.1-2.5-.4-3.5z"
+      />
+      <path
+        fill="#FF3D00"
+        d="M6.3 14.7l6.6 4.8C14.5 15.1 18.9 12 24 12c3.1 0 5.8 1.1 8 3l6-6C34.5 5.1 29.5 3 24 3 16.3 3 9.7 7.3 6.3 14.7z"
+      />
+      <path
+        fill="#4CAF50"
+        d="M24 45c5.4 0 10.3-1.8 14-5.1l-6.5-5.4C29.5 36.6 26.9 37.5 24 37.5c-5.2 0-9.6-3.3-11.2-7.9l-6.5 5C9.5 40.6 16.2 45 24 45z"
+      />
+      <path
+        fill="#1976D2"
+        d="M43.6 20.5H42V20H24v8h11.3c-.8 2.3-2.2 4.2-4.1 5.6l6.5 5.4C40.9 36.1 45 30.5 45 24c0-1.3-.1-2.5-.4-3.5z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Sign-in dialog offering Google OAuth (and, when EMAIL_LOGIN_ENABLED is
+ * flipped back on, passwordless email magic-link sign-in via OP-97's
+ * Auth.js "resend" provider, which sends the link through our shared sender
+ * with a dev fallback that logs it).
  */
 export function LoginDialog() {
   const [email, setEmail] = useState("");
@@ -62,7 +101,7 @@ export function LoginDialog() {
         <DialogHeader>
           <DialogTitle>Sign in to Offroad Parks</DialogTitle>
           <DialogDescription>
-            Continue with Google, or get a one-time sign-in link by email.
+            Sign in to save favorites, plan routes, and leave reviews.
           </DialogDescription>
         </DialogHeader>
 
@@ -78,38 +117,43 @@ export function LoginDialog() {
           <div className="space-y-4">
             <Button
               variant="outline"
-              className="w-full"
+              className="w-full h-11 gap-3 border-gray-300 bg-white font-medium text-gray-700 shadow-sm hover:bg-gray-50 hover:text-gray-700 dark:border-gray-300 dark:bg-white dark:text-gray-700 dark:hover:bg-gray-50 dark:hover:text-gray-700"
               onClick={() => signIn("google", { callbackUrl: CALLBACK_URL })}
             >
-              Continue with Google
+              <GoogleLogo />
+              Sign in with Google
             </Button>
 
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
-              <span className="h-px flex-1 bg-border" />
-              or
-              <span className="h-px flex-1 bg-border" />
-            </div>
+            {EMAIL_LOGIN_ENABLED && (
+              <>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span className="h-px flex-1 bg-border" />
+                  or
+                  <span className="h-px flex-1 bg-border" />
+                </div>
 
-            <form onSubmit={handleEmailSignIn} className="space-y-2">
-              <Input
-                type="email"
-                required
-                autoComplete="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                aria-label="Email address"
-              />
-              <Button
-                type="submit"
-                className="w-full gap-2"
-                disabled={submitting}
-              >
-                <Mail className="w-4 h-4" />
-                {submitting ? "Sending…" : "Email me a sign-in link"}
-              </Button>
-              {error && <p className="text-sm text-destructive">{error}</p>}
-            </form>
+                <form onSubmit={handleEmailSignIn} className="space-y-2">
+                  <Input
+                    type="email"
+                    required
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    aria-label="Email address"
+                  />
+                  <Button
+                    type="submit"
+                    className="w-full gap-2"
+                    disabled={submitting}
+                  >
+                    <Mail className="w-4 h-4" />
+                    {submitting ? "Sending…" : "Email me a sign-in link"}
+                  </Button>
+                  {error && <p className="text-sm text-destructive">{error}</p>}
+                </form>
+              </>
+            )}
           </div>
         )}
       </DialogContent>

--- a/test/components/auth/LoginDialog.test.tsx
+++ b/test/components/auth/LoginDialog.test.tsx
@@ -21,14 +21,18 @@ describe("LoginDialog", () => {
     expect(screen.getByText("Sign In")).toBeInTheDocument();
   });
 
-  it("reveals Google and email options when opened", async () => {
+  it("reveals the Google option when opened (email login hidden)", async () => {
     const user = userEvent.setup();
     render(<LoginDialog />);
 
     await user.click(screen.getByText("Sign In"));
 
-    expect(await screen.findByText("Continue with Google")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Sign in with Google"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("you@example.com"),
+    ).not.toBeInTheDocument();
   });
 
   it("calls Google sign-in with a callback URL", async () => {
@@ -36,44 +40,50 @@ describe("LoginDialog", () => {
     render(<LoginDialog />);
 
     await user.click(screen.getByText("Sign In"));
-    await user.click(await screen.findByText("Continue with Google"));
+    await user.click(await screen.findByText("Sign in with Google"));
 
     expect(signInMock).toHaveBeenCalledWith("google", { callbackUrl: "/" });
   });
 
-  it("sends a magic link via the resend provider and confirms", async () => {
-    const user = userEvent.setup();
-    render(<LoginDialog />);
+  // Passwordless email magic-link sign-in (OP-97) is hidden behind the
+  // EMAIL_LOGIN_ENABLED flag in LoginDialog.tsx. These tests exercise that
+  // path and are skipped while the flag is off; re-enable them alongside the
+  // flag.
+  describe.skip("email magic-link sign-in (disabled via EMAIL_LOGIN_ENABLED)", () => {
+    it("sends a magic link via the resend provider and confirms", async () => {
+      const user = userEvent.setup();
+      render(<LoginDialog />);
 
-    await user.click(screen.getByText("Sign In"));
-    await user.type(
-      await screen.findByPlaceholderText("you@example.com"),
-      "rider@example.com",
-    );
-    await user.click(screen.getByText(/Email me a sign-in link/));
+      await user.click(screen.getByText("Sign In"));
+      await user.type(
+        await screen.findByPlaceholderText("you@example.com"),
+        "rider@example.com",
+      );
+      await user.click(screen.getByText(/Email me a sign-in link/));
 
-    expect(signInMock).toHaveBeenCalledWith("resend", {
-      email: "rider@example.com",
-      redirect: false,
-      callbackUrl: "/",
+      expect(signInMock).toHaveBeenCalledWith("resend", {
+        email: "rider@example.com",
+        redirect: false,
+        callbackUrl: "/",
+      });
+      expect(await screen.findByText("Check your email")).toBeInTheDocument();
     });
-    expect(await screen.findByText("Check your email")).toBeInTheDocument();
-  });
 
-  it("shows an error when the magic-link request fails", async () => {
-    signInMock.mockResolvedValue({ error: "EmailSignInError" } as never);
-    const user = userEvent.setup();
-    render(<LoginDialog />);
+    it("shows an error when the magic-link request fails", async () => {
+      signInMock.mockResolvedValue({ error: "EmailSignInError" } as never);
+      const user = userEvent.setup();
+      render(<LoginDialog />);
 
-    await user.click(screen.getByText("Sign In"));
-    await user.type(
-      await screen.findByPlaceholderText("you@example.com"),
-      "rider@example.com",
-    );
-    await user.click(screen.getByText(/Email me a sign-in link/));
+      await user.click(screen.getByText("Sign In"));
+      await user.type(
+        await screen.findByPlaceholderText("you@example.com"),
+        "rider@example.com",
+      );
+      await user.click(screen.getByText(/Email me a sign-in link/));
 
-    await waitFor(() =>
-      expect(screen.getByText(/Something went wrong/)).toBeInTheDocument(),
-    );
+      await waitFor(() =>
+        expect(screen.getByText(/Something went wrong/)).toBeInTheDocument(),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Temporarily hides passwordless email magic-link sign-in (the "or" divider and email input/submit form) in `src/components/auth/LoginDialog.tsx`, gated behind a single `EMAIL_LOGIN_ENABLED = false` constant. All related state, the `handleEmailSignIn` handler, and imports are kept intact behind the flag — to re-enable, flip `EMAIL_LOGIN_ENABLED` back to `true` (no other code changes needed).
- Restyles the Google button to look like a standard Google sign-in button: white background with a subtle border (readable in both light and dark mode), inline SVG of the official 4-color Google "G" mark (no network image), "Sign in with Google" label, full width, comfortable height, and a clear hover state.
- Updates `DialogDescription` to "Sign in to save favorites, plan routes, and leave reviews." so it no longer promises email sign-in.
- Updates `test/components/auth/LoginDialog.test.tsx` to match: Google-only assertions run normally; the two email magic-link tests are preserved but skipped via `describe.skip` (with a comment pointing back to `EMAIL_LOGIN_ENABLED`) so they're easy to re-enable alongside the flag.

## Validation
- `npm run lint` — 0 errors (15 pre-existing unrelated warnings)
- `npx tsc --noEmit` — clean
- `npm run test` — 158 files, 2099 passed, 2 skipped (the intentionally-disabled email tests)
- Live browser preview was not exercised: this worktree has no `.claude/launch.json`, and the shared dev-server infra available required a Postgres DB (`POSTGRES_PRISMA_URL`) not configured in this sandbox. Static checks (lint/tsc/test) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)