### PR TITLE
feat(home): sticky filters + infinite scroll with server-side filtering

### DIFF
--- a/src/app/api/parks/markers/route.ts
+++ b/src/app/api/parks/markers/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { parseParkFilterParams } from "@/lib/park-filters";
+import { getParkMarkers } from "@/lib/park-query";
+
+// Filtering depends on the request query string, so responses must not be
+// statically cached.
+export const dynamic = "force-dynamic";
+
+/**
+ * Lightweight map markers for the home page's map view.
+ *
+ * Accepts the SAME filters as the list endpoint (see `buildParkQueryString`)
+ * but returns ALL matching parks — the map needs the full filtered set — as a
+ * minimal projection (id/slug, name, coords, and the fields the popup renders).
+ * No pagination, no hero/weather decoration, so the payload stays small.
+ *
+ *   { parks: Park[] }
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const params = parseParkFilterParams(searchParams);
+    const parks = await getParkMarkers(params);
+    return NextResponse.json({ parks });
+  } catch (error) {
+    console.error("Error fetching park markers:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch park markers" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/parks/route.ts
+++ b/src/app/api/parks/route.ts
@@ -1,39 +1,38 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { transformDbPark } from "@/lib/types";
-import { CONDITION_STALE_AFTER_MS } from "@/lib/trail-conditions";
+import { parseParkFilterParams, PARK_PAGE_SIZE } from "@/lib/park-filters";
+import { getParkPage } from "@/lib/park-query";
 
-export async function GET() {
+// Filtering depends on the request query string, so responses must not be
+// statically cached.
+export const dynamic = "force-dynamic";
+
+/**
+ * Paginated, server-filtered park list for the home page.
+ *
+ * Accepts every filter the UI supports (see `buildParkQueryString`) plus a
+ * zero-based `page` (and optional `pageSize`). Returns one page of fully
+ * card-shaped parks together with pagination metadata:
+ *
+ *   { parks: Park[], hasMore: boolean, nextPage: number | null, total: number }
+ */
+export async function GET(request: Request) {
   try {
-    const parks = await prisma.park.findMany({
-      where: {
-        status: "APPROVED",
-      },
-      include: {
-        terrain: true,
-        amenities: true,
-        camping: true,
-        vehicleTypes: true,
-        address: true,
-        trailConditions: {
-          where: {
-            reportStatus: "PUBLISHED",
-            createdAt: { gte: new Date(Date.now() - CONDITION_STALE_AFTER_MS) },
-          },
-          orderBy: { createdAt: "desc" },
-          take: 1,
-          select: { id: true, status: true, reportStatus: true, createdAt: true },
-        },
-      },
-      orderBy: {
-        name: "asc",
-      },
-    });
+    const { searchParams } = new URL(request.url);
+    const params = parseParkFilterParams(searchParams);
 
-    // Transform to client-friendly format
-    const transformedParks = parks.map(transformDbPark);
+    const pageRaw = Number(searchParams.get("page") ?? "0");
+    const page = Number.isFinite(pageRaw) && pageRaw > 0 ? Math.floor(pageRaw) : 0;
 
-    return NextResponse.json(transformedParks);
+    const pageSizeRaw = Number(
+      searchParams.get("pageSize") ?? String(PARK_PAGE_SIZE),
+    );
+    const pageSize =
+      Number.isFinite(pageSizeRaw) && pageSizeRaw > 0
+        ? Math.min(Math.floor(pageSizeRaw), 100)
+        : PARK_PAGE_SIZE;
+
+    const result = await getParkPage(params, page, pageSize);
+    return NextResponse.json(result);
   } catch (error) {
     console.error("Error fetching parks:", error);
     return NextResponse.json(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,27 @@
 import UtvParksApp from "@/components/ui/OffroadParksApp";
-import { parseParkFilterParams } from "@/lib/park-filters";
+import {
+  parseParkFilterParams,
+  searchParamsToURLSearchParams,
+} from "@/lib/park-filters";
 import { getParkFacets, getParkMarkers, getParkPage } from "@/lib/park-query";
 
 // Force dynamic rendering to always show fresh data
 export const dynamic = "force-dynamic";
 
-export default async function Page() {
-  // Server-render the first page (with hero images + rain badges), the full
-  // filtered marker set, and the static filter facets. The client takes over
-  // for infinite scroll + filter changes. Default (unfiltered, name-sorted)
-  // params drive the first paint; saved-default filters (if any) re-query on
-  // the client after mount.
-  const params = parseParkFilterParams(new URLSearchParams());
+interface PageProps {
+  // Next.js 16 App Router: searchParams is an async prop.
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  // Parse the real request query string so deep-linked / shared filtered URLs
+  // (e.g. `/?state=Arkansas`) server-render the correctly filtered first page
+  // and marker set. The client seeds its Filters panel from the same URL, so
+  // the mount state matches what was rendered here (no filtered/unfiltered
+  // flicker). Saved-preference-only filters (not in the URL) are applied on the
+  // client after mount, which triggers a page-0 refetch.
+  const resolved = (await searchParams) ?? {};
+  const params = parseParkFilterParams(searchParamsToURLSearchParams(resolved));
 
   const [initialPage, initialMarkers, facets] = await Promise.all([
     getParkPage(params, 0),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,84 +1,29 @@
 import UtvParksApp from "@/components/ui/OffroadParksApp";
-import { prisma } from "@/lib/prisma";
-import { resolveParkHeroImage } from "@/lib/park-hero";
-import { transformDbPark } from "@/lib/types";
-import { getBatchRainProbabilities } from "@/lib/weather";
+import { parseParkFilterParams } from "@/lib/park-filters";
+import { getParkFacets, getParkMarkers, getParkPage } from "@/lib/park-query";
 
 // Force dynamic rendering to always show fresh data
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  // Fetch parks from database
-  const dbParks = await prisma.park.findMany({
-    where: {
-      status: "APPROVED",
-    },
-    include: {
-      terrain: true,
-      amenities: true,
-      camping: true,
-      vehicleTypes: true,
-      address: true,
-      photos: {
-        where: {
-          status: "APPROVED",
-        },
-        take: 1,
-        orderBy: {
-          createdAt: "desc",
-        },
-        select: {
-          id: true,
-          url: true,
-          status: true,
-        },
-      },
-      heroPhoto: {
-        select: {
-          id: true,
-          url: true,
-          status: true,
-        },
-      },
-      // Latest published trail condition — drives the condition badge on
-      // the card. Without this, `park.latestCondition` is undefined on the
-      // home grid and the badge never renders (bug pre-dated OP-90).
-      trailConditions: {
-        where: { reportStatus: "PUBLISHED" },
-        orderBy: { createdAt: "desc" },
-        take: 1,
-        select: {
-          id: true,
-          status: true,
-          reportStatus: true,
-          createdAt: true,
-        },
-      },
-    },
-    orderBy: {
-      name: "asc",
-    },
-  });
+  // Server-render the first page (with hero images + rain badges), the full
+  // filtered marker set, and the static filter facets. The client takes over
+  // for infinite scroll + filter changes. Default (unfiltered, name-sorted)
+  // params drive the first paint; saved-default filters (if any) re-query on
+  // the client after mount.
+  const params = parseParkFilterParams(new URLSearchParams());
 
-  // OP-55: batched fetch of today's rain probability for each park. Uses
-  // the same forecast cache as OP-53 (6h TTL), so warm requests are
-  // basically free. Per-park 2s timeout + concurrency cap bound the
-  // first-render cost; parks that don't respond in time simply omit the
-  // badge until the next render.
-  const rainByParkId = await getBatchRainProbabilities(
-    dbParks.map((p) => ({
-      parkId: p.id,
-      latitude: p.latitude ?? p.address?.latitude ?? null,
-      longitude: p.longitude ?? p.address?.longitude ?? null,
-    })),
+  const [initialPage, initialMarkers, facets] = await Promise.all([
+    getParkPage(params, 0),
+    getParkMarkers(params),
+    getParkFacets(),
+  ]);
+
+  return (
+    <UtvParksApp
+      initialData={initialPage}
+      initialMarkers={initialMarkers}
+      facets={facets}
+    />
   );
-
-  // Transform to client format with hero images (respects operator selection)
-  const parks = dbParks.map((park) => ({
-    ...transformDbPark(park),
-    heroImage: resolveParkHeroImage(park),
-    todaysRainChance: rainByParkId.get(park.id) ?? null,
-  }));
-
-  return <UtvParksApp parks={parks} />;
 }

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -8,8 +8,11 @@ import { useFilteredParks } from "@/hooks/useFilteredParks";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useRouteBuilder } from "@/hooks/useRouteBuilder";
 import { useSearchPreferences } from "@/hooks/useSearchPreferences";
+import { useParkList, useParkMarkers } from "@/hooks/useServerParks";
 import { haversineDistance } from "@/lib/geo";
 import { FILTER_QUERY_KEYS } from "@/lib/search-preferences";
+import { buildParkQueryString } from "@/lib/park-filters";
+import type { ParkFacets, ParkPage } from "@/lib/park-query";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { SearchHeader } from "@/components/layout/SearchHeader";
 import { SearchFiltersPanel } from "@/components/parks/SearchFiltersPanel";
@@ -23,7 +26,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { LayoutGrid, Map } from "lucide-react";
+import { LayoutGrid, Loader2, Map } from "lucide-react";
 
 // Dynamically import MapView to avoid SSR issues with Leaflet
 const MapView = dynamic(
@@ -32,10 +35,19 @@ const MapView = dynamic(
 );
 
 interface OffroadParksAppProps {
-  parks: Park[];
+  /** Server-rendered first page of list parks (hero + rain decorated). */
+  initialData: ParkPage;
+  /** Server-rendered full filtered marker set for the map view. */
+  initialMarkers: Park[];
+  /** Static filter facets (states + slider bounds) over all approved parks. */
+  facets: ParkFacets;
 }
 
-function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
+function OffroadParksAppInner({
+  initialData,
+  initialMarkers,
+  facets,
+}: OffroadParksAppProps) {
   const { data: session } = useSession();
   const searchParams = useSearchParams();
   const routeIdParam = searchParams?.get("routeId") ?? null;
@@ -46,6 +58,11 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
   const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(null);
   const [locationLoading, setLocationLoading] = useState(false);
 
+  // The filter/sort STATE (and its setters, saved-default helpers) still live
+  // in useFilteredParks so behaviour and tests are preserved. Its client-side
+  // `filteredParks` output is no longer used for rendering — filtering + sorting
+  // now happen server-side. We pass an empty list and source the panel facets
+  // (states + slider maxes) from the server instead.
   const {
     searchQuery,
     setSearchQuery,
@@ -61,10 +78,8 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
     setSelectedVehicleTypes,
     minTrailMiles,
     setMinTrailMiles,
-    maxTrailMiles,
     minAcres,
     setMinAcres,
-    maxAcres,
     minRating,
     setMinRating,
     selectedOwnership,
@@ -79,12 +94,69 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
     setSparkArrestorRequired,
     sortOption,
     setSortOption,
-    availableStates,
-    filteredParks,
     clearAllFilters,
     getCurrentFilters,
     applyFilters,
-  } = useFilteredParks({ parks, userCoords });
+  } = useFilteredParks({ parks: [], userCoords });
+
+  // Serialised filter query — the single key that drives both server endpoints.
+  const queryString = useMemo(
+    () =>
+      buildParkQueryString({
+        searchQuery,
+        selectedState,
+        selectedTerrains,
+        selectedAmenities,
+        selectedCamping,
+        selectedVehicleTypes,
+        minTrailMiles,
+        minAcres,
+        minRating,
+        selectedOwnership,
+        permitRequired,
+        membershipRequired,
+        flagsRequired,
+        sparkArrestorRequired,
+        sortOption,
+        userCoords,
+      }).toString(),
+    [
+      searchQuery,
+      selectedState,
+      selectedTerrains,
+      selectedAmenities,
+      selectedCamping,
+      selectedVehicleTypes,
+      minTrailMiles,
+      minAcres,
+      minRating,
+      selectedOwnership,
+      permitRequired,
+      membershipRequired,
+      flagsRequired,
+      sparkArrestorRequired,
+      sortOption,
+      userCoords,
+    ],
+  );
+
+  const {
+    parks: listParks,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    loadMore,
+    error: listError,
+  } = useParkList({ queryString, initialData });
+
+  // Markers are only fetched while the map view is active. The markers hook
+  // seeds from the server-rendered set and refetches when the filters differ
+  // from the last load, so opening the map after changing filters re-syncs it.
+  const markerParks = useParkMarkers({
+    queryString,
+    initialMarkers,
+    enabled: activeView === "map",
+  });
 
   const {
     preference,
@@ -142,17 +214,18 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
     setSortOption("name");
   };
 
+  // Distance badge on each card — computed over the currently loaded pages.
   const distances = useMemo(() => {
     if (!userCoords) return {} as Record<string, number | undefined>;
     return Object.fromEntries(
-      filteredParks.map((park) => [
+      listParks.map((park) => [
         park.id,
         park.coords
           ? haversineDistance(userCoords.lat, userCoords.lng, park.coords.lat, park.coords.lng)
           : undefined,
       ]),
     );
-  }, [filteredParks, userCoords]);
+  }, [listParks, userCoords]);
 
   const { toggleFavorite, isFavorite } = useFavorites();
 
@@ -227,11 +300,40 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
     return () => mq.removeEventListener("change", closeIfDesktop);
   }, []);
 
+  // Measure the sticky top block (app header + search bar) so the desktop
+  // filters sidebar can stick directly beneath it regardless of header height.
+  const stickyRef = useRef<HTMLDivElement | null>(null);
+  const [stickyOffset, setStickyOffset] = useState(0);
+  useEffect(() => {
+    const el = stickyRef.current;
+    if (!el) return;
+    const update = () => setStickyOffset(el.offsetHeight);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Infinite-scroll sentinel — loads the next page as it nears the viewport.
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "600px 0px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
   const filtersPanel = (
     <SearchFiltersPanel
       selectedState={selectedState}
       onStateChange={setSelectedState}
-      availableStates={availableStates}
+      availableStates={facets.states}
       selectedTerrains={selectedTerrains}
       onTerrainsChange={setSelectedTerrains}
       selectedAmenities={selectedAmenities}
@@ -242,10 +344,10 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
       onVehicleTypesChange={setSelectedVehicleTypes}
       minTrailMiles={minTrailMiles}
       onMinTrailMilesChange={setMinTrailMiles}
-      maxTrailMiles={maxTrailMiles}
+      maxTrailMiles={facets.maxTrailMiles}
       minAcres={minAcres}
       onMinAcresChange={setMinAcres}
-      maxAcres={maxAcres}
+      maxAcres={facets.maxAcres}
       minRating={minRating}
       onMinRatingChange={setMinRating}
       selectedOwnership={selectedOwnership}
@@ -269,23 +371,23 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Sticky header */}
-      <div className="sticky top-0 z-20">
+      {/* Sticky top block: app header + search/sort bar stay pinned while the
+          list scrolls. Solid background + high z-index keep cards from showing
+          through. */}
+      <div ref={stickyRef} className="sticky top-0 z-30 bg-background">
         <AppHeader user={user} />
+        <SearchHeader
+          searchQuery={searchQuery}
+          onSearchQueryChange={setSearchQuery}
+          sortOption={sortOption}
+          onSortChange={setSortOption}
+          locationActive={userCoords !== null}
+          locationLoading={locationLoading}
+          onUseMyLocation={handleUseMyLocation}
+          onClearLocation={handleClearLocation}
+          onOpenFilters={() => setFiltersOpen(true)}
+        />
       </div>
-
-      {/* Search and sort bar */}
-      <SearchHeader
-        searchQuery={searchQuery}
-        onSearchQueryChange={setSearchQuery}
-        sortOption={sortOption}
-        onSortChange={setSortOption}
-        locationActive={userCoords !== null}
-        locationLoading={locationLoading}
-        onUseMyLocation={handleUseMyLocation}
-        onClearLocation={handleClearLocation}
-        onOpenFilters={() => setFiltersOpen(true)}
-      />
 
       <main className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-6 pb-8">
         {/* Mobile filters — opened by the funnel button in the search bar.
@@ -304,8 +406,14 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
         </Sheet>
 
         <div className="flex flex-col lg:flex-row gap-6 items-start">
-          {/* Desktop sidebar — hidden on mobile, shown in the sheet above */}
-          <div className="hidden w-72 shrink-0 lg:block">{filtersPanel}</div>
+          {/* Desktop sidebar — hidden on mobile, shown in the sheet above.
+              Sticks beneath the pinned header while the list scrolls. */}
+          <div
+            className="hidden w-72 shrink-0 lg:block lg:sticky lg:self-start lg:max-h-[calc(100vh-1rem)] lg:overflow-y-auto"
+            style={{ top: stickyOffset ? stickyOffset + 16 : undefined }}
+          >
+            {filtersPanel}
+          </div>
 
           <div className="flex-1 min-w-0 w-full">
             <Tabs
@@ -324,8 +432,14 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
               </TabsList>
 
               <TabsContent value="list" className="mt-0">
+                {listError && (
+                  <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+                    {listError}
+                  </div>
+                )}
+
                 <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 gap-5">
-                  {filteredParks.map((park) => (
+                  {listParks.map((park) => (
                     <ParkCard
                       key={park.id}
                       park={park}
@@ -335,13 +449,41 @@ function OffroadParksAppInner({ parks }: OffroadParksAppProps) {
                     />
                   ))}
                 </div>
+
+                {/* Empty state — only when a completed load returned nothing. */}
+                {!isLoading && listParks.length === 0 && (
+                  <div className="py-16 text-center text-muted-foreground">
+                    No parks match your filters.
+                  </div>
+                )}
+
+                {/* Loading / infinite-scroll region */}
+                {(isLoading || isLoadingMore) && (
+                  <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading parks…
+                  </div>
+                )}
+
+                {/* Sentinel: triggers loadMore as it approaches the viewport. */}
+                {hasMore && !isLoading && (
+                  <div ref={sentinelRef} className="h-1 w-full" aria-hidden />
+                )}
+
+                {/* End-of-list state */}
+                {!hasMore && !isLoading && listParks.length > 0 && (
+                  <div className="py-8 text-center text-xs text-muted-foreground">
+                    You&rsquo;ve reached the end · {listParks.length} park
+                    {listParks.length === 1 ? "" : "s"}
+                  </div>
+                )}
               </TabsContent>
 
               <TabsContent value="map" className="mt-0">
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                   <div className="lg:col-span-2">
                     <MapView
-                      parks={filteredParks}
+                      parks={markerParks}
                       routeWaypoints={waypoints}
                       routeGeometry={routeResult?.geometry}
                       savedRoutePreview={

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -11,7 +11,11 @@ import { useSearchPreferences } from "@/hooks/useSearchPreferences";
 import { useParkList, useParkMarkers } from "@/hooks/useServerParks";
 import { haversineDistance } from "@/lib/geo";
 import { FILTER_QUERY_KEYS } from "@/lib/search-preferences";
-import { buildParkQueryString } from "@/lib/park-filters";
+import {
+  buildParkQueryString,
+  parkFilterParamsToState,
+  parseParkFilterParams,
+} from "@/lib/park-filters";
 import type { ParkFacets, ParkPage } from "@/lib/park-query";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { SearchHeader } from "@/components/layout/SearchHeader";
@@ -55,14 +59,29 @@ function OffroadParksAppInner({
   const [activeView, setActiveView] = useState<"list" | "map">(
     viewParam === "map" || routeIdParam ? "map" : "list",
   );
-  const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(null);
+
+  // Parse the URL filter params ONCE for the initial render (lazy initializer =
+  // mount-only). This seeds both the Filters panel (via useFilteredParks) and
+  // the location state so the client's mount filter set matches the
+  // server-rendered first page for deep-linked / shared filtered URLs. Later
+  // filter changes flow through state, not the URL.
+  const [initialUrlParams] = useState(() =>
+    parseParkFilterParams(new URLSearchParams(searchParams?.toString() ?? "")),
+  );
+
+  const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(
+    initialUrlParams.userLat != null && initialUrlParams.userLng != null
+      ? { lat: initialUrlParams.userLat, lng: initialUrlParams.userLng }
+      : null,
+  );
   const [locationLoading, setLocationLoading] = useState(false);
 
   // The filter/sort STATE (and its setters, saved-default helpers) still live
   // in useFilteredParks so behaviour and tests are preserved. Its client-side
   // `filteredParks` output is no longer used for rendering — filtering + sorting
   // now happen server-side. We pass an empty list and source the panel facets
-  // (states + slider maxes) from the server instead.
+  // (states + slider maxes) from the server instead. Initial state is seeded
+  // from the URL so shared filtered links render consistently.
   const {
     searchQuery,
     setSearchQuery,
@@ -97,7 +116,11 @@ function OffroadParksAppInner({
     clearAllFilters,
     getCurrentFilters,
     applyFilters,
-  } = useFilteredParks({ parks: [], userCoords });
+  } = useFilteredParks({
+    parks: [],
+    userCoords,
+    initialState: parkFilterParamsToState(initialUrlParams),
+  });
 
   // Serialised filter query — the single key that drives both server endpoints.
   const queryString = useMemo(

--- a/src/hooks/useFilteredParks.ts
+++ b/src/hooks/useFilteredParks.ts
@@ -10,27 +10,48 @@ export interface UserCoords {
   lng: number;
 }
 
+/** Optional initial Filters-panel state — used to seed the panel from URL
+ *  query params so deep-linked / shared filtered URLs render consistently. */
+export interface InitialFilterState {
+  searchQuery?: string;
+  selectedState?: string;
+  selectedTerrains?: string[];
+  selectedAmenities?: string[];
+  selectedCamping?: string[];
+  selectedVehicleTypes?: string[];
+  minTrailMiles?: number;
+  minAcres?: number;
+  minRating?: string;
+  selectedOwnership?: string;
+  permitRequired?: string;
+  membershipRequired?: string;
+  flagsRequired?: string;
+  sparkArrestorRequired?: string;
+  sortOption?: SortOption;
+}
+
 interface UseFilteredParksProps {
   parks: Park[];
   userCoords?: UserCoords | null;
+  initialState?: InitialFilterState;
 }
 
-export function useFilteredParks({ parks, userCoords }: UseFilteredParksProps) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedState, setSelectedState] = useState<string | undefined>();
-  const [selectedTerrains, setSelectedTerrains] = useState<string[]>([]);
-  const [selectedAmenities, setSelectedAmenities] = useState<string[]>([]);
-  const [selectedCamping, setSelectedCamping] = useState<string[]>([]);
-  const [selectedVehicleTypes, setSelectedVehicleTypes] = useState<string[]>([]);
-  const [minTrailMiles, setMinTrailMiles] = useState<number>(0);
-  const [minAcres, setMinAcres] = useState<number>(0);
-  const [minRating, setMinRating] = useState<string>("");
-  const [selectedOwnership, setSelectedOwnership] = useState<string>("");
-  const [permitRequired, setPermitRequired] = useState<string>("");
-  const [membershipRequired, setMembershipRequired] = useState<string>("");
-  const [flagsRequired, setFlagsRequired] = useState<string>("");
-  const [sparkArrestorRequired, setSparkArrestorRequired] = useState<string>("");
-  const [sortOption, setSortOption] = useState<SortOption>("name");
+export function useFilteredParks({ parks, userCoords, initialState }: UseFilteredParksProps) {
+  const [searchQuery, setSearchQuery] = useState(initialState?.searchQuery ?? "");
+  const [selectedState, setSelectedState] = useState<string | undefined>(initialState?.selectedState);
+  const [selectedTerrains, setSelectedTerrains] = useState<string[]>(initialState?.selectedTerrains ?? []);
+  const [selectedAmenities, setSelectedAmenities] = useState<string[]>(initialState?.selectedAmenities ?? []);
+  const [selectedCamping, setSelectedCamping] = useState<string[]>(initialState?.selectedCamping ?? []);
+  const [selectedVehicleTypes, setSelectedVehicleTypes] = useState<string[]>(initialState?.selectedVehicleTypes ?? []);
+  const [minTrailMiles, setMinTrailMiles] = useState<number>(initialState?.minTrailMiles ?? 0);
+  const [minAcres, setMinAcres] = useState<number>(initialState?.minAcres ?? 0);
+  const [minRating, setMinRating] = useState<string>(initialState?.minRating ?? "");
+  const [selectedOwnership, setSelectedOwnership] = useState<string>(initialState?.selectedOwnership ?? "");
+  const [permitRequired, setPermitRequired] = useState<string>(initialState?.permitRequired ?? "");
+  const [membershipRequired, setMembershipRequired] = useState<string>(initialState?.membershipRequired ?? "");
+  const [flagsRequired, setFlagsRequired] = useState<string>(initialState?.flagsRequired ?? "");
+  const [sparkArrestorRequired, setSparkArrestorRequired] = useState<string>(initialState?.sparkArrestorRequired ?? "");
+  const [sortOption, setSortOption] = useState<SortOption>(initialState?.sortOption ?? "name");
 
   const availableStates = useMemo(
     () => Array.from(new Set(parks.map((park) => park.address.state))).sort(),

--- a/src/hooks/useServerParks.ts
+++ b/src/hooks/useServerParks.ts
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Park } from "@/lib/types";
+import type { ParkPage } from "@/lib/park-query";
+
+function withPage(queryString: string, page: number): string {
+  return queryString ? `${queryString}&page=${page}` : `page=${page}`;
+}
+
+interface UseParkListArgs {
+  /** Serialised filter query (from `buildParkQueryString`), WITHOUT `page`. */
+  queryString: string;
+  /** Server-rendered first page — used verbatim while the filters are still
+   *  the ones the page was rendered with (no redundant refetch on mount). */
+  initialData: ParkPage;
+}
+
+export interface UseParkListResult {
+  parks: Park[];
+  /** Reset load (filters changed) in flight. */
+  isLoading: boolean;
+  /** Appending the next page in flight. */
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  loadMore: () => void;
+  error: string | null;
+}
+
+/**
+ * Infinite-scroll list backed by `/api/parks`.
+ *
+ * Seeds from `initialData`. When the serialised filters change it resets to
+ * page 0 and refetches; `loadMore()` appends the next page. Stale responses
+ * (filters changed mid-flight) are discarded via a monotonic request id.
+ */
+export function useParkList({
+  queryString,
+  initialData,
+}: UseParkListArgs): UseParkListResult {
+  const initialQueryString = useRef(queryString);
+  const [parks, setParks] = useState<Park[]>(initialData.parks);
+  const [nextPage, setNextPage] = useState<number | null>(initialData.nextPage);
+  const [hasMore, setHasMore] = useState(initialData.hasMore);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Bumped on every filter change; page fetches carry the id they started with
+  // so responses from a superseded filter generation can be ignored.
+  const generation = useRef(0);
+  const skippedInitial = useRef(false);
+  // Synchronous guard so an IntersectionObserver that fires several times
+  // before React re-renders can't kick off duplicate page fetches.
+  const loadingMoreRef = useRef(false);
+
+  useEffect(() => {
+    // The very first render is already seeded from server data when the filters
+    // still match what the page was rendered with.
+    if (!skippedInitial.current) {
+      skippedInitial.current = true;
+      if (queryString === initialQueryString.current) return;
+    }
+
+    const id = ++generation.current;
+    const controller = new AbortController();
+    loadingMoreRef.current = false;
+    setIsLoading(true);
+    setError(null);
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/parks?${withPage(queryString, 0)}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: ParkPage = await res.json();
+        if (id !== generation.current) return;
+        setParks(data.parks);
+        setNextPage(data.nextPage);
+        setHasMore(data.hasMore);
+      } catch {
+        if (controller.signal.aborted || id !== generation.current) return;
+        setError("Failed to load parks");
+      } finally {
+        if (id === generation.current) setIsLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [queryString]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMoreRef.current || isLoading || !hasMore || nextPage == null) {
+      return;
+    }
+    const id = generation.current;
+    loadingMoreRef.current = true;
+    setIsLoadingMore(true);
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/parks?${withPage(queryString, nextPage)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: ParkPage = await res.json();
+        // Discard if the filters changed while this page was loading.
+        if (id !== generation.current) return;
+        setParks((current) => [...current, ...data.parks]);
+        setNextPage(data.nextPage);
+        setHasMore(data.hasMore);
+      } catch {
+        if (id === generation.current) setError("Failed to load more parks");
+      } finally {
+        loadingMoreRef.current = false;
+        if (id === generation.current) setIsLoadingMore(false);
+      }
+    })();
+  }, [queryString, nextPage, hasMore, isLoading]);
+
+  return { parks, isLoading, isLoadingMore, hasMore, loadMore, error };
+}
+
+interface UseParkMarkersArgs {
+  queryString: string;
+  initialMarkers: Park[];
+  /** Only fetch when the map view is (or has been) active. */
+  enabled: boolean;
+}
+
+/**
+ * Full filtered set of lightweight map markers, backed by
+ * `/api/parks/markers`. Seeds from `initialMarkers`; refetches when the
+ * filters change while the map is active, or when the map first becomes active
+ * under filters that differ from the last load.
+ */
+export function useParkMarkers({
+  queryString,
+  initialMarkers,
+  enabled,
+}: UseParkMarkersArgs): Park[] {
+  const [markers, setMarkers] = useState<Park[]>(initialMarkers);
+  const lastLoaded = useRef<string>(queryString);
+  const generation = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (queryString === lastLoaded.current) return;
+
+    const id = ++generation.current;
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/parks/markers?${queryString}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { parks: Park[] } = await res.json();
+        if (id !== generation.current) return;
+        setMarkers(data.parks);
+        lastLoaded.current = queryString;
+      } catch {
+        /* keep the previous markers on failure */
+      }
+    })();
+
+    return () => controller.abort();
+  }, [queryString, enabled]);
+
+  return markers;
+}

--- a/src/lib/park-filters.ts
+++ b/src/lib/park-filters.ts
@@ -1,0 +1,318 @@
+/**
+ * Shared park filter/sort semantics.
+ *
+ * This module is the single source of truth for how the home page's search +
+ * filters map onto a query. It is consumed in two places that must never
+ * drift apart:
+ *
+ *   - The client (`OffroadParksApp`) serialises its current Filters-panel
+ *     state into a query string via {@link buildParkQueryString} and sends it
+ *     to the list + markers endpoints.
+ *   - The server (`/api/parks`, `/api/parks/markers`, and `page.tsx` via
+ *     `src/lib/park-query.ts`) parses that query string with
+ *     {@link parseParkFilterParams} and turns it into a Prisma `where` /
+ *     `orderBy` via {@link buildParkWhere} / {@link buildParkOrderBy}.
+ *
+ * The predicates here mirror the client-side semantics that historically
+ * lived in `useFilteredParks` (which is retained for filter STATE + tests).
+ */
+import type { Prisma } from "@prisma/client";
+import type { SortOption } from "@/hooks/useFilteredParks";
+
+/** Tri-state select value used by the permit-style filters. */
+export type TriState = "" | "yes" | "no";
+
+/** Number of parks returned per list page. */
+export const PARK_PAGE_SIZE = 24;
+
+/** Fully-parsed, normalised filter parameters. */
+export interface ParkFilterParams {
+  q: string;
+  state?: string;
+  terrains: string[];
+  amenities: string[];
+  camping: string[];
+  vehicleTypes: string[];
+  minTrailMiles: number;
+  minAcres: number;
+  minRating: string;
+  ownership: string;
+  permitRequired: TriState;
+  membershipRequired: TriState;
+  flagsRequired: TriState;
+  sparkArrestorRequired: TriState;
+  sort: SortOption;
+  /** Present only when the user has shared their browser geolocation and the
+   *  distance sort is active. Used for server-side distance ordering. */
+  userLat?: number;
+  userLng?: number;
+}
+
+const VALID_SORTS: readonly SortOption[] = [
+  "name",
+  "price",
+  "miles",
+  "acres",
+  "rating",
+  "difficulty-high",
+  "difficulty-low",
+  "most-reviewed",
+  "distance-nearest",
+];
+
+function normaliseTriState(value: string | null): TriState {
+  return value === "yes" || value === "no" ? value : "";
+}
+
+/** Read a possibly-repeated OR comma-separated multi-select param. */
+function readMulti(params: URLSearchParams, key: string): string[] {
+  const all = params.getAll(key);
+  const raw = all.length > 0 ? all : [];
+  return raw
+    .flatMap((v) => v.split(","))
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function readNumber(value: string | null, fallback: number): number {
+  if (value == null || value === "") return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Parse a URLSearchParams (from a request URL) into normalised filter params.
+ * Unknown / malformed values fall back to the "no filter" default so the
+ * endpoint can never throw on user-supplied query strings.
+ */
+export function parseParkFilterParams(
+  params: URLSearchParams,
+): ParkFilterParams {
+  const sortRaw = params.get("sort");
+  const sort = (VALID_SORTS as string[]).includes(sortRaw ?? "")
+    ? (sortRaw as SortOption)
+    : "name";
+
+  const latRaw = params.get("lat");
+  const lngRaw = params.get("lng");
+  const userLat = latRaw != null && latRaw !== "" ? Number(latRaw) : undefined;
+  const userLng = lngRaw != null && lngRaw !== "" ? Number(lngRaw) : undefined;
+
+  return {
+    q: (params.get("q") ?? "").trim(),
+    state: params.get("state") || undefined,
+    terrains: readMulti(params, "terrain"),
+    amenities: readMulti(params, "amenity"),
+    camping: readMulti(params, "camping"),
+    vehicleTypes: readMulti(params, "vehicleType"),
+    minTrailMiles: readNumber(params.get("minTrailMiles"), 0),
+    minAcres: readNumber(params.get("minAcres"), 0),
+    minRating: params.get("minRating") ?? "",
+    ownership: params.get("ownership") ?? "",
+    permitRequired: normaliseTriState(params.get("permit")),
+    membershipRequired: normaliseTriState(params.get("membership")),
+    flagsRequired: normaliseTriState(params.get("flags")),
+    sparkArrestorRequired: normaliseTriState(params.get("sparkArrestor")),
+    sort,
+    userLat: Number.isFinite(userLat) ? userLat : undefined,
+    userLng: Number.isFinite(userLng) ? userLng : undefined,
+  };
+}
+
+/** Client-side Filters-panel state shape used to build a request query. */
+export interface ParkQueryInput {
+  searchQuery?: string;
+  selectedState?: string;
+  selectedTerrains?: string[];
+  selectedAmenities?: string[];
+  selectedCamping?: string[];
+  selectedVehicleTypes?: string[];
+  minTrailMiles?: number;
+  minAcres?: number;
+  minRating?: string;
+  selectedOwnership?: string;
+  permitRequired?: string;
+  membershipRequired?: string;
+  flagsRequired?: string;
+  sparkArrestorRequired?: string;
+  sortOption?: SortOption;
+  userCoords?: { lat: number; lng: number } | null;
+}
+
+/**
+ * Serialise the current client Filters-panel state into a URLSearchParams.
+ * Only non-default values are emitted so the query string stays compact and
+ * identical requests share a cache key. `page` is appended separately by the
+ * caller so this can be reused verbatim for the markers endpoint.
+ */
+export function buildParkQueryString(input: ParkQueryInput): URLSearchParams {
+  const params = new URLSearchParams();
+
+  const q = input.searchQuery?.trim();
+  if (q) params.set("q", q);
+  if (input.selectedState) params.set("state", input.selectedState);
+  for (const t of input.selectedTerrains ?? []) params.append("terrain", t);
+  for (const a of input.selectedAmenities ?? []) params.append("amenity", a);
+  for (const c of input.selectedCamping ?? []) params.append("camping", c);
+  for (const v of input.selectedVehicleTypes ?? [])
+    params.append("vehicleType", v);
+  if (input.minTrailMiles && input.minTrailMiles > 0)
+    params.set("minTrailMiles", String(input.minTrailMiles));
+  if (input.minAcres && input.minAcres > 0)
+    params.set("minAcres", String(input.minAcres));
+  if (input.minRating) params.set("minRating", input.minRating);
+  if (input.selectedOwnership) params.set("ownership", input.selectedOwnership);
+  if (input.permitRequired) params.set("permit", input.permitRequired);
+  if (input.membershipRequired)
+    params.set("membership", input.membershipRequired);
+  if (input.flagsRequired) params.set("flags", input.flagsRequired);
+  if (input.sparkArrestorRequired)
+    params.set("sparkArrestor", input.sparkArrestorRequired);
+
+  const sort = input.sortOption ?? "name";
+  if (sort !== "name") params.set("sort", sort);
+
+  // Only forward coordinates when they're actually needed for distance sort —
+  // avoids leaking the user's location into unrelated requests/caches.
+  if (sort === "distance-nearest" && input.userCoords) {
+    params.set("lat", String(input.userCoords.lat));
+    params.set("lng", String(input.userCoords.lng));
+  }
+
+  return params;
+}
+
+/** True when the requested sort must be computed in JS (needs user coords). */
+export function isDistanceSort(sort: SortOption): boolean {
+  return sort === "distance-nearest";
+}
+
+/** For a nullable boolean tri-state "no", match both `false` and `null`
+ *  (mirrors the client `value !== true` predicate, which SQL `!= true` does
+ *  NOT do because it excludes NULLs). */
+function triStateWhere(
+  field: "permitRequired" | "membershipRequired" | "flagsRequired" | "sparkArrestorRequired",
+  value: TriState,
+): Prisma.ParkWhereInput[] {
+  if (value === "yes") return [{ [field]: true }];
+  if (value === "no") return [{ OR: [{ [field]: false }, { [field]: null }] }];
+  return [];
+}
+
+/**
+ * Build the Prisma `where` for a set of filter params. Always constrains to
+ * APPROVED parks. Mirrors `useFilteredParks` semantics field-for-field.
+ */
+export function buildParkWhere(
+  params: ParkFilterParams,
+): Prisma.ParkWhereInput {
+  const and: Prisma.ParkWhereInput[] = [{ status: "APPROVED" }];
+
+  if (params.q) {
+    const contains = { contains: params.q, mode: "insensitive" as const };
+    and.push({
+      OR: [
+        { name: contains },
+        { notes: contains },
+        { address: { city: contains } },
+        { address: { state: contains } },
+      ],
+    });
+  }
+
+  if (params.state) {
+    and.push({ address: { state: params.state } });
+  }
+
+  if (params.terrains.length > 0) {
+    and.push({
+      terrain: { some: { terrain: { in: params.terrains as never } } },
+    });
+  }
+  if (params.amenities.length > 0) {
+    and.push({
+      amenities: { some: { amenity: { in: params.amenities as never } } },
+    });
+  }
+  if (params.camping.length > 0) {
+    and.push({
+      camping: { some: { camping: { in: params.camping as never } } },
+    });
+  }
+  if (params.vehicleTypes.length > 0) {
+    and.push({
+      vehicleTypes: {
+        some: { vehicleType: { in: params.vehicleTypes as never } },
+      },
+    });
+  }
+
+  if (params.minTrailMiles > 0) {
+    and.push({ milesOfTrails: { gte: params.minTrailMiles } });
+  }
+  if (params.minAcres > 0) {
+    and.push({ acres: { gte: params.minAcres } });
+  }
+  if (params.minRating) {
+    const value = parseFloat(params.minRating);
+    if (Number.isFinite(value)) {
+      and.push({ averageRating: { gte: value } });
+    }
+  }
+  if (params.ownership) {
+    and.push({ ownership: params.ownership as never });
+  }
+
+  and.push(...triStateWhere("permitRequired", params.permitRequired));
+  and.push(...triStateWhere("membershipRequired", params.membershipRequired));
+  and.push(...triStateWhere("flagsRequired", params.flagsRequired));
+  and.push(
+    ...triStateWhere("sparkArrestorRequired", params.sparkArrestorRequired),
+  );
+
+  return { AND: and };
+}
+
+/**
+ * Build a deterministic Prisma `orderBy` for the requested sort. Distance
+ * sort has no SQL equivalent (needs user coords) so it falls back to name —
+ * callers detect it via {@link isDistanceSort} and reorder in JS.
+ *
+ * A `name` + `id` tiebreaker is always appended so pagination is stable even
+ * when the primary key has ties or NULLs.
+ */
+export function buildParkOrderBy(
+  params: ParkFilterParams,
+): Prisma.ParkOrderByWithRelationInput[] {
+  const tiebreak: Prisma.ParkOrderByWithRelationInput[] = [
+    { name: "asc" },
+    { id: "asc" },
+  ];
+
+  switch (params.sort) {
+    case "price":
+      return [{ dayPassUSD: { sort: "asc", nulls: "last" } }, ...tiebreak];
+    case "miles":
+      return [{ milesOfTrails: { sort: "desc", nulls: "last" } }, ...tiebreak];
+    case "acres":
+      return [{ acres: { sort: "desc", nulls: "last" } }, ...tiebreak];
+    case "rating":
+      return [{ averageRating: { sort: "desc", nulls: "last" } }, ...tiebreak];
+    case "difficulty-high":
+      return [
+        { averageDifficulty: { sort: "desc", nulls: "last" } },
+        ...tiebreak,
+      ];
+    case "difficulty-low":
+      return [
+        { averageDifficulty: { sort: "asc", nulls: "last" } },
+        ...tiebreak,
+      ];
+    case "most-reviewed":
+      return [{ reviewCount: "desc" }, ...tiebreak];
+    case "name":
+    case "distance-nearest":
+    default:
+      return tiebreak;
+  }
+}

--- a/src/lib/park-filters.ts
+++ b/src/lib/park-filters.ts
@@ -119,6 +119,72 @@ export function parseParkFilterParams(
   };
 }
 
+/**
+ * The client Filters-panel state shape (as managed by `useFilteredParks`).
+ * Kept here so URL params can be mapped onto the initial hook state in exactly
+ * one place, keeping the server-rendered page and the client's mount state in
+ * sync for deep-linked / shared filtered URLs.
+ */
+export interface ParkFilterState {
+  searchQuery: string;
+  selectedState?: string;
+  selectedTerrains: string[];
+  selectedAmenities: string[];
+  selectedCamping: string[];
+  selectedVehicleTypes: string[];
+  minTrailMiles: number;
+  minAcres: number;
+  minRating: string;
+  selectedOwnership: string;
+  permitRequired: TriState;
+  membershipRequired: TriState;
+  flagsRequired: TriState;
+  sparkArrestorRequired: TriState;
+  sortOption: SortOption;
+}
+
+/** Map parsed filter params onto the client Filters-panel state shape. */
+export function parkFilterParamsToState(p: ParkFilterParams): ParkFilterState {
+  return {
+    searchQuery: p.q,
+    selectedState: p.state,
+    selectedTerrains: p.terrains,
+    selectedAmenities: p.amenities,
+    selectedCamping: p.camping,
+    selectedVehicleTypes: p.vehicleTypes,
+    minTrailMiles: p.minTrailMiles,
+    minAcres: p.minAcres,
+    minRating: p.minRating,
+    selectedOwnership: p.ownership,
+    permitRequired: p.permitRequired,
+    membershipRequired: p.membershipRequired,
+    flagsRequired: p.flagsRequired,
+    sparkArrestorRequired: p.sparkArrestorRequired,
+    sortOption: p.sort,
+  };
+}
+
+/**
+ * Convert a Next.js App Router `searchParams` record (string | string[] |
+ * undefined values) into a `URLSearchParams` so it can be fed to
+ * {@link parseParkFilterParams}. Array values (repeated query keys) are
+ * appended so multi-selects round-trip correctly.
+ */
+export function searchParamsToURLSearchParams(
+  record: Record<string, string | string[] | undefined>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(record)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) params.append(key, v);
+    } else {
+      params.append(key, value);
+    }
+  }
+  return params;
+}
+
 /** Client-side Filters-panel state shape used to build a request query. */
 export interface ParkQueryInput {
   searchQuery?: string;

--- a/src/lib/park-query.ts
+++ b/src/lib/park-query.ts
@@ -1,0 +1,246 @@
+/**
+ * Server-side park querying for the home page.
+ *
+ * Centralises the Prisma reads used by the paginated list endpoint, the map
+ * markers endpoint, and the server-rendered first page so the filter/sort
+ * logic (via `src/lib/park-filters.ts`) is applied in exactly one place.
+ */
+import { prisma } from "@/lib/prisma";
+import { resolveParkHeroImage } from "@/lib/park-hero";
+import { transformDbPark, type DbPark, type Park } from "@/lib/types";
+import { getBatchRainProbabilities } from "@/lib/weather";
+import { haversineDistance } from "@/lib/geo";
+import {
+  buildParkOrderBy,
+  buildParkWhere,
+  isDistanceSort,
+  PARK_PAGE_SIZE,
+  type ParkFilterParams,
+} from "@/lib/park-filters";
+
+/** Full relation graph needed to build a card-shaped `Park` (mirrors the
+ *  include the home page has always used). */
+const parkCardInclude = {
+  terrain: true,
+  amenities: true,
+  camping: true,
+  vehicleTypes: true,
+  address: true,
+  photos: {
+    where: { status: "APPROVED" as const },
+    take: 1,
+    orderBy: { createdAt: "desc" as const },
+    select: { id: true, url: true, status: true },
+  },
+  heroPhoto: {
+    select: { id: true, url: true, status: true },
+  },
+  trailConditions: {
+    where: { reportStatus: "PUBLISHED" as const },
+    orderBy: { createdAt: "desc" as const },
+    take: 1,
+    select: { id: true, status: true, reportStatus: true, createdAt: true },
+  },
+} as const;
+
+export interface ParkPage {
+  parks: Park[];
+  hasMore: boolean;
+  nextPage: number | null;
+  total: number;
+}
+
+/** Shape hero image + today's rain onto a page of raw Prisma parks. The
+ *  expensive weather fan-out is bounded to just this page. */
+async function decorateParks(dbParks: unknown[]): Promise<Park[]> {
+  const rows = dbParks as Array<
+    DbPark & {
+      latitude: number | null;
+      longitude: number | null;
+      address: { latitude: number | null; longitude: number | null } | null;
+    }
+  >;
+
+  const rainByParkId = await getBatchRainProbabilities(
+    rows.map((p) => ({
+      parkId: p.id,
+      latitude: p.latitude ?? p.address?.latitude ?? null,
+      longitude: p.longitude ?? p.address?.longitude ?? null,
+    })),
+  );
+
+  return rows.map((park) => ({
+    ...transformDbPark(park),
+    heroImage: resolveParkHeroImage(park as never),
+    todaysRainChance: rainByParkId.get(park.id) ?? null,
+  }));
+}
+
+/**
+ * Fetch one page of fully-shaped parks for the list view.
+ *
+ * Non-distance sorts are ordered + paginated entirely in Prisma so the DB
+ * only materialises one page. Distance sort has no SQL equivalent, so we load
+ * the matching set, order by great-circle distance in JS, then slice — but the
+ * costly hero/weather decoration still only runs on the returned page.
+ *
+ * @param page zero-based page index.
+ */
+export async function getParkPage(
+  params: ParkFilterParams,
+  page: number,
+  pageSize: number = PARK_PAGE_SIZE,
+): Promise<ParkPage> {
+  const where = buildParkWhere(params);
+  const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 0;
+  const skip = safePage * pageSize;
+
+  if (isDistanceSort(params.sort) && params.userLat != null && params.userLng != null) {
+    const userLat = params.userLat;
+    const userLng = params.userLng;
+
+    // Load matching parks (name-ordered for a stable base), then sort by
+    // distance. Parks without coordinates sort last (Infinity), matching the
+    // client comparator.
+    const all = await prisma.park.findMany({
+      where,
+      include: parkCardInclude,
+      orderBy: [{ name: "asc" }, { id: "asc" }],
+    });
+
+    const withDistance = all.map((p) => ({
+      park: p,
+      distance: p.latitude != null && p.longitude != null
+        ? haversineDistance(userLat, userLng, p.latitude, p.longitude)
+        : Number.POSITIVE_INFINITY,
+    }));
+    withDistance.sort((a, b) => a.distance - b.distance);
+
+    const total = withDistance.length;
+    const slice = withDistance.slice(skip, skip + pageSize).map((d) => d.park);
+    const parks = await decorateParks(slice);
+    const hasMore = skip + pageSize < total;
+    return { parks, hasMore, nextPage: hasMore ? safePage + 1 : null, total };
+  }
+
+  const [total, dbParks] = await Promise.all([
+    prisma.park.count({ where }),
+    prisma.park.findMany({
+      where,
+      include: parkCardInclude,
+      orderBy: buildParkOrderBy(params),
+      skip,
+      take: pageSize,
+    }),
+  ]);
+
+  const parks = await decorateParks(dbParks);
+  const hasMore = skip + parks.length < total;
+  return { parks, hasMore, nextPage: hasMore ? safePage + 1 : null, total };
+}
+
+/** Minimal fields the map markers + popups + route-builder need. */
+const parkMarkerSelect = {
+  slug: true,
+  name: true,
+  latitude: true,
+  longitude: true,
+  isFree: true,
+  dayPassUSD: true,
+  vehicleEntryFeeUSD: true,
+  riderFeeUSD: true,
+  membershipFeeUSD: true,
+  milesOfTrails: true,
+  acres: true,
+  address: { select: { city: true, state: true } },
+} as const;
+
+type ParkMarkerRow = {
+  slug: string;
+  name: string;
+  latitude: number | null;
+  longitude: number | null;
+  isFree: boolean | null;
+  dayPassUSD: number | null;
+  vehicleEntryFeeUSD: number | null;
+  riderFeeUSD: number | null;
+  membershipFeeUSD: number | null;
+  milesOfTrails: number | null;
+  acres: number | null;
+  address: { city: string | null; state: string } | null;
+};
+
+/** Build a card-compatible `Park` carrying only the fields the map view reads.
+ *  Relation arrays are empty (markers never render terrain/amenities). */
+export function toMarkerPark(row: ParkMarkerRow): Park {
+  return {
+    id: row.slug, // Park.id is the slug (see transformDbPark)
+    name: row.name,
+    coords:
+      row.latitude != null && row.longitude != null
+        ? { lat: row.latitude, lng: row.longitude }
+        : undefined,
+    isFree: row.isFree ?? undefined,
+    dayPassUSD: row.dayPassUSD ?? undefined,
+    vehicleEntryFeeUSD: row.vehicleEntryFeeUSD ?? undefined,
+    riderFeeUSD: row.riderFeeUSD ?? undefined,
+    membershipFeeUSD: row.membershipFeeUSD ?? undefined,
+    milesOfTrails: row.milesOfTrails ?? undefined,
+    acres: row.acres ?? undefined,
+    terrain: [],
+    amenities: [],
+    camping: [],
+    vehicleTypes: [],
+    address: {
+      city: row.address?.city ?? undefined,
+      state: row.address?.state ?? "Unknown",
+    },
+  };
+}
+
+/**
+ * Fetch ALL parks matching the filters as lightweight markers. No pagination —
+ * the map needs the full filtered set — but each object is a small projection
+ * so the payload stays bounded.
+ */
+export async function getParkMarkers(params: ParkFilterParams): Promise<Park[]> {
+  const where = buildParkWhere(params);
+  const rows = await prisma.park.findMany({
+    where,
+    select: parkMarkerSelect,
+    orderBy: [{ name: "asc" }, { id: "asc" }],
+  });
+  return rows.map(toMarkerPark);
+}
+
+export interface ParkFacets {
+  states: string[];
+  maxTrailMiles: number;
+  maxAcres: number;
+}
+
+/**
+ * Static facets for the Filters panel — the list of states plus the slider
+ * upper bounds. Computed over ALL approved parks (unfiltered) so the controls
+ * don't shrink as the user narrows results. Cheap aggregate queries.
+ */
+export async function getParkFacets(): Promise<ParkFacets> {
+  const [addresses, aggregate] = await Promise.all([
+    prisma.address.findMany({
+      where: { park: { status: "APPROVED" } },
+      select: { state: true },
+      distinct: ["state"],
+      orderBy: { state: "asc" },
+    }),
+    prisma.park.aggregate({
+      where: { status: "APPROVED" },
+      _max: { milesOfTrails: true, acres: true },
+    }),
+  ]);
+
+  return {
+    states: addresses.map((a) => a.state).filter(Boolean).sort(),
+    maxTrailMiles: aggregate._max.milesOfTrails ?? 500,
+    maxAcres: aggregate._max.acres ?? 10000,
+  };
+}

--- a/test/app/api/parks/route.test.ts
+++ b/test/app/api/parks/route.test.ts
@@ -1,273 +1,125 @@
 import { GET } from "@/app/api/parks/route";
-import { prisma } from "@/lib/prisma";
+import { getParkPage } from "@/lib/park-query";
 import { vi } from "vitest";
+import type { ParkPage } from "@/lib/park-query";
 
-// Mock Prisma
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    park: {
-      findMany: vi.fn(),
-    },
-  },
+// The route delegates the actual query to getParkPage; here we assert it
+// parses the request query string correctly and shapes the response.
+vi.mock("@/lib/park-query", () => ({
+  getParkPage: vi.fn(),
 }));
+
+const emptyPage: ParkPage = {
+  parks: [],
+  hasMore: false,
+  nextPage: null,
+  total: 0,
+};
+
+function req(query = ""): Request {
+  return new Request(`http://localhost/api/parks${query}`);
+}
 
 describe("GET /api/parks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getParkPage).mockResolvedValue(emptyPage);
   });
 
-  it("should return all approved parks", async () => {
-    // Arrange
-    const mockParks = [
-      {
-        id: "1",
-        name: "Test Park 1",
-        slug: "test-park-1",
-        latitude: 34.0522,
-        longitude: -118.2437,
-        website: "https://test1.com",
-        phone: "5551234567",
-        dayPassUSD: 25,
-        milesOfTrails: 50,
-        acres: 1000,
-        notes: "Great park",
-        status: "APPROVED",
-        terrain: [{ terrain: "sand" as const }],
-        amenities: [{ amenity: "restrooms" as const }],
-        camping: [],
-        vehicleTypes: [],
-        address: {
-          city: "Test City",
-          state: "CA",
-        },
-      },
-      {
-        id: "2",
-        name: "Test Park 2",
-        slug: "test-park-2",
-        latitude: null,
-        longitude: null,
-        website: null,
-        phone: null,
-        dayPassUSD: null,
-        milesOfTrails: null,
-        acres: null,
-        notes: null,
-        status: "APPROVED",
-        terrain: [],
-        amenities: [],
-        camping: [],
-        vehicleTypes: [],
-        address: {
-          city: null,
-          state: "TX",
-        },
-      },
-    ];
+  it("returns the paginated page shape", async () => {
+    const page: ParkPage = {
+      parks: [{ id: "p1", name: "Park 1", terrain: [], amenities: [], camping: [], vehicleTypes: [], address: { state: "CA" } }],
+      hasMore: true,
+      nextPage: 1,
+      total: 30,
+    };
+    vi.mocked(getParkPage).mockResolvedValue(page);
 
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockParks as any);
-
-    // Act
-    const response = await GET();
+    const response = await GET(req());
     const data = await response.json();
 
-    // Assert
     expect(response.status).toBe(200);
-    expect(Array.isArray(data)).toBe(true);
-    expect(data).toHaveLength(2);
+    expect(data).toEqual(page);
+  });
 
-    // Verify first park transformation
-    expect(data[0]).toMatchObject({
-      id: "test-park-1", // slug used as id
-      name: "Test Park 1",
-      coords: { lat: 34.0522, lng: -118.2437 },
-      website: "https://test1.com",
-      phone: "5551234567",
-      dayPassUSD: 25,
-      milesOfTrails: 50,
-      acres: 1000,
-      notes: "Great park",
-      terrain: ["sand"],
-      amenities: ["restrooms"],
-      camping: [],
-      vehicleTypes: [],
-      address: {
-        city: "Test City",
-        state: "CA",
-      },
-    });
-
-    // Verify second park (with null values)
-    expect(data[1]).toMatchObject({
-      id: "test-park-2",
-      name: "Test Park 2",
-      terrain: [],
-      amenities: [],
-      camping: [],
-      vehicleTypes: [],
-      address: {
-        state: "TX",
-      },
-    });
-
-    // Verify Prisma was called with correct filter
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { status: "APPROVED" },
-        include: expect.objectContaining({
-          terrain: true,
-          amenities: true,
-          camping: true,
-          vehicleTypes: true,
-          address: true,
-          trailConditions: expect.objectContaining({
-            where: expect.objectContaining({ reportStatus: "PUBLISHED" }),
-          }),
-        }),
-        orderBy: { name: "asc" },
-      }),
+  it("defaults to page 0 with the default page size", async () => {
+    await GET(req());
+    expect(getParkPage).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "name" }),
+      0,
+      24,
     );
   });
 
-  it("should return empty array when no parks exist", async () => {
-    // Arrange
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    // Act
-    const response = await GET();
-    const data = await response.json();
-
-    // Assert
-    expect(response.status).toBe(200);
-    expect(Array.isArray(data)).toBe(true);
-    expect(data).toHaveLength(0);
+  it("parses the requested page number", async () => {
+    await GET(req("?page=3"));
+    expect(getParkPage).toHaveBeenCalledWith(expect.anything(), 3, 24);
   });
 
-  it("should only return APPROVED parks", async () => {
-    // Arrange
-    const mockParks = [
-      {
-        id: "1",
-        name: "Approved Park",
-        slug: "approved-park",
-        latitude: null,
-        longitude: null,
-        website: null,
-        phone: null,
-        dayPassUSD: null,
-        milesOfTrails: null,
-        acres: null,
-        notes: null,
-        status: "APPROVED",
-        terrain: [],
-        amenities: [],
-        camping: [],
-        vehicleTypes: [],
-        address: {
-          city: null,
-          state: "CA",
-        },
-      },
-    ];
+  it("clamps invalid/negative pages to 0", async () => {
+    await GET(req("?page=-4"));
+    expect(getParkPage).toHaveBeenCalledWith(expect.anything(), 0, 24);
+  });
 
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockParks as any);
+  it("caps pageSize at 100", async () => {
+    await GET(req("?pageSize=500"));
+    expect(getParkPage).toHaveBeenCalledWith(expect.anything(), 0, 100);
+  });
 
-    // Act
-    await GET();
+  it("forwards all filter params to getParkPage", async () => {
+    await GET(
+      req(
+        "?q=sand&state=California&terrain=sand&terrain=rocks&amenity=fuel&camping=tent&vehicleType=atv&minTrailMiles=25&minAcres=500&minRating=4&ownership=public&permit=yes&membership=no&flags=yes&sparkArrestor=no&sort=rating",
+      ),
+    );
 
-    // Assert - should filter by APPROVED status
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
+    expect(getParkPage).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: {
-          status: "APPROVED",
-        },
+        q: "sand",
+        state: "California",
+        terrains: ["sand", "rocks"],
+        amenities: ["fuel"],
+        camping: ["tent"],
+        vehicleTypes: ["atv"],
+        minTrailMiles: 25,
+        minAcres: 500,
+        minRating: "4",
+        ownership: "public",
+        permitRequired: "yes",
+        membershipRequired: "no",
+        flagsRequired: "yes",
+        sparkArrestorRequired: "no",
+        sort: "rating",
       }),
+      0,
+      24,
     );
   });
 
-  it("should handle database errors gracefully", async () => {
-    // Arrange
-    const dbError = new Error("Database connection failed");
-    vi.mocked(prisma.park.findMany).mockRejectedValue(dbError);
+  it("passes user coordinates through for distance sort", async () => {
+    await GET(req("?sort=distance-nearest&lat=39.7&lng=-104.9"));
+    expect(getParkPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: "distance-nearest",
+        userLat: 39.7,
+        userLng: -104.9,
+      }),
+      0,
+      24,
+    );
+  });
 
-    // Mock console.error to avoid noise in test output
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
+  it("handles query errors gracefully", async () => {
+    const err = new Error("boom");
+    vi.mocked(getParkPage).mockRejectedValue(err);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    // Act
-    const response = await GET();
+    const response = await GET(req());
     const data = await response.json();
 
-    // Assert
     expect(response.status).toBe(500);
     expect(data).toEqual({ error: "Failed to fetch parks" });
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error fetching parks:",
-      dbError,
-    );
-
-    // Cleanup
-    consoleErrorSpy.mockRestore();
-  });
-
-  it("should transform parks with multiple terrain types", async () => {
-    // Arrange
-    const mockPark = {
-      id: "1",
-      name: "Multi-Terrain Park",
-      slug: "multi-terrain-park",
-      latitude: null,
-      longitude: null,
-      website: null,
-      phone: null,
-      dayPassUSD: null,
-      milesOfTrails: null,
-      acres: null,
-      notes: null,
-      status: "APPROVED",
-      terrain: [
-        { terrain: "sand" as const },
-        { terrain: "rocks" as const },
-        { terrain: "mud" as const },
-      ],
-      amenities: [
-        { amenity: "restrooms" as const },
-        { amenity: "fuel" as const },
-      ],
-      camping: [],
-      vehicleTypes: [],
-      address: {
-        city: "Test",
-        state: "CA",
-      },
-    };
-
-    vi.mocked(prisma.park.findMany).mockResolvedValue([mockPark] as any);
-
-    // Act
-    const response = await GET();
-    const data = await response.json();
-
-    // Assert
-    expect(data[0].terrain).toEqual(["sand", "rocks", "mud"]);
-    expect(data[0].amenities).toEqual(["restrooms", "fuel"]);
-  });
-
-  it("should order parks by name ascending", async () => {
-    // Arrange
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    // Act
-    await GET();
-
-    // Assert
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: {
-          name: "asc",
-        },
-      }),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith("Error fetching parks:", err);
+    consoleSpy.mockRestore();
   });
 });

