### PR TITLE
fix(map): resolve mobile map z-index over login/filters/menu overlays

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,6 +127,25 @@
   }
 }
 
+/*
+ * Leaflet's own CSS puts .leaflet-pane at z-index 400 and
+ * .leaflet-top/.leaflet-bottom/.leaflet-control at z-index 1000, but
+ * .leaflet-container does not establish its own stacking context. That lets
+ * Leaflet's internal z-indexes compete directly with (and beat) app overlays
+ * such as Radix dialogs/sheets/dropdowns, which use z-50, in the root
+ * stacking context — e.g. on mobile the map can render on top of the login
+ * dialog, the filters sheet, and the header dropdown menu.
+ *
+ * Trap Leaflet's internal stacking inside its own container so its
+ * panes/controls only ever compete with each other, never with
+ * body-portaled app overlays.
+ */
+.leaflet-container {
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+}
+
 /* Collapsible animations */
 @keyframes collapse {
   from {


### PR DESCRIPTION
## Root cause

On mobile, in the Map view, the Leaflet map rendered on top of app overlays: the login menu/dialog, the filters popover/sheet, and the header dropdown menu.

Leaflet's own CSS assigns `.leaflet-pane` a z-index of 400 and `.leaflet-top`/`.leaflet-bottom`/`.leaflet-control` a z-index of 1000. `.leaflet-container` itself never establishes a stacking context. All of the app's Radix overlay primitives (dialog, sheet, dropdown-menu, select) use Tailwind's `z-50`. Because `.leaflet-container` doesn't isolate its own descendants into a stacking context, Leaflet's internal 400/1000 z-indexes compete directly with the app's `z-50` overlays in the *root* stacking context — and Leaflet wins.

## Fix

In `src/app/globals.css`, added:

```css
.leaflet-container {
  position: relative;
  z-index: 0;
  isolation: isolate;
}
```

`isolation: isolate` forces `.leaflet-container` to establish its own stacking context. Leaflet's internal panes/controls (400/1000) now only ever compete with *each other* inside that context — they can no longer escape it to compete with body-portaled overlays in the root stacking context. `position: relative; z-index: 0;` makes the container's own stacking position in the root context explicit and low, well below the `z-50` overlays.

This does not touch any individual `.leaflet-*` pane z-indexes, so Leaflet's internal marker/popup/tile ordering is unaffected.

## Why this scope

Per the task constraints, only `src/app/globals.css` was touched — no changes to `MapView.tsx`, `OffroadParksApp.tsx`, `SearchFiltersPanel.tsx`, `AppHeader.tsx`, `SearchHeader.tsx`, `LoginDialog.tsx`, or `tabs.tsx`, since other in-flight PRs are actively changing those files. The `isolation` fix alone is sufficient in principle (a properly isolated stacking context at low z-index cannot leak z-index values above `z-50` overlays regardless of the overlay's exact z-index value), so the belt-and-suspenders bump to the Radix primitives' `z-50` classes was not needed.

## Validation

- `npm run lint` — clean (0 errors, pre-existing unrelated warnings only)
- `npx tsc --noEmit` — clean
- `npm run test` — 158 test files, 2108 tests passed (2 pre-existing skips)

No local DB was reachable in the sandbox, so this was not visually verified against a running dev server. **Please verify on this PR's Vercel preview at ~375px width (mobile):**

1. Open the app on the **Map view** on a mobile viewport.
2. Open the **login dialog** — confirm it renders fully above the map (not obscured/clipped by map tiles or Leaflet controls).
3. Open the **filters popover/sheet** — confirm it renders fully above the map.
4. Open the **header dropdown menu** — confirm it renders fully above the map.
5. With the map visible, confirm Leaflet's own internal stacking still looks correct: markers, popups/tooltips, and the zoom/attribution controls should still layer correctly *among themselves* (e.g. a popup should still appear above markers/tiles, controls should still be clickable and visible over the map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)