### PR TITLE
feat(admin): redesign AI Research into Discover / Research / Review workflow

### DIFF
--- a/src/app/admin/ai-research/conflicts/page.tsx
+++ b/src/app/admin/ai-research/conflicts/page.tsx
@@ -1,35 +1,7 @@
-// TODO OP-84: Field Conflict Resolution UI
-// When multiple sources disagree on a field value, surface conflicts
-// in review queue with side-by-side source comparison.
+import { redirect } from "next/navigation";
 
-export default function ConflictsPage() {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground">
-          Field Conflicts
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Review and resolve conflicting field values from multiple sources.
-        </p>
-      </div>
-
-      <div className="bg-card rounded-lg border border-border p-12 text-center">
-        <div className="text-muted-foreground text-4xl mb-4">
-          {"{ }"}
-        </div>
-        <h2 className="text-lg font-semibold text-foreground">
-          Coming Soon — OP-84
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground max-w-md mx-auto">
-          Field Conflict Resolution UI. When multiple sources disagree on a
-          field value, this page will show side-by-side comparisons with source
-          reliability context and smart resolution suggestions.
-        </p>
-        <p className="mt-4 text-xs text-muted-foreground">
-          Depends on OP-83 (Multi-Source Cross-Validation)
-        </p>
-      </div>
-    </div>
-  );
+// Field conflicts are now surfaced inline within the Review tab (multiple pending
+// proposals for the same field are shown side by side), so this standalone route redirects there.
+export default function ConflictsRedirectPage() {
+  redirect("/admin/ai-research/review");
 }