--- a/test/app/page.test.tsx
+++ b/test/app/page.test.tsx
@@ -1,24 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import Page from "@/app/page";
-import { prisma } from "@/lib/prisma";
+import { getParkFacets, getParkMarkers, getParkPage } from "@/lib/park-query";
 import { vi } from "vitest";
+import type { ParkPage, ParkFacets } from "@/lib/park-query";
+import type { Park } from "@/lib/types";
 
-// Mock Prisma
-vi.mock("@/lib/prisma", () => ({
-  prisma: {
-    park: {
-      findMany: vi.fn(),
-    },
-  },
+// Mock the server query module — the page just wires it into the client app.
+vi.mock("@/lib/park-query", () => ({
+  getParkPage: vi.fn(),
+  getParkMarkers: vi.fn(),
+  getParkFacets: vi.fn(),
 }));
 
-// Mock the main app component
+// Mock the main app component so we can assert the props the page passes.
 vi.mock("@/components/ui/OffroadParksApp", () => ({
-  default: ({ parks }: any) => (
+  default: ({ initialData, initialMarkers, facets }: any) => (
     <div data-testid="utv-parks-app">
-      <h1>UTV Parks App</h1>
-      <div data-testid="parks-count">{parks.length} parks</div>
-      {parks.map((park: any) => (
+      <div data-testid="parks-count">{initialData.parks.length} parks</div>
+      <div data-testid="markers-count">{initialMarkers.length} markers</div>
+      <div data-testid="states-count">{facets.states.length} states</div>
+      {initialData.parks.map((park: Park) => (
         <div key={park.id} data-testid="park-item">
           {park.name}
         </div>
@@ -27,246 +28,84 @@ vi.mock("@/components/ui/OffroadParksApp", () => ({
   ),
 }));
 
+const makePark = (id: string, name: string): Park => ({
+  id,
+  name,
+  terrain: [],
+  amenities: [],
+  camping: [],
+  vehicleTypes: [],
+  address: { state: "California" },
+});
+
 describe("Homepage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render the app with parks data", async () => {
-    const mockDbParks = [
-      {
-        id: "park-1",
-        slug: "test-park-1",
-        name: "Test Park 1",
-        state: "California",
-        city: "Los Angeles",
-        latitude: 34.0522,
-        longitude: -118.2437,
-        dayPassUSD: 25,
-        milesOfTrails: 50,
-        acres: 1000,website: "https://testpark1.com",
-        phone: "5551234567",
-        notes: "Great park",
-        status: "APPROVED",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: "user-1",
-        terrain: [{ id: "1", name: "sand", parkId: "park-1" }],
-        difficulty: [{ id: "1", level: "moderate", parkId: "park-1" }],
-        amenities: [{ id: "1", name: "camping", parkId: "park-1" }],
-        
-      camping: [],vehicleTypes: [],
-        photos: [{ url: "https://example.com/photo1.jpg" }],
-      },
-      {
-        id: "park-2",
-        slug: "test-park-2",
-        name: "Test Park 2",
-        state: "Arizona",
-        city: null,
-        latitude: 33.4484,
-        longitude: -112.074,
-        dayPassUSD: null,
-        milesOfTrails: null,
-        acres: null,website: null,
-        phone: null,
-        notes: null,
-        status: "APPROVED",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: "user-1",
-        terrain: [{ id: "2", name: "rocks", parkId: "park-2" }],
-        difficulty: [],
-        amenities: [],
-        
-      camping: [],vehicleTypes: [],
-        photos: [],
-      },
-    ];
+  const page: ParkPage = {
+    parks: [makePark("test-park-1", "Test Park 1"), makePark("test-park-2", "Test Park 2")],
+    hasMore: true,
+    nextPage: 1,
+    total: 30,
+  };
+  const markers: Park[] = [makePark("test-park-1", "Test Park 1")];
+  const facets: ParkFacets = {
+    states: ["California", "Colorado"],
+    maxTrailMiles: 100,
+    maxAcres: 2000,
+  };
 
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockDbParks as any);
+  it("renders the app with the server-rendered first page", async () => {
+    vi.mocked(getParkPage).mockResolvedValue(page);
+    vi.mocked(getParkMarkers).mockResolvedValue(markers);
+    vi.mocked(getParkFacets).mockResolvedValue(facets);
 
     const component = await Page();
     render(component);
 
     expect(screen.getByTestId("utv-parks-app")).toBeInTheDocument();
     expect(screen.getByText("2 parks")).toBeInTheDocument();
+    expect(screen.getByText("1 markers")).toBeInTheDocument();
+    expect(screen.getByText("2 states")).toBeInTheDocument();
+    expect(screen.getByText("Test Park 1")).toBeInTheDocument();
   });
 
-  it("should only fetch approved parks", async () => {
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
+  it("fetches page 0 with default (unfiltered, name-sorted) params", async () => {
+    vi.mocked(getParkPage).mockResolvedValue(page);
+    vi.mocked(getParkMarkers).mockResolvedValue(markers);
+    vi.mocked(getParkFacets).mockResolvedValue(facets);
 
     await Page();
 
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { status: "APPROVED" },
-      }),
+    expect(getParkPage).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "name", q: "", terrains: [] }),
+      0,
     );
-  });
-
-  it("should include terrain, amenities, camping, vehicleTypes, and address", async () => {
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    await Page();
-
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        include: expect.objectContaining({
-          terrain: true,
-          amenities: true,
-          camping: true,
-          vehicleTypes: true,
-          address: true,
-        }),
-      }),
+    expect(getParkMarkers).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "name" }),
     );
+    expect(getParkFacets).toHaveBeenCalled();
   });
 
-  it("should fetch approved photos", async () => {
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    await Page();
-
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        include: expect.objectContaining({
-          photos: expect.objectContaining({
-            where: { status: "APPROVED" },
-            take: 1,
-          }),
-        }),
-      }),
-    );
-  });
-
-  it("should order parks by name", async () => {
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    await Page();
-
-    expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: { name: "asc" },
-      }),
-    );
-  });
-
-  it("should handle parks with hero images", async () => {
-    const mockDbParks = [
-      {
-        id: "park-1",
-        slug: "test-park",
-        name: "Test Park",
-        state: "California",
-        city: "LA",
-        latitude: 34,
-        longitude: -118,
-        dayPassUSD: 25,
-        milesOfTrails: 50,
-        acres: 1000,website: null,
-        phone: null,
-        notes: null,
-        status: "APPROVED",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: "user-1",
-        terrain: [],
-        difficulty: [],
-        amenities: [],
-        
-      camping: [],vehicleTypes: [],
-        photos: [{ url: "https://example.com/hero.jpg" }],
-      },
-    ];
-
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockDbParks as any);
-
-    const component = await Page();
-    render(component);
-
-    expect(screen.getByText("Test Park")).toBeInTheDocument();
-  });
-
-  it("should handle parks without hero images", async () => {
-    const mockDbParks = [
-      {
-        id: "park-1",
-        slug: "test-park",
-        name: "Test Park No Photo",
-        state: "Texas",
-        city: null,
-        latitude: 30,
-        longitude: -98,
-        dayPassUSD: null,
-        milesOfTrails: null,
-        acres: null,website: null,
-        phone: null,
-        notes: null,
-        status: "APPROVED",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: "user-1",
-        terrain: [],
-        difficulty: [],
-        amenities: [],
-        
-      camping: [],vehicleTypes: [],
-        photos: [],
-      },
-    ];
-
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockDbParks as any);
-
-    const component = await Page();
-    render(component);
-
-    expect(screen.getByText("Test Park No Photo")).toBeInTheDocument();
-  });
-
-  it("should render with empty parks array", async () => {
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
+  it("renders with an empty first page", async () => {
+    vi.mocked(getParkPage).mockResolvedValue({
+      parks: [],
+      hasMore: false,
+      nextPage: null,
+      total: 0,
+    });
+    vi.mocked(getParkMarkers).mockResolvedValue([]);
+    vi.mocked(getParkFacets).mockResolvedValue({
+      states: [],
+      maxTrailMiles: 500,
+      maxAcres: 10000,
+    });
 
     const component = await Page();
     render(component);
 
     expect(screen.getByTestId("utv-parks-app")).toBeInTheDocument();
     expect(screen.getByText("0 parks")).toBeInTheDocument();
-  });
-
-  it("should transform database parks to client format", async () => {
-    const mockDbParks = [
-      {
-        id: "park-1",
-        slug: "test-park",
-        name: "Test Park",
-        state: "California",
-        city: "LA",
-        latitude: 34.0522,
-        longitude: -118.2437,
-        dayPassUSD: 25,
-        milesOfTrails: 50,
-        acres: 1000,website: "https://test.com",
-        phone: "5551234567",
-        notes: "Test notes",
-        status: "APPROVED",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdBy: "user-1",
-        terrain: [{ id: "1", name: "sand", parkId: "park-1" }],
-        difficulty: [{ id: "1", level: "moderate", parkId: "park-1" }],
-        amenities: [{ id: "1", name: "camping", parkId: "park-1" }],
-        
-      camping: [],vehicleTypes: [],
-        photos: [{ url: "https://example.com/photo.jpg" }],
-      },
-    ];
-
-    vi.mocked(prisma.park.findMany).mockResolvedValue(mockDbParks as any);
-
-    const component = await Page();
-    render(component);
-
-    expect(screen.getByText("Test Park")).toBeInTheDocument();
   });
 });

--- a/test/app/page.test.tsx
+++ b/test/app/page.test.tsx
@@ -56,12 +56,17 @@ describe("Homepage", () => {
     maxAcres: 2000,
   };
 
+  // Helper: Next 16 passes searchParams as an async prop.
+  const props = (
+    sp: Record<string, string | string[] | undefined> = {},
+  ) => ({ searchParams: Promise.resolve(sp) });
+
   it("renders the app with the server-rendered first page", async () => {
     vi.mocked(getParkPage).mockResolvedValue(page);
     vi.mocked(getParkMarkers).mockResolvedValue(markers);
     vi.mocked(getParkFacets).mockResolvedValue(facets);
 
-    const component = await Page();
+    const component = await Page(props());
     render(component);
 
     expect(screen.getByTestId("utv-parks-app")).toBeInTheDocument();
@@ -76,7 +81,7 @@ describe("Homepage", () => {
     vi.mocked(getParkMarkers).mockResolvedValue(markers);
     vi.mocked(getParkFacets).mockResolvedValue(facets);
 
-    await Page();
+    await Page(props());
 
     expect(getParkPage).toHaveBeenCalledWith(
       expect.objectContaining({ sort: "name", q: "", terrains: [] }),
@@ -86,6 +91,37 @@ describe("Homepage", () => {
       expect.objectContaining({ sort: "name" }),
     );
     expect(getParkFacets).toHaveBeenCalled();
+  });
+
+  it("server-renders a FILTERED first page + markers from URL searchParams", async () => {
+    vi.mocked(getParkPage).mockResolvedValue(page);
+    vi.mocked(getParkMarkers).mockResolvedValue(markers);
+    vi.mocked(getParkFacets).mockResolvedValue(facets);
+
+    // Deep link: /?state=Arkansas
+    await Page(props({ state: "Arkansas" }));
+
+    expect(getParkPage).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "Arkansas" }),
+      0,
+    );
+    expect(getParkMarkers).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "Arkansas" }),
+    );
+  });
+
+  it("handles repeated multi-select params (array searchParams values)", async () => {
+    vi.mocked(getParkPage).mockResolvedValue(page);
+    vi.mocked(getParkMarkers).mockResolvedValue(markers);
+    vi.mocked(getParkFacets).mockResolvedValue(facets);
+
+    // /?terrain=sand&terrain=rocks&sort=rating
+    await Page(props({ terrain: ["sand", "rocks"], sort: "rating" }));
+
+    expect(getParkPage).toHaveBeenCalledWith(
+      expect.objectContaining({ terrains: ["sand", "rocks"], sort: "rating" }),
+      0,
+    );
   });
 
   it("renders with an empty first page", async () => {
@@ -102,7 +138,7 @@ describe("Homepage", () => {
       maxAcres: 10000,
     });
 
-    const component = await Page();
+    const component = await Page(props());
     render(component);
 
     expect(screen.getByTestId("utv-parks-app")).toBeInTheDocument();

--- a/test/hooks/useFilteredParks.test.ts
+++ b/test/hooks/useFilteredParks.test.ts
@@ -55,6 +55,31 @@ describe("useFilteredParks", () => {
     },
   ];
 
+  it("should seed panel state + sort from initialState (deep-linked URL)", () => {
+    const { result } = renderHook(() =>
+      useFilteredParks({
+        parks: mockParks,
+        initialState: {
+          selectedState: "California",
+          selectedTerrains: ["sand"],
+          minTrailMiles: 20,
+          permitRequired: "yes",
+          sortOption: "rating",
+        },
+      }),
+    );
+
+    expect(result.current.selectedState).toBe("California");
+    expect(result.current.selectedTerrains).toEqual(["sand"]);
+    expect(result.current.minTrailMiles).toBe(20);
+    expect(result.current.permitRequired).toBe("yes");
+    expect(result.current.sortOption).toBe("rating");
+    // And the seeded filters actually narrow the list on first render.
+    expect(
+      result.current.filteredParks.every((p) => p.address.state === "California"),
+    ).toBe(true);
+  });
+
   it("should initialize with all parks sorted by name", () => {
     const { result } = renderHook(() => useFilteredParks({ parks: mockParks }));
 

--- a/test/lib/park-filters.test.ts
+++ b/test/lib/park-filters.test.ts
@@ -3,7 +3,9 @@ import {
   buildParkQueryString,
   buildParkWhere,
   isDistanceSort,
+  parkFilterParamsToState,
   parseParkFilterParams,
+  searchParamsToURLSearchParams,
   PARK_PAGE_SIZE,
   type ParkFilterParams,
 } from "@/lib/park-filters";
@@ -258,6 +260,60 @@ describe("buildParkQueryString", () => {
     });
     expect(qs.get("lat")).toBe("39.7");
     expect(qs.get("lng")).toBe("-104.9");
+  });
+});
+
+describe("searchParamsToURLSearchParams", () => {
+  it("converts scalar values", () => {
+    const params = searchParamsToURLSearchParams({ state: "Arkansas", sort: "rating" });
+    expect(params.get("state")).toBe("Arkansas");
+    expect(params.get("sort")).toBe("rating");
+  });
+
+  it("appends array (repeated) values", () => {
+    const params = searchParamsToURLSearchParams({ terrain: ["sand", "rocks"] });
+    expect(params.getAll("terrain")).toEqual(["sand", "rocks"]);
+  });
+
+  it("skips undefined values", () => {
+    const params = searchParamsToURLSearchParams({ state: undefined, sort: "name" });
+    expect(params.has("state")).toBe(false);
+    expect(params.get("sort")).toBe("name");
+  });
+
+  it("round-trips a filtered URL record through parseParkFilterParams", () => {
+    const record = { state: "Arkansas", terrain: ["sand", "rocks"], sort: "rating" };
+    const parsed = parseParkFilterParams(searchParamsToURLSearchParams(record));
+    expect(parsed).toMatchObject({
+      state: "Arkansas",
+      terrains: ["sand", "rocks"],
+      sort: "rating",
+    });
+  });
+});
+
+describe("parkFilterParamsToState", () => {
+  it("maps parsed params onto the client Filters-panel state shape", () => {
+    const params = parseParkFilterParams(
+      new URLSearchParams("q=dunes&state=Arkansas&terrain=sand&minTrailMiles=25&permit=yes&sort=rating"),
+    );
+    expect(parkFilterParamsToState(params)).toEqual({
+      searchQuery: "dunes",
+      selectedState: "Arkansas",
+      selectedTerrains: ["sand"],
+      selectedAmenities: [],
+      selectedCamping: [],
+      selectedVehicleTypes: [],
+      minTrailMiles: 25,
+      minAcres: 0,
+      minRating: "",
+      selectedOwnership: "",
+      permitRequired: "yes",
+      membershipRequired: "",
+      flagsRequired: "",
+      sparkArrestorRequired: "",
+      sortOption: "rating",
+    });
   });
 });
 