--- a/src/app/admin/ai-research/discovery/page.tsx
+++ b/src/app/admin/ai-research/discovery/page.tsx
@@ -47,9 +47,10 @@ export default async function ParkDiscoveryPage({
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-foreground">Park Discovery</h1>
+        <h2 className="text-xl font-semibold text-foreground">Discover New Parks</h2>
         <p className="text-sm text-muted-foreground mt-1">
-          Review AI-discovered park candidates and seed them into the database.
+          Job 1 of 3. Search a state to find parks not yet in the database, then accept the good
+          candidates to seed them. Once seeded, switch to the Research tab to enrich their data.
         </p>
       </div>
 

--- a/src/app/admin/ai-research/layout.tsx
+++ b/src/app/admin/ai-research/layout.tsx
@@ -1,0 +1,31 @@
+import { prisma } from "@/lib/prisma";
+import { BrainCircuit } from "lucide-react";
+import { AIResearchTabs } from "@/components/admin/AIResearchTabs";
+
+export default async function AIResearchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pendingReviewCount = await prisma.fieldExtraction.count({
+    where: { status: "PENDING_REVIEW" },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <BrainCircuit className="w-6 h-6 text-primary" />
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">AI Research</h1>
+          <p className="text-sm text-muted-foreground">
+            Discover new parks, research existing ones, and review proposed changes before they go live.
+          </p>
+        </div>
+      </div>
+
+      <AIResearchTabs pendingReviewCount={pendingReviewCount} />
+
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/app/admin/ai-research/page.tsx
+++ b/src/app/admin/ai-research/page.tsx
@@ -2,11 +2,14 @@ import { prisma } from "@/lib/prisma";
 import { getDomainAccuracyStats } from "@/lib/ai/feedback-loop";
 import Link from "next/link";
 import {
-  BrainCircuit,
   DollarSign,
   FileSearch,
-  AlertCircle,
   BarChart3,
+  Search,
+  FlaskConical,
+  ClipboardCheck,
+  ArrowRight,
+  BrainCircuit,
 } from "lucide-react";
 
 export default async function AIResearchPage() {
@@ -17,6 +20,7 @@ export default async function AIResearchPage() {
     researched,
     maintenance,
     pendingReviewCount,
+    pendingCandidates,
     totalSessions,
     costResult,
     recentSessions,
@@ -28,6 +32,7 @@ export default async function AIResearchPage() {
     prisma.park.count({ where: { researchStatus: "RESEARCHED" } }),
     prisma.park.count({ where: { researchStatus: "MAINTENANCE" } }),
     prisma.fieldExtraction.count({ where: { status: "PENDING_REVIEW" } }),
+    prisma.parkCandidate.count({ where: { status: "PENDING" } }),
     prisma.researchSession.count(),
     prisma.researchSession.aggregate({ _sum: { estimatedCostUSD: true } }),
     prisma.researchSession.findMany({
@@ -42,49 +47,41 @@ export default async function AIResearchPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-foreground">AI Research</h1>
-        {pendingReviewCount > 0 && (
-          <Link
-            href="/admin/ai-research/pending"
-            className="inline-flex items-center gap-2 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 px-4 py-2 text-sm font-medium text-yellow-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900/40 hover:bg-yellow-100 dark:hover:bg-yellow-900/30 transition-colors"
-          >
-            <AlertCircle className="w-4 h-4" />
-            {pendingReviewCount} pending review{pendingReviewCount !== 1 ? "s" : ""}
-          </Link>
-        )}
+      {/* Three jobs */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <JobCard
+          href="/admin/ai-research/discovery"
+          icon={<Search className="w-5 h-5" />}
+          title="Discover"
+          description="Find parks not yet in the database and seed the good ones."
+          metricLabel="candidates awaiting review"
+          metricValue={pendingCandidates}
+        />
+        <JobCard
+          href="/admin/ai-research/research"
+          icon={<FlaskConical className="w-5 h-5" />}
+          title="Research"
+          description="Run AI on existing parks to gather more and better data. Research continuously — proposed edits accumulate per park."
+          metricLabel="parks still need research"
+          metricValue={needsResearch}
+        />
+        <JobCard
+          href="/admin/ai-research/review"
+          icon={<ClipboardCheck className="w-5 h-5" />}
+          title="Review"
+          description="Approve, edit, or deny the AI's proposed field changes. Nothing goes live until you approve it."
+          metricLabel="proposed changes pending"
+          metricValue={pendingReviewCount}
+          highlight={pendingReviewCount > 0}
+        />
       </div>
 
-      {/* Stats Grid */}
+      {/* Supporting stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="rounded-lg border border-border bg-card p-6">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <BrainCircuit className="w-4 h-4" />
-            Total Parks
-          </div>
-          <p className="mt-2 text-2xl font-bold text-foreground">{totalParks}</p>
-        </div>
-        <div className="rounded-lg border border-border bg-card p-6">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <AlertCircle className="w-4 h-4" />
-            Pending Reviews
-          </div>
-          <p className="mt-2 text-2xl font-bold text-yellow-600 dark:text-yellow-400">{pendingReviewCount}</p>
-        </div>
-        <div className="rounded-lg border border-border bg-card p-6">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <FileSearch className="w-4 h-4" />
-            Research Sessions
-          </div>
-          <p className="mt-2 text-2xl font-bold text-foreground">{totalSessions}</p>
-        </div>
-        <div className="rounded-lg border border-border bg-card p-6">
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <DollarSign className="w-4 h-4" />
-            Total Cost
-          </div>
-          <p className="mt-2 text-2xl font-bold text-foreground">${totalCost.toFixed(2)}</p>
-        </div>
+        <StatCard icon={<BrainCircuit className="w-4 h-4" />} label="Total Parks" value={totalParks} />
+        <StatCard icon={<FileSearch className="w-4 h-4" />} label="Research Sessions" value={totalSessions} />
+        <StatCard icon={<DollarSign className="w-4 h-4" />} label="Total Cost" value={`$${totalCost.toFixed(2)}`} />
+        <StatCard icon={<ClipboardCheck className="w-4 h-4" />} label="Pending Reviews" value={pendingReviewCount} />
       </div>
 
       {/* Research Status Breakdown */}
@@ -181,7 +178,7 @@ export default async function AIResearchPage() {
                 {recentSessions.map((session) => (
                   <tr key={session.id} className="hover:bg-accent/50 transition-colors">
                     <td className="px-4 py-3 text-sm font-medium text-foreground">
-                      <Link href={`/parks/${session.park.slug}`} className="hover:text-primary">
+                      <Link href={`/admin/ai-research/research/${session.parkId}`} className="hover:text-primary">
                         {session.park.name}
                       </Link>
                     </td>
@@ -207,6 +204,60 @@ export default async function AIResearchPage() {
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function JobCard({
+  href,
+  icon,
+  title,
+  description,
+  metricLabel,
+  metricValue,
+  highlight,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  metricLabel: string;
+  metricValue: number;
+  highlight?: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      className={`group flex flex-col rounded-lg border bg-card p-6 transition-colors hover:border-primary/60 hover:bg-accent/30 ${
+        highlight ? "border-yellow-300 dark:border-yellow-900/50" : "border-border"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-primary">
+          {icon}
+          <span className="text-base font-semibold text-foreground">{title}</span>
+        </div>
+        <ArrowRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground flex-1">{description}</p>
+      <p className="mt-4 text-sm">
+        <span className={`text-2xl font-bold ${highlight ? "text-yellow-600 dark:text-yellow-400" : "text-foreground"}`}>
+          {metricValue}
+        </span>{" "}
+        <span className="text-muted-foreground">{metricLabel}</span>
+      </p>
+    </Link>
+  );
+}
+
+function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string | number }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-2 text-2xl font-bold text-foreground">{value}</p>
     </div>
   );
 }

--- a/src/app/admin/ai-research/pending/page.tsx
+++ b/src/app/admin/ai-research/pending/page.tsx
@@ -1,57 +1,6 @@
-import { prisma } from "@/lib/prisma";
-import { getCurrentFieldValue } from "@/lib/ai/research-lifecycle";
-import type { DbPark, FieldExtractionSummary } from "@/lib/types";
-import { FieldExtractionReview } from "@/components/admin/FieldExtractionReview";
+import { redirect } from "next/navigation";
 
-export default async function PendingReviewsPage() {
-  const extractions = await prisma.fieldExtraction.findMany({
-    where: { status: "PENDING_REVIEW" },
-    include: {
-      park: {
-        include: {
-          terrain: true,
-          amenities: true,
-          camping: true,
-          vehicleTypes: true,
-          address: true,
-        },
-      },
-      dataSource: { select: { url: true, title: true } },
-    },
-    orderBy: { createdAt: "desc" },
-  });
-
-  const summaries: FieldExtractionSummary[] = extractions.map((e) => ({
-    id: e.id,
-    parkId: e.parkId,
-    parkName: e.park.name,
-    parkSlug: e.park.slug,
-    fieldName: e.fieldName,
-    extractedValue: e.extractedValue,
-    currentValue: getCurrentFieldValue(e.park as unknown as DbPark, e.fieldName),
-    confidence: e.confidence,
-    confidenceScore: e.confidenceScore,
-    status: e.status,
-    sourcesChecked: e.sourcesChecked,
-    sourceUrl: e.dataSource?.url ?? null,
-    sourceTitle: e.dataSource?.title ?? null,
-    sessionId: e.sessionId,
-    createdAt: e.createdAt.toISOString(),
-  }));
-
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-foreground">Review Queue</h1>
-        <p className="text-sm text-muted-foreground">{summaries.length} pending extraction{summaries.length !== 1 ? "s" : ""}</p>
-      </div>
-      {summaries.length === 0 ? (
-        <div className="rounded-lg border border-border bg-card p-12 text-center">
-          <p className="text-muted-foreground">No extractions pending review.</p>
-        </div>
-      ) : (
-        <FieldExtractionReview extractions={summaries} />
-      )}
-    </div>
-  );
+// The old "Review Queue"/"pending" route now lives under the clearer "Review" tab.
+export default function PendingRedirectPage() {
+  redirect("/admin/ai-research/review");
 }

--- a/src/app/admin/ai-research/research/[parkId]/page.tsx
+++ b/src/app/admin/ai-research/research/[parkId]/page.tsx
@@ -1,0 +1,190 @@
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, ExternalLink, Layers, Database, ClipboardCheck } from "lucide-react";
+import { getCurrentFieldValue } from "@/lib/ai/research-lifecycle";
+import type {
+  DbPark,
+  DataSourceSummary,
+  DomainReliabilitySummary,
+  FieldExtractionSummary,
+} from "@/lib/types";
+import { SourceManagementTable } from "@/components/admin/SourceManagementTable";
+import { DomainReliabilityTable } from "@/components/admin/DomainReliabilityTable";
+import { FieldExtractionReview } from "@/components/admin/FieldExtractionReview";
+
+export default async function ParkResearchWorkspacePage({
+  params,
+}: {
+  params: Promise<{ parkId: string }>;
+}) {
+  const { parkId } = await params;
+
+  const park = await prisma.park.findUnique({
+    where: { id: parkId },
+    include: {
+      terrain: true,
+      amenities: true,
+      camping: true,
+      vehicleTypes: true,
+      address: true,
+    },
+  });
+
+  if (!park) notFound();
+
+  const [sources, extractions, domainEntries] = await Promise.all([
+    prisma.dataSource.findMany({
+      where: { parkId },
+      orderBy: [{ reliability: "desc" }, { createdAt: "desc" }],
+    }),
+    prisma.fieldExtraction.findMany({
+      where: { parkId, status: "PENDING_REVIEW" },
+      include: { dataSource: { select: { url: true, title: true } } },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.domainReliability.findMany({ orderBy: { defaultReliability: "desc" } }),
+  ]);
+
+  const sourceSummaries: DataSourceSummary[] = sources.map((s) => ({
+    id: s.id,
+    parkId: s.parkId,
+    url: s.url,
+    type: s.type,
+    origin: s.origin,
+    title: s.title,
+    reliability: s.reliability,
+    isOfficial: s.isOfficial,
+    lastCrawledAt: s.lastCrawledAt?.toISOString() ?? null,
+    contentChanged: s.contentChanged,
+    crawlStatus: s.crawlStatus,
+    crawlError: s.crawlError,
+    approveCount: s.approveCount,
+    rejectCount: s.rejectCount,
+    createdAt: s.createdAt.toISOString(),
+  }));
+
+  const extractionSummaries: FieldExtractionSummary[] = extractions.map((e) => ({
+    id: e.id,
+    parkId: e.parkId,
+    parkName: park.name,
+    parkSlug: park.slug,
+    fieldName: e.fieldName,
+    extractedValue: e.extractedValue,
+    currentValue: getCurrentFieldValue(park as unknown as DbPark, e.fieldName),
+    confidence: e.confidence,
+    confidenceScore: e.confidenceScore,
+    status: e.status,
+    sourcesChecked: e.sourcesChecked,
+    sourceUrl: e.dataSource?.url ?? null,
+    sourceTitle: e.dataSource?.title ?? null,
+    sessionId: e.sessionId,
+    createdAt: e.createdAt.toISOString(),
+  }));
+
+  const domainSummaries: DomainReliabilitySummary[] = domainEntries.map((d) => ({
+    id: d.id,
+    domainPattern: d.domainPattern,
+    defaultReliability: d.defaultReliability,
+    isBlocked: d.isBlocked,
+    notes: d.notes,
+    createdAt: d.createdAt.toISOString(),
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/ai-research/research"
+          className="inline-flex items-center gap-1 text-sm text-primary hover:text-primary/80"
+        >
+          <ArrowLeft className="w-4 h-4" /> All parks
+        </Link>
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <h2 className="text-2xl font-bold text-foreground">{park.name}</h2>
+          <ResearchStatusBadge status={park.researchStatus} />
+          <Link
+            href={`/parks/${park.slug}`}
+            target="_blank"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink className="w-3 h-3" /> View public page
+          </Link>
+        </div>
+        <p className="text-sm text-muted-foreground mt-1">
+          Run research as many times as you like — each run crawls sources, discovers new ones, and
+          adds any findings to the proposed changes below. Nothing is applied to the live park until
+          you approve it.
+        </p>
+      </div>
+
+      {/* Proposed changes (accumulated, awaiting review) */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <ClipboardCheck className="w-5 h-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold text-foreground">Proposed Changes</h3>
+          {extractionSummaries.length > 0 && (
+            <span className="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900/50 px-2 py-0.5 text-xs font-medium">
+              {extractionSummaries.length} pending
+            </span>
+          )}
+        </div>
+        {extractionSummaries.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card p-8 text-center">
+            <p className="text-muted-foreground text-sm">
+              No proposed changes yet. Run research below to have the AI gather data for this park.
+              Anything it finds will show up here for you to approve, edit, or deny.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Approve to apply a value to the live park, or deny to discard it. You can edit a value
+              before approving. Approved and denied results also train the domain-accuracy scores.
+            </p>
+            <FieldExtractionReview extractions={extractionSummaries} />
+          </>
+        )}
+      </section>
+
+      {/* Sources + Run Research (SourceManagementTable includes the Run Research trigger) */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Database className="w-5 h-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold text-foreground">Sources &amp; Research</h3>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          These are the sources the AI reads for this park. Add trusted URLs, skip or flag bad ones,
+          then run research to extract new data.
+        </p>
+        <SourceManagementTable sources={sourceSummaries} parkId={parkId} />
+      </section>
+
+      {/* Domain reliability (supporting context) */}
+      <section className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Layers className="w-5 h-5 text-muted-foreground" />
+          <h3 className="text-lg font-semibold text-foreground">Domain Reliability</h3>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Global reliability settings that influence how much the AI trusts each domain across all parks.
+        </p>
+        <DomainReliabilityTable domains={domainSummaries} />
+      </section>
+    </div>
+  );
+}
+
+function ResearchStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    NEEDS_RESEARCH: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50",
+    IN_PROGRESS: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border-yellow-200 dark:border-yellow-900/50",
+    RESEARCHED: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50",
+    MAINTENANCE: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-900/50",
+  };
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${styles[status] || "bg-muted text-foreground border-border"}`}>
+      {status.replace("_", " ")}
+    </span>
+  );
+}

--- a/src/app/admin/ai-research/research/page.tsx
+++ b/src/app/admin/ai-research/research/page.tsx
@@ -1,0 +1,183 @@
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import { ArrowRight, FlaskConical } from "lucide-react";
+
+export default async function ResearchListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string; status?: string }>;
+}) {
+  const params = await searchParams;
+  const q = params.q?.trim() || "";
+  const statusFilter = params.status || "ALL";
+
+  const where: {
+    status: "APPROVED";
+    researchStatus?: "NEEDS_RESEARCH" | "IN_PROGRESS" | "RESEARCHED" | "MAINTENANCE";
+    name?: { contains: string; mode: "insensitive" };
+  } = { status: "APPROVED" };
+  if (statusFilter !== "ALL") {
+    where.researchStatus = statusFilter as typeof where.researchStatus;
+  }
+  if (q) {
+    where.name = { contains: q, mode: "insensitive" };
+  }
+
+  const parks = await prisma.park.findMany({
+    where,
+    select: {
+      id: true,
+      name: true,
+      researchStatus: true,
+      address: { select: { state: true } },
+      _count: {
+        select: {
+          dataSources: true,
+          fieldExtractions: { where: { status: "PENDING_REVIEW" } },
+        },
+      },
+    },
+    orderBy: [{ researchStatus: "asc" }, { name: "asc" }],
+    take: 200,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">Research Existing Parks</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Job 2 of 3. Pick a park to open its research workspace, where you can run AI research
+          repeatedly, manage its sources, and watch proposed edits accumulate. Nothing is applied
+          until you approve it on the Review tab.
+        </p>
+      </div>
+
+      {/* Search + filters */}
+      <form method="GET" className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          name="q"
+          defaultValue={q}
+          placeholder="Search parks by name..."
+          className="flex-1 min-w-[12rem] max-w-md rounded-md border border-input bg-background text-foreground px-3 py-2 text-sm focus:border-ring focus:ring-1 focus:ring-ring"
+        />
+        {statusFilter !== "ALL" && <input type="hidden" name="status" value={statusFilter} />}
+        <button
+          type="submit"
+          className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          Search
+        </button>
+      </form>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-foreground">Status:</span>
+        <StatusFilterLink label="All" value="ALL" active={statusFilter === "ALL"} q={q} />
+        <StatusFilterLink label="Needs Research" value="NEEDS_RESEARCH" active={statusFilter === "NEEDS_RESEARCH"} q={q} />
+        <StatusFilterLink label="In Progress" value="IN_PROGRESS" active={statusFilter === "IN_PROGRESS"} q={q} />
+        <StatusFilterLink label="Researched" value="RESEARCHED" active={statusFilter === "RESEARCHED"} q={q} />
+        <StatusFilterLink label="Maintenance" value="MAINTENANCE" active={statusFilter === "MAINTENANCE"} q={q} />
+      </div>
+
+      {parks.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-12 text-center">
+          <FlaskConical className="w-8 h-8 mx-auto text-muted-foreground mb-3" />
+          <p className="text-muted-foreground text-sm">
+            No parks match. {q || statusFilter !== "ALL" ? "Try clearing the filters." : "Seed parks from the Discover tab first."}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border bg-card overflow-hidden">
+          <table className="min-w-full divide-y divide-border">
+            <thead>
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Park</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">State</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Research Status</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Sources</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Proposed Changes</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {parks.map((park) => (
+                <tr key={park.id} className="hover:bg-accent/50 transition-colors">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/admin/ai-research/research/${park.id}`}
+                      className="text-sm font-medium text-primary hover:text-primary/80"
+                    >
+                      {park.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-muted-foreground">{park.address?.state ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <ResearchStatusBadge status={park.researchStatus} />
+                  </td>
+                  <td className="px-4 py-3 text-sm text-foreground">{park._count.dataSources}</td>
+                  <td className="px-4 py-3">
+                    {park._count.fieldExtractions > 0 ? (
+                      <span className="inline-flex items-center rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-900/50 px-2 py-0.5 text-xs font-medium">
+                        {park._count.fieldExtractions} pending
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">{"—"}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <Link
+                      href={`/admin/ai-research/research/${park.id}`}
+                      className="inline-flex items-center gap-1 text-sm text-primary hover:text-primary/80"
+                    >
+                      Open <ArrowRight className="w-4 h-4" />
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusFilterLink({
+  label,
+  value,
+  active,
+  q,
+}: {
+  label: string;
+  value: string;
+  active: boolean;
+  q: string;
+}) {
+  const query = new URLSearchParams();
+  if (value !== "ALL") query.set("status", value);
+  if (q) query.set("q", q);
+  const href = `/admin/ai-research/research${query.toString() ? `?${query.toString()}` : ""}`;
+  return (
+    <a
+      href={href}
+      className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+        active ? "bg-primary text-primary-foreground" : "bg-muted text-foreground hover:bg-accent"
+      }`}
+    >
+      {label}
+    </a>
+  );
+}
+
+function ResearchStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    NEEDS_RESEARCH: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50",
+    IN_PROGRESS: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border-yellow-200 dark:border-yellow-900/50",
+    RESEARCHED: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50",
+    MAINTENANCE: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-900/50",
+  };
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${styles[status] || "bg-muted text-foreground border-border"}`}>
+      {status.replace("_", " ")}
+    </span>
+  );
+}

--- a/src/app/admin/ai-research/review/page.tsx
+++ b/src/app/admin/ai-research/review/page.tsx
@@ -1,0 +1,95 @@
+import { prisma } from "@/lib/prisma";
+import { getCurrentFieldValue } from "@/lib/ai/research-lifecycle";
+import type { DbPark, FieldExtractionSummary } from "@/lib/types";
+import { FieldExtractionReview } from "@/components/admin/FieldExtractionReview";
+import { CheckCircle2, GitCompareArrows } from "lucide-react";
+
+export default async function ReviewPage() {
+  const extractions = await prisma.fieldExtraction.findMany({
+    where: { status: "PENDING_REVIEW" },
+    include: {
+      park: {
+        include: {
+          terrain: true,
+          amenities: true,
+          camping: true,
+          vehicleTypes: true,
+          address: true,
+        },
+      },
+      dataSource: { select: { url: true, title: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const summaries: FieldExtractionSummary[] = extractions.map((e) => ({
+    id: e.id,
+    parkId: e.parkId,
+    parkName: e.park.name,
+    parkSlug: e.park.slug,
+    fieldName: e.fieldName,
+    extractedValue: e.extractedValue,
+    currentValue: getCurrentFieldValue(e.park as unknown as DbPark, e.fieldName),
+    confidence: e.confidence,
+    confidenceScore: e.confidenceScore,
+    status: e.status,
+    sourcesChecked: e.sourcesChecked,
+    sourceUrl: e.dataSource?.url ?? null,
+    sourceTitle: e.dataSource?.title ?? null,
+    sessionId: e.sessionId,
+    createdAt: e.createdAt.toISOString(),
+  }));
+
+  // Fields with more than one pending extraction represent a conflict:
+  // multiple sources proposed different values for the same field on the same park.
+  const conflictKeys = new Set<string>();
+  const seen = new Map<string, number>();
+  for (const e of summaries) {
+    const key = `${e.parkId}:${e.fieldName}`;
+    seen.set(key, (seen.get(key) ?? 0) + 1);
+  }
+  for (const [key, count] of seen) if (count > 1) conflictKeys.add(key);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-foreground">Review Proposed Changes</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Job 3 of 3. Every value the AI extracts lands here first — grouped by park — and stays
+          pending until you act on it. Approving a change applies it to the live park (array fields
+          like terrain and amenities are added, never overwritten); denying discards it. You can edit
+          a value before approving. Approvals and denials also tune the domain-accuracy scores.
+        </p>
+      </div>
+
+      {conflictKeys.size > 0 && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4 flex gap-3">
+          <GitCompareArrows className="w-5 h-5 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+          <div className="text-sm text-amber-800 dark:text-amber-300">
+            <p className="font-medium">
+              {conflictKeys.size} field{conflictKeys.size !== 1 ? "s have" : " has"} conflicting
+              proposals.
+            </p>
+            <p className="mt-1">
+              Multiple sources suggested different values for the same field. They appear side by side
+              under their park below — approve the correct one and the rest are superseded automatically.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {summaries.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-12 text-center">
+          <CheckCircle2 className="w-8 h-8 mx-auto text-green-600 dark:text-green-400 mb-3" />
+          <p className="text-foreground font-medium">You&apos;re all caught up</p>
+          <p className="text-muted-foreground text-sm mt-1 max-w-md mx-auto">
+            No proposed changes are waiting for review. Run AI research on a park from the Research tab
+            and its findings will show up here for approval.
+          </p>
+        </div>
+      ) : (
+        <FieldExtractionReview extractions={summaries} />
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/ai-research/sources/page.tsx
+++ b/src/app/admin/ai-research/sources/page.tsx
@@ -1,150 +1,16 @@
-import { prisma } from "@/lib/prisma";
-import type { DataSourceSummary, DomainReliabilitySummary } from "@/lib/types";
-import { SourceManagementTable } from "@/components/admin/SourceManagementTable";
-import { DomainReliabilityTable } from "@/components/admin/DomainReliabilityTable";
+import { redirect } from "next/navigation";
 
-export default async function SourcesPage({
+// Source management is now folded into each park's Research workspace instead of a
+// standalone destination. Deep links with ?parkId= route straight to that park's workspace;
+// otherwise land on the Research park list.
+export default async function SourcesRedirectPage({
   searchParams,
 }: {
   searchParams: Promise<{ parkId?: string }>;
 }) {
   const { parkId } = await searchParams;
-
-  // Fetch domain reliability entries for the top section
-  const domainEntries = await prisma.domainReliability.findMany({
-    orderBy: { defaultReliability: "desc" },
-  });
-
-  const domainSummaries: DomainReliabilitySummary[] = domainEntries.map((d) => ({
-    id: d.id,
-    domainPattern: d.domainPattern,
-    defaultReliability: d.defaultReliability,
-    isBlocked: d.isBlocked,
-    notes: d.notes,
-    createdAt: d.createdAt.toISOString(),
-  }));
-
-  // If no parkId, show park list for selection
-  if (!parkId) {
-    const parks = await prisma.park.findMany({
-      where: { status: "APPROVED" },
-      select: {
-        id: true,
-        name: true,
-        slug: true,
-        address: { select: { state: true } },
-        researchStatus: true,
-        _count: { select: { dataSources: true } },
-      },
-      orderBy: { name: "asc" },
-    });
-
-    return (
-      <div className="space-y-6">
-        <h1 className="text-2xl font-bold text-foreground">Data Sources</h1>
-
-        {/* Domain Reliability Section */}
-        <DomainReliabilityTable domains={domainSummaries} />
-
-        <hr className="border-border" />
-
-        <p className="text-sm text-muted-foreground">Select a park to manage its data sources.</p>
-        <div className="rounded-lg border border-border bg-card overflow-hidden">
-          <table className="min-w-full divide-y divide-border">
-            <thead>
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Park</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">State</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Research Status</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase">Sources</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {parks.map((park) => (
-                <tr key={park.id} className="hover:bg-accent/50 transition-colors">
-                  <td className="px-4 py-3">
-                    <a
-                      href={`/admin/ai-research/sources?parkId=${park.id}`}
-                      className="text-sm font-medium text-primary hover:text-primary/80"
-                    >
-                      {park.name}
-                    </a>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground">{park.address?.state}</td>
-                  <td className="px-4 py-3">
-                    <ResearchStatusBadge status={park.researchStatus} />
-                  </td>
-                  <td className="px-4 py-3 text-sm text-foreground">{park._count.dataSources}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    );
+  if (parkId) {
+    redirect(`/admin/ai-research/research/${parkId}`);
   }
-
-  // Show sources for specific park
-  const park = await prisma.park.findUnique({
-    where: { id: parkId },
-    select: { id: true, name: true, slug: true },
-  });
-
-  if (!park) {
-    return <div className="text-destructive">Park not found.</div>;
-  }
-
-  const sources = await prisma.dataSource.findMany({
-    where: { parkId },
-    orderBy: [{ reliability: "desc" }, { createdAt: "desc" }],
-  });
-
-  const summaries: DataSourceSummary[] = sources.map((s) => ({
-    id: s.id,
-    parkId: s.parkId,
-    url: s.url,
-    type: s.type,
-    origin: s.origin,
-    title: s.title,
-    reliability: s.reliability,
-    isOfficial: s.isOfficial,
-    lastCrawledAt: s.lastCrawledAt?.toISOString() ?? null,
-    contentChanged: s.contentChanged,
-    crawlStatus: s.crawlStatus,
-    crawlError: s.crawlError,
-    approveCount: s.approveCount,
-    rejectCount: s.rejectCount,
-    createdAt: s.createdAt.toISOString(),
-  }));
-
-  return (
-    <div className="space-y-6">
-      <div>
-        <a href="/admin/ai-research/sources" className="text-sm text-primary hover:text-primary/80">&larr; All Parks</a>
-        <h1 className="text-2xl font-bold text-foreground mt-2">Sources: {park.name}</h1>
-      </div>
-
-      {/* Domain Reliability Section */}
-      <DomainReliabilityTable domains={domainSummaries} />
-
-      <hr className="border-border" />
-
-      <SourceManagementTable sources={summaries} parkId={parkId} />
-    </div>
-  );
-}
-
-function ResearchStatusBadge({ status }: { status: string }) {
-  const styles: Record<string, string> = {
-    NEEDS_RESEARCH: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50",
-    IN_PROGRESS: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border-yellow-200 dark:border-yellow-900/50",
-    RESEARCHED: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50",
-    MAINTENANCE: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-900/50",
-  };
-
-  return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${styles[status] || "bg-muted text-foreground border-border"}`}>
-      {status.replace("_", " ")}
-    </span>
-  );
+  redirect("/admin/ai-research/research");
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -9,7 +9,7 @@ import {
   Camera,
   ClipboardCheck,
   ClipboardList,
-  Globe,
+  FlaskConical,
   Home,
   Image as ImageIcon,
   KeyRound,
@@ -167,25 +167,25 @@ export default async function AdminLayout({
               <span className="font-medium">AI Research</span>
             </Link>
             <Link
-              href="/admin/ai-research/pending"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <ClipboardCheck className="w-4 h-4" />
-              <span className="font-medium text-sm">Review Queue</span>
-            </Link>
-            <Link
-              href="/admin/ai-research/sources"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <Globe className="w-4 h-4" />
-              <span className="font-medium text-sm">Sources</span>
-            </Link>
-            <Link
               href="/admin/ai-research/discovery"
               className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
             >
               <Search className="w-4 h-4" />
-              <span className="font-medium text-sm">Park Discovery</span>
+              <span className="font-medium text-sm">Discover</span>
+            </Link>
+            <Link
+              href="/admin/ai-research/research"
+              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
+            >
+              <FlaskConical className="w-4 h-4" />
+              <span className="font-medium text-sm">Research</span>
+            </Link>
+            <Link
+              href="/admin/ai-research/review"
+              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
+            >
+              <ClipboardCheck className="w-4 h-4" />
+              <span className="font-medium text-sm">Review</span>
             </Link>
             <Link
               href="/admin/users"

--- a/src/components/admin/AIResearchTabs.tsx
+++ b/src/components/admin/AIResearchTabs.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { LayoutDashboard, Search, FlaskConical, ClipboardCheck } from "lucide-react";
+
+type Tab = {
+  href: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  /** Match sub-routes (e.g. /research/[parkId]) as active too. */
+  matchPrefix?: boolean;
+};
+
+const TABS: Tab[] = [
+  { href: "/admin/ai-research", label: "Overview", icon: LayoutDashboard },
+  { href: "/admin/ai-research/discovery", label: "Discover", icon: Search, matchPrefix: true },
+  { href: "/admin/ai-research/research", label: "Research", icon: FlaskConical, matchPrefix: true },
+  { href: "/admin/ai-research/review", label: "Review", icon: ClipboardCheck, matchPrefix: true },
+];
+
+export function AIResearchTabs({ pendingReviewCount }: { pendingReviewCount?: number }) {
+  const pathname = usePathname();
+
+  const isActive = (tab: Tab) => {
+    if (tab.matchPrefix) return pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+    return pathname === tab.href;
+  };
+
+  return (
+    <div className="border-b border-border">
+      <nav className="flex gap-1 -mb-px overflow-x-auto" aria-label="AI Research sections">
+        {TABS.map((tab) => {
+          const active = isActive(tab);
+          const Icon = tab.icon;
+          const showBadge = tab.label === "Review" && (pendingReviewCount ?? 0) > 0;
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={`inline-flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                active
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
+              }`}
+              aria-current={active ? "page" : undefined}
+            >
+              <Icon className="w-4 h-4" />
+              {tab.label}
+              {showBadge && (
+                <span className="inline-flex items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 text-xs font-semibold px-2 py-0.5 min-w-[1.25rem]">
+                  {pendingReviewCount}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/admin/FieldExtractionReview.tsx
+++ b/src/components/admin/FieldExtractionReview.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon } from "lucide-react";
+import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon, Pencil, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { FieldExtractionSummary } from "@/lib/types";
 import { FIELD_DISPLAY_NAMES } from "@/lib/ai/field-display-names";
@@ -15,6 +15,9 @@ export function FieldExtractionReview({ extractions }: Props) {
   const router = useRouter();
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [processingBulk, setProcessingBulk] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState<string>("");
+  const [editError, setEditError] = useState<string | null>(null);
 
   // Group extractions by park
   const grouped = new Map<string, FieldExtractionSummary[]>();
@@ -57,13 +60,16 @@ export function FieldExtractionReview({ extractions }: Props) {
     }
   };
 
-  const handleApprove = async (id: string) => {
+  const handleApprove = async (id: string, editedValue?: string) => {
     setProcessingId(id);
     try {
       const response = await fetch(`/api/admin/ai-research/extractions/${id}/approve`, {
         method: "POST",
+        headers: editedValue !== undefined ? { "Content-Type": "application/json" } : undefined,
+        body: editedValue !== undefined ? JSON.stringify({ editedValue }) : undefined,
       });
       if (response.ok) {
+        setEditingId(null);
         router.refresh();
       } else {
         const data = await response.json();
@@ -72,6 +78,24 @@ export function FieldExtractionReview({ extractions }: Props) {
     } finally {
       setProcessingId(null);
     }
+  };
+
+  const startEdit = (extraction: FieldExtractionSummary) => {
+    setEditError(null);
+    // Prefill the editor with the human-readable form of the extracted value.
+    setEditValue(extraction.extractedValue ? formatValue(extraction.extractedValue) : "");
+    setEditingId(extraction.id);
+  };
+
+  const saveEdit = (extraction: FieldExtractionSummary) => {
+    // Re-encode the edited text back into the JSON shape the API expects,
+    // preserving the field's underlying type (array / boolean / number / string).
+    const encoded = encodeValue(extraction.fieldName, editValue, extraction.extractedValue);
+    if (encoded === null) {
+      setEditError("Could not parse that value. For list fields use comma-separated values.");
+      return;
+    }
+    handleApprove(extraction.id, encoded);
   };
 
   const handleReject = async (id: string) => {
@@ -150,6 +174,48 @@ export function FieldExtractionReview({ extractions }: Props) {
                         </p>
                       </div>
                     </div>
+                    {editingId === extraction.id && (
+                      <div className="mt-3 rounded-md border border-border bg-muted/40 p-3">
+                        <label className="block text-xs text-muted-foreground mb-1">
+                          {isArrayField(extraction.fieldName)
+                            ? "Edit values (comma-separated), then approve"
+                            : "Edit value, then approve"}
+                        </label>
+                        <textarea
+                          value={editValue}
+                          onChange={(e) => setEditValue(e.target.value)}
+                          rows={isArrayField(extraction.fieldName) ? 2 : 1}
+                          className="w-full rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm font-mono focus:border-ring focus:ring-1 focus:ring-ring"
+                        />
+                        {editError && (
+                          <p className="mt-1 text-xs text-red-600 dark:text-red-400">{editError}</p>
+                        )}
+                        <div className="mt-2 flex items-center gap-2">
+                          <Button
+                            size="sm"
+                            onClick={() => saveEdit(extraction)}
+                            disabled={processingId !== null}
+                            className="text-green-700 dark:text-green-400"
+                            variant="outline"
+                          >
+                            <Check className="w-4 h-4 mr-1" />
+                            Approve with edit
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => {
+                              setEditingId(null);
+                              setEditError(null);
+                            }}
+                            disabled={processingId !== null}
+                          >
+                            <X className="w-4 h-4 mr-1" />
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
                     {extraction.sourceUrl && (
                       <div className="mt-2">
                         <a
@@ -168,8 +234,19 @@ export function FieldExtractionReview({ extractions }: Props) {
                     <Button
                       variant="ghost"
                       size="icon-sm"
+                      onClick={() => (editingId === extraction.id ? setEditingId(null) : startEdit(extraction))}
+                      disabled={processingId !== null}
+                      title="Edit value before approving"
+                      className="text-muted-foreground hover:text-primary hover:bg-primary/10"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
                       onClick={() => handleApprove(extraction.id)}
                       disabled={processingId !== null}
+                      title="Approve — apply this value to the live park"
                       className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
                     >
                       <CheckCircle className="w-5 h-5" />
@@ -179,6 +256,7 @@ export function FieldExtractionReview({ extractions }: Props) {
                       size="icon-sm"
                       onClick={() => handleReject(extraction.id)}
                       disabled={processingId !== null}
+                      title="Deny — discard this proposed change"
                       className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
                     >
                       <XCircle className="w-5 h-5" />
@@ -227,4 +305,52 @@ function formatValue(jsonStr: string): string {
   } catch {
     return jsonStr;
   }
+}
+
+/**
+ * Re-encode admin-edited display text back into the JSON shape the approve API
+ * expects, inferring the target type from the field and the original value.
+ * Returns null if the input can't be coerced sensibly.
+ */
+function encodeValue(
+  fieldName: string,
+  text: string,
+  originalJson: string | null
+): string | null {
+  const trimmed = text.trim();
+
+  if (isArrayField(fieldName)) {
+    const items = trimmed
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    return JSON.stringify(items);
+  }
+
+  // Infer scalar type from the original extracted value when available.
+  let originalType: "boolean" | "number" | "string" = "string";
+  if (originalJson) {
+    try {
+      const parsed = JSON.parse(originalJson);
+      if (typeof parsed === "boolean") originalType = "boolean";
+      else if (typeof parsed === "number") originalType = "number";
+    } catch {
+      // fall back to string
+    }
+  }
+
+  if (originalType === "boolean") {
+    const lower = trimmed.toLowerCase();
+    if (["yes", "true", "1"].includes(lower)) return JSON.stringify(true);
+    if (["no", "false", "0"].includes(lower)) return JSON.stringify(false);
+    return null;
+  }
+
+  if (originalType === "number") {
+    const num = Number(trimmed);
+    if (Number.isNaN(num)) return null;
+    return JSON.stringify(num);
+  }
+
+  return JSON.stringify(trimmed);
 }


### PR DESCRIPTION
## Why

The AI Research area sprawled across four confusing destinations — **Discovery**, **Sources**, **Conflicts**, and a **"pending" Review Queue** whose purpose was opaque. This PR is a **UI / information-architecture reorganization only**: it reorganizes the section around the three jobs an admin actually does. No changes to the AI extraction/research pipeline or the Prisma schema.

## The three jobs → the new UI

A single AI Research hub (shared `layout.tsx` + tab nav) with four sections: **Overview • Discover • Research • Review**.

1. **Discover** new parks — `/admin/ai-research/discovery` (unchanged behavior, relabeled "Discover New Parks", job framing added).
2. **Research** existing parks — new `/admin/ai-research/research` park list → per-park workspace `/admin/ai-research/research/[parkId]`.
3. **Review** proposed changes — new `/admin/ai-research/review`, replacing the opaque "Review Queue".

## Before → After (information architecture)

| Old destination | What it did | Where it lives now |
| --- | --- | --- |
| `/ai-research` (Overview) | Stats grid, research-status breakdown, domain accuracy, recent sessions | **Overview** tab — same stats kept as *supporting context* beneath three job cards (Discover / Research / Review) with live counts |
| `/ai-research/discovery` | AI-discovered park candidates; accept/reject/seed | **Discover** tab — unchanged component (`ParkDiscoveryTable`), clearer heading/help copy |
| `/ai-research/sources` | Domain reliability + park list → per-park source management + **Run Research** button | Folded into the **per-park Research workspace**. `/sources` redirects to `/research`; `/sources?parkId=X` redirects to `/research/X` |
| `/ai-research/conflicts` | "Coming soon" stub (OP-84) | Removed as a standalone mystery tab; conflicts are now surfaced **inline in Review** (multiple pending proposals for the same field are flagged and shown side by side). `/conflicts` redirects to `/review` |
| `/ai-research/pending` (Review Queue) | `FieldExtractionReview`, approve/reject grouped by park | **Review** tab with explanatory header + empty state. `/pending` redirects to `/review` |

## Continuous research + edit-before-approve

- The per-park workspace (`research/[parkId]`) shows the park's **accumulated proposed changes** (its `PENDING_REVIEW` `FieldExtraction`s) above a **Sources & Research** panel (reusing `SourceManagementTable`, which already contains the Run Research trigger + add-source form). An admin can run research **repeatedly**; each run appends findings to the proposed-changes list. Copy makes explicit that **nothing is applied to the live park until approved**.
- **Edit before approving**: `FieldExtractionReview` now has a per-field pencil → inline editor → "Approve with edit". This uses the approve API's already-existing `editedValue` parameter (no API change); values are re-encoded to the field's underlying type (array / boolean / number / string).

## Reused vs added

- **Reused (unchanged):** `ParkDiscoveryTable`, `SourceManagementTable`, `DomainReliabilityTable`, `FieldExtractionReview` (behavior; edit UI added), and **all** API endpoints (`discovery`, `sources`, `parks/[parkId]/research`, `extractions/[id]/approve|reject`, `dashboard`, `pending-reviews`). No schema or pipeline changes. **No new API endpoints.**
- **Added (presentation/glue only):** section `layout.tsx`, `AIResearchTabs.tsx`, `research/page.tsx`, `research/[parkId]/page.tsx`, `review/page.tsx`; reframed Overview; three thin redirect pages; sidebar link updates; edit-before-approve UI.

## Old-route handling

No 404s — every removed destination redirects: `/pending`→`/review`, `/conflicts`→`/review`, `/sources`→`/research`, `/sources?parkId=X`→`/research/X`. Auth guards are inherited unchanged from `admin/layout.tsx`.

## Validation

- `npx tsc --noEmit` — clean
- `npm run lint` — clean (only pre-existing warnings in unrelated files)
- `npm run test` — **2101 passed** (also re-run green by the pre-commit hook)

## Verification notes — READ THIS

Live browser verification of the admin screens was **not possible in this environment**: there is no `POSTGRES_PRISMA_URL` / database and no `AUTH secret`. The dev server compiles and boots, but every DB-backed page fails at runtime — **including the public homepage** (same `PrismaClientInitializationError`), confirming this is an environment-wide DB/auth absence, not a defect in these routes. TypeScript, lint, and the full test suite pass.

**The orchestrator should re-verify live (with a DB + admin session):**
- `/admin/ai-research` — Overview: three job cards + supporting stats render, counts correct.
- `/admin/ai-research/discovery` — Discover tab renders and search/accept still work.
- `/admin/ai-research/research` — park list, search, status filters, pending-change counts.
- `/admin/ai-research/research/[parkId]` — proposed changes + Sources/Run Research + domain reliability; run research twice and confirm proposals accumulate.
- `/admin/ai-research/review` — grouped pending extractions; approve, deny, **edit-then-approve**; conflict banner when a field has multiple pending proposals.
- Redirects: `/admin/ai-research/pending`, `/conflicts`, `/sources`, `/sources?parkId=X`.
- Tab active-state highlighting and the sidebar sub-links.

## Follow-ups

- `edit-before-approve` edits raw display text re-encoded by field type; a richer typed editor (dropdowns for enum array fields) could be a later enhancement.
- The conflict surfacing is presentational (side-by-side grouping); the deeper OP-83/OP-84 cross-validation logic remains out of scope per constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