--- a/test/lib/park-filters.test.ts
+++ b/test/lib/park-filters.test.ts
@@ -1,0 +1,273 @@
+import {
+  buildParkOrderBy,
+  buildParkQueryString,
+  buildParkWhere,
+  isDistanceSort,
+  parseParkFilterParams,
+  PARK_PAGE_SIZE,
+  type ParkFilterParams,
+} from "@/lib/park-filters";
+
+const base: ParkFilterParams = {
+  q: "",
+  state: undefined,
+  terrains: [],
+  amenities: [],
+  camping: [],
+  vehicleTypes: [],
+  minTrailMiles: 0,
+  minAcres: 0,
+  minRating: "",
+  ownership: "",
+  permitRequired: "",
+  membershipRequired: "",
+  flagsRequired: "",
+  sparkArrestorRequired: "",
+  sort: "name",
+};
+
+describe("parseParkFilterParams", () => {
+  it("returns defaults for an empty query string", () => {
+    expect(parseParkFilterParams(new URLSearchParams())).toEqual(base);
+  });
+
+  it("parses all supported filters", () => {
+    const params = new URLSearchParams(
+      "q=%20sand%20&state=California&terrain=sand&terrain=rocks&amenity=fuel&camping=tent&vehicleType=atv&minTrailMiles=25&minAcres=500&minRating=4&ownership=public&permit=yes&membership=no&flags=yes&sparkArrestor=no&sort=rating",
+    );
+    expect(parseParkFilterParams(params)).toEqual({
+      q: "sand",
+      state: "California",
+      terrains: ["sand", "rocks"],
+      amenities: ["fuel"],
+      camping: ["tent"],
+      vehicleTypes: ["atv"],
+      minTrailMiles: 25,
+      minAcres: 500,
+      minRating: "4",
+      ownership: "public",
+      permitRequired: "yes",
+      membershipRequired: "no",
+      flagsRequired: "yes",
+      sparkArrestorRequired: "no",
+      sort: "rating",
+      userLat: undefined,
+      userLng: undefined,
+    });
+  });
+
+  it("supports comma-separated multi-selects", () => {
+    const params = new URLSearchParams("terrain=sand,rocks,mud");
+    expect(parseParkFilterParams(params).terrains).toEqual([
+      "sand",
+      "rocks",
+      "mud",
+    ]);
+  });
+
+  it("falls back to name sort for an unknown sort value", () => {
+    expect(parseParkFilterParams(new URLSearchParams("sort=bogus")).sort).toBe(
+      "name",
+    );
+  });
+
+  it("parses user coordinates for distance sort", () => {
+    const params = parseParkFilterParams(
+      new URLSearchParams("sort=distance-nearest&lat=39.7&lng=-104.9"),
+    );
+    expect(params.userLat).toBe(39.7);
+    expect(params.userLng).toBe(-104.9);
+  });
+
+  it("ignores non-numeric coordinates and slider values", () => {
+    const params = parseParkFilterParams(
+      new URLSearchParams("lat=abc&lng=xyz&minTrailMiles=nope"),
+    );
+    expect(params.userLat).toBeUndefined();
+    expect(params.userLng).toBeUndefined();
+    expect(params.minTrailMiles).toBe(0);
+  });
+});
+
+describe("buildParkWhere", () => {
+  it("always constrains to APPROVED status", () => {
+    const where = buildParkWhere(base);
+    expect(where.AND).toContainEqual({ status: "APPROVED" });
+  });
+
+  it("builds a case-insensitive OR search across name/notes/city/state", () => {
+    const where = buildParkWhere({ ...base, q: "dunes" });
+    const search = (where.AND as any[]).find((c) => c.OR);
+    expect(search.OR).toEqual([
+      { name: { contains: "dunes", mode: "insensitive" } },
+      { notes: { contains: "dunes", mode: "insensitive" } },
+      { address: { city: { contains: "dunes", mode: "insensitive" } } },
+      { address: { state: { contains: "dunes", mode: "insensitive" } } },
+    ]);
+  });
+
+  it("filters relations with `some ... in`", () => {
+    const where = buildParkWhere({
+      ...base,
+      terrains: ["sand"],
+      amenities: ["fuel"],
+      camping: ["tent"],
+      vehicleTypes: ["atv"],
+    });
+    const and = where.AND as any[];
+    expect(and).toContainEqual({ terrain: { some: { terrain: { in: ["sand"] } } } });
+    expect(and).toContainEqual({ amenities: { some: { amenity: { in: ["fuel"] } } } });
+    expect(and).toContainEqual({ camping: { some: { camping: { in: ["tent"] } } } });
+    expect(and).toContainEqual({
+      vehicleTypes: { some: { vehicleType: { in: ["atv"] } } },
+    });
+  });
+
+  it("applies numeric gte thresholds only when > 0", () => {
+    const none = buildParkWhere(base).AND as any[];
+    expect(none.some((c) => c.milesOfTrails)).toBe(false);
+    expect(none.some((c) => c.acres)).toBe(false);
+
+    const some = buildParkWhere({
+      ...base,
+      minTrailMiles: 30,
+      minAcres: 500,
+      minRating: "4",
+    }).AND as any[];
+    expect(some).toContainEqual({ milesOfTrails: { gte: 30 } });
+    expect(some).toContainEqual({ acres: { gte: 500 } });
+    expect(some).toContainEqual({ averageRating: { gte: 4 } });
+  });
+
+  it("maps tri-state 'yes' to true", () => {
+    const and = buildParkWhere({ ...base, permitRequired: "yes" }).AND as any[];
+    expect(and).toContainEqual({ permitRequired: true });
+  });
+
+  it("maps tri-state 'no' to false OR null (so NULLs are included)", () => {
+    const and = buildParkWhere({ ...base, flagsRequired: "no" }).AND as any[];
+    expect(and).toContainEqual({
+      OR: [{ flagsRequired: false }, { flagsRequired: null }],
+    });
+  });
+
+  it("filters by exact state and ownership", () => {
+    const and = buildParkWhere({
+      ...base,
+      state: "Colorado",
+      ownership: "public",
+    }).AND as any[];
+    expect(and).toContainEqual({ address: { state: "Colorado" } });
+    expect(and).toContainEqual({ ownership: "public" });
+  });
+});
+
+describe("buildParkOrderBy", () => {
+  it("orders by name with an id tiebreaker by default", () => {
+    expect(buildParkOrderBy(base)).toEqual([{ name: "asc" }, { id: "asc" }]);
+  });
+
+  it("orders price ascending with nulls last", () => {
+    expect(buildParkOrderBy({ ...base, sort: "price" })[0]).toEqual({
+      dayPassUSD: { sort: "asc", nulls: "last" },
+    });
+  });
+
+  it("orders miles/acres/rating descending with nulls last", () => {
+    expect(buildParkOrderBy({ ...base, sort: "miles" })[0]).toEqual({
+      milesOfTrails: { sort: "desc", nulls: "last" },
+    });
+    expect(buildParkOrderBy({ ...base, sort: "acres" })[0]).toEqual({
+      acres: { sort: "desc", nulls: "last" },
+    });
+    expect(buildParkOrderBy({ ...base, sort: "rating" })[0]).toEqual({
+      averageRating: { sort: "desc", nulls: "last" },
+    });
+  });
+
+  it("orders difficulty in both directions", () => {
+    expect(buildParkOrderBy({ ...base, sort: "difficulty-high" })[0]).toEqual({
+      averageDifficulty: { sort: "desc", nulls: "last" },
+    });
+    expect(buildParkOrderBy({ ...base, sort: "difficulty-low" })[0]).toEqual({
+      averageDifficulty: { sort: "asc", nulls: "last" },
+    });
+  });
+
+  it("orders most-reviewed descending", () => {
+    expect(buildParkOrderBy({ ...base, sort: "most-reviewed" })[0]).toEqual({
+      reviewCount: "desc",
+    });
+  });
+
+  it("falls back to the name tiebreaker for distance sort", () => {
+    expect(buildParkOrderBy({ ...base, sort: "distance-nearest" })).toEqual([
+      { name: "asc" },
+      { id: "asc" },
+    ]);
+  });
+});
+
+describe("buildParkQueryString", () => {
+  it("emits nothing for default state", () => {
+    expect(buildParkQueryString({}).toString()).toBe("");
+  });
+
+  it("omits the default name sort but keeps other sorts", () => {
+    expect(buildParkQueryString({ sortOption: "name" }).toString()).toBe("");
+    expect(buildParkQueryString({ sortOption: "rating" }).toString()).toBe(
+      "sort=rating",
+    );
+  });
+
+  it("serialises multi-selects as repeated params", () => {
+    const qs = buildParkQueryString({
+      selectedTerrains: ["sand", "rocks"],
+    }).toString();
+    expect(qs).toBe("terrain=sand&terrain=rocks");
+  });
+
+  it("round-trips through parse", () => {
+    const qs = buildParkQueryString({
+      searchQuery: "dunes",
+      selectedState: "California",
+      selectedTerrains: ["sand"],
+      minTrailMiles: 25,
+      permitRequired: "yes",
+      sortOption: "rating",
+    });
+    const parsed = parseParkFilterParams(new URLSearchParams(qs.toString()));
+    expect(parsed).toMatchObject({
+      q: "dunes",
+      state: "California",
+      terrains: ["sand"],
+      minTrailMiles: 25,
+      permitRequired: "yes",
+      sort: "rating",
+    });
+  });
+
+  it("only forwards coordinates for distance sort", () => {
+    const coords = { lat: 39.7, lng: -104.9 };
+    expect(
+      buildParkQueryString({ sortOption: "name", userCoords: coords }).has("lat"),
+    ).toBe(false);
+    const qs = buildParkQueryString({
+      sortOption: "distance-nearest",
+      userCoords: coords,
+    });
+    expect(qs.get("lat")).toBe("39.7");
+    expect(qs.get("lng")).toBe("-104.9");
+  });
+});
+
+describe("misc", () => {
+  it("isDistanceSort only matches distance-nearest", () => {
+    expect(isDistanceSort("distance-nearest")).toBe(true);
+    expect(isDistanceSort("name")).toBe(false);
+  });
+
+  it("exposes a page size", () => {
+    expect(PARK_PAGE_SIZE).toBeGreaterThan(0);
+  });
+});

--- a/test/lib/park-query.test.ts
+++ b/test/lib/park-query.test.ts
@@ -1,0 +1,223 @@
+import { vi } from "vitest";
+import {
+  getParkFacets,
+  getParkMarkers,
+  getParkPage,
+  toMarkerPark,
+} from "@/lib/park-query";
+import { prisma } from "@/lib/prisma";
+import { getBatchRainProbabilities } from "@/lib/weather";
+import type { ParkFilterParams } from "@/lib/park-filters";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    park: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      aggregate: vi.fn(),
+    },
+    address: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/weather", () => ({
+  getBatchRainProbabilities: vi.fn(),
+}));
+
+const params: ParkFilterParams = {
+  q: "",
+  state: undefined,
+  terrains: [],
+  amenities: [],
+  camping: [],
+  vehicleTypes: [],
+  minTrailMiles: 0,
+  minAcres: 0,
+  minRating: "",
+  ownership: "",
+  permitRequired: "",
+  membershipRequired: "",
+  flagsRequired: "",
+  sparkArrestorRequired: "",
+  sort: "name",
+};
+
+function dbPark(id: string, name: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    slug: id,
+    name,
+    latitude: 34,
+    longitude: -118,
+    terrain: [],
+    amenities: [],
+    camping: [],
+    vehicleTypes: [],
+    address: { state: "California", city: "LA", latitude: 34, longitude: -118 },
+    photos: [],
+    trailConditions: [],
+    ...extra,
+  };
+}
+
+describe("getParkPage (offset pagination)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getBatchRainProbabilities).mockResolvedValue(new Map());
+  });
+
+  it("returns a decorated page with pagination metadata", async () => {
+    vi.mocked(prisma.park.count).mockResolvedValue(30);
+    vi.mocked(prisma.park.findMany).mockResolvedValue([
+      dbPark("p1", "Park 1"),
+      dbPark("p2", "Park 2"),
+    ] as never);
+
+    const result = await getParkPage(params, 0, 2);
+
+    expect(result.total).toBe(30);
+    expect(result.parks).toHaveLength(2);
+    expect(result.parks[0].id).toBe("p1"); // slug used as id
+    expect(result.hasMore).toBe(true);
+    expect(result.nextPage).toBe(1);
+    expect(result.parks[0]).toHaveProperty("todaysRainChance");
+  });
+
+  it("uses skip/take derived from the page index", async () => {
+    vi.mocked(prisma.park.count).mockResolvedValue(30);
+    vi.mocked(prisma.park.findMany).mockResolvedValue([] as never);
+
+    await getParkPage(params, 2, 10);
+
+    expect(prisma.park.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 10 }),
+    );
+  });
+
+  it("reports hasMore=false on the final page", async () => {
+    vi.mocked(prisma.park.count).mockResolvedValue(2);
+    vi.mocked(prisma.park.findMany).mockResolvedValue([
+      dbPark("p1", "Park 1"),
+      dbPark("p2", "Park 2"),
+    ] as never);
+
+    const result = await getParkPage(params, 0, 24);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextPage).toBeNull();
+  });
+});
+
+describe("getParkPage (distance sort)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getBatchRainProbabilities).mockResolvedValue(new Map());
+  });
+
+  it("orders by great-circle distance and paginates in JS", async () => {
+    // Denver user; LA park is far, Denver park is near, no-coords park last.
+    vi.mocked(prisma.park.findMany).mockResolvedValue([
+      dbPark("la", "LA Park", { latitude: 34, longitude: -118 }),
+      dbPark("den", "Denver Park", { latitude: 39.7, longitude: -104.9 }),
+      dbPark("none", "No Coords", { latitude: null, longitude: null }),
+    ] as never);
+
+    const result = await getParkPage(
+      { ...params, sort: "distance-nearest", userLat: 39.74, userLng: -104.99 },
+      0,
+      24,
+    );
+
+    expect(result.parks.map((p) => p.id)).toEqual(["den", "la", "none"]);
+    expect(prisma.park.count).not.toHaveBeenCalled(); // JS path counts in-memory
+    expect(result.total).toBe(3);
+  });
+});
+
+describe("getParkMarkers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("projects rows into lightweight marker parks", async () => {
+    vi.mocked(prisma.park.findMany).mockResolvedValue([
+      {
+        slug: "p1",
+        name: "Park 1",
+        latitude: 34,
+        longitude: -118,
+        isFree: true,
+        dayPassUSD: null,
+        vehicleEntryFeeUSD: null,
+        riderFeeUSD: null,
+        membershipFeeUSD: null,
+        milesOfTrails: 50,
+        acres: 1000,
+        address: { city: "LA", state: "California" },
+      },
+    ] as never);
+
+    const markers = await getParkMarkers(params);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      id: "p1",
+      name: "Park 1",
+      coords: { lat: 34, lng: -118 },
+      milesOfTrails: 50,
+      acres: 1000,
+      terrain: [],
+      address: { city: "LA", state: "California" },
+    });
+  });
+});
+
+describe("toMarkerPark", () => {
+  it("omits coords when latitude/longitude are missing", () => {
+    const park = toMarkerPark({
+      slug: "x",
+      name: "X",
+      latitude: null,
+      longitude: null,
+      isFree: null,
+      dayPassUSD: null,
+      vehicleEntryFeeUSD: null,
+      riderFeeUSD: null,
+      membershipFeeUSD: null,
+      milesOfTrails: null,
+      acres: null,
+      address: null,
+    });
+    expect(park.coords).toBeUndefined();
+    expect(park.address.state).toBe("Unknown");
+  });
+});
+
+describe("getParkFacets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns distinct states and slider maxes", async () => {
+    vi.mocked(prisma.address.findMany).mockResolvedValue([
+      { state: "California" },
+      { state: "Colorado" },
+    ] as never);
+    vi.mocked(prisma.park.aggregate).mockResolvedValue({
+      _max: { milesOfTrails: 120, acres: 5000 },
+    } as never);
+
+    const facets = await getParkFacets();
+    expect(facets.states).toEqual(["California", "Colorado"]);
+    expect(facets.maxTrailMiles).toBe(120);
+    expect(facets.maxAcres).toBe(5000);
+  });
+
+  it("falls back to defaults when there is no data", async () => {
+    vi.mocked(prisma.address.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.park.aggregate).mockResolvedValue({
+      _max: { milesOfTrails: null, acres: null },
+    } as never);
+
+    const facets = await getParkFacets();
+    expect(facets.states).toEqual([]);
+    expect(facets.maxTrailMiles).toBe(500);
+    expect(facets.maxAcres).toBe(10000);
+  });
+});


### PR DESCRIPTION
## Summary

Reworks the landing page scroll UX in two parts: (A) a sticky search + filters region, and (B) replacing the "load ALL approved parks into the client" home query with infinite scroll backed by **server-side** filtering/sorting plus a lightweight map-markers endpoint.

## (A) Sticky search + filters

- The `AppHeader` and the search/sort bar (`SearchHeader`) are now wrapped in a single `sticky top-0 z-30 bg-background` block, so the search bar stays pinned directly below the app header while the list scrolls (solid background + z-index prevent cards showing through).
- The desktop filters sidebar is `lg:sticky` and sticks **directly beneath** the pinned header. Its `top` offset is measured from the header block via a `ResizeObserver` (`stickyOffset`), so it stays correct regardless of header height. The sidebar scrolls internally (`max-h`/`overflow-y-auto`) when the filter list is tall.
- Mobile is unchanged: filters stay in the slide-in `Sheet`; the sticky search bar (with the funnel trigger) works full-width.
- Map view is unaffected — the sticky top block applies to both tabs and behaves sensibly.

## (B) Pagination + markers architecture

- **List endpoint** `GET /api/parks` — now accepts every UI filter (`q`, `state`, `terrain`, `amenity`, `camping`, `vehicleType`, `minTrailMiles`, `minAcres`, `minRating`, `ownership`, `permit`, `membership`, `flags`, `sparkArrestor`, `sort`) plus `page`/`pageSize`. Filtering + sorting happen in Prisma; returns one page of fully card-shaped parks (via `transformDbPark` + `resolveParkHeroImage` + batched rain), plus `{ hasMore, nextPage, total }`. Hero/weather decoration is bounded to the returned page.
- **Markers endpoint** `GET /api/parks/markers` — same filters, returns **all** matching parks but as a minimal projection (id/slug, name, coords, and the pricing/location fields the popup renders). Keeps the map showing the full filtered set without shipping full park objects.
- **`page.tsx`** — still `force-dynamic`; SSR-fetches page 1 + markers + facets and passes them as initial data for fast first paint / SEO. The client takes over for subsequent pages.
- **`OffroadParksApp`** — list view seeds from initial data then appends pages via an `IntersectionObserver` sentinel; changing any search/filter/sort resets to page 1 and refetches (stale responses discarded via a monotonic generation id + a sync ref guard against duplicate `loadMore` fires). Loading indicator, empty state, and end-of-list state added. Map view fetches markers for the current filters when active. Favorites, route-builder, saved-routes overlay, view switching, and `?routeId`/`?view` URL behavior are preserved.

## Filter parity (no drift)

A single shared module `src/lib/park-filters.ts` is the source of truth:
- `buildParkQueryString(...)` — client serialises its Filters-panel state into the request query.
- `parseParkFilterParams(...)` + `buildParkWhere(...)` / `buildParkOrderBy(...)` — server parses that same query into Prisma `where`/`orderBy`.

The predicates mirror the old `useFilteredParks` semantics field-for-field (case-insensitive OR search over name/notes/city/state; `some … in` relation filters; `gte` thresholds; nulls-last sorts; and critically the tri-state **"no"** maps to `false OR null` so NULLs are included, matching the client's `!== true`). `useFilteredParks` is **retained** unchanged for filter state + its existing test suite; only its client-side `filteredParks` output is no longer used for rendering. Panel facets (state list + slider maxes) now come from a server `getParkFacets()` so they don't shrink as results narrow.

## Distance sort

Chose option (i): when distance sort is active and the browser has shared geolocation, the user's coords are forwarded to the API (`lat`/`lng`, only for distance sort to avoid leaking location into other requests/caches) and ordering is computed **server-side** by great-circle distance. Because SQL can't order by haversine, that one sort loads the filtered set and orders in JS, then paginates — but the payload to the client stays bounded to one page, and hero/weather decoration still runs only on the returned slice. Parks without coords sort last (Infinity), matching the old client comparator.

## Validation

- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (remaining warnings are pre-existing in `src/lib/ai/**`).
- `npm run test` — **160 files / 2131 tests pass**. Added `test/lib/park-filters.test.ts` and `test/lib/park-query.test.ts`; updated `test/app/api/parks/route.test.ts` and `test/app/page.test.tsx` for the new shapes.

## Verification notes / screenshots

⚠️ **No database is reachable in this sandbox** (no `POSTGRES_PRISMA_URL`; there is no `.env`). The dev server boots and compiles, but `/` is `force-dynamic` and server-fetches, so it renders the Next error page with `PrismaClientInitializationError: Environment variable not found: POSTGRES_PRISMA_URL` — a pure DB-connection issue, not a code defect. I could not capture live screenshots of the list/scroll/map/sticky states. Validation relied on lint + tsc + the full test suite.

**Please re-verify in a browser with a real DB before merging:**
1. First page renders; scrolling loads more pages (sentinel).
2. Changing a filter/search/sort resets to page 1 and refetches.
3. Map view shows the full **filtered** marker set (switch tabs after filtering).
4. Sticky header + filters stay pinned while scrolling (desktop sidebar sticks below the header; mobile sheet still works).
5. Distance sort ("Near Me") orders by distance and paginates correctly.
6. No console errors.

## Follow-ups / risks

- Nulls-last SQL ordering vs the old `?? 0` / `?? Infinity` JS fallbacks are equivalent except for the relative order of real-zero vs NULL values within a page — cosmetic only.
- Filter query-string params in the URL are still not wired to populate filter state (that was already the case before this PR); only the saved-default gate reads them. Left as-is to keep scope tight.
- `pageSize` is capped at 100; default page size is 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)