### PR TITLE
fix(parks): prevent park detail body overflow on mobile

### DIFF
--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -227,9 +227,12 @@ function ParkDetailPageInner({
             <ParkAlertsBanner alerts={alerts} />
           </div>
         )}
-        <div className="grid lg:grid-cols-3 gap-6">
-          {/* Main Content with Tabs */}
-          <div className="lg:col-span-2">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Main Content with Tabs. `min-w-0` lets this grid column shrink
+              below its content's intrinsic width on mobile — without it the
+              column grows to the widest child (e.g. the tab bar / cards) and
+              pushes the whole page past the viewport. */}
+          <div className="lg:col-span-2 min-w-0">
             <Tabs defaultValue="overview">
               <TabsList className="w-full justify-start mb-6">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
@@ -435,7 +438,7 @@ function ParkDetailPageInner({
           </div>
 
           {/* Sidebar */}
-          <div className="lg:col-span-1">
+          <div className="lg:col-span-1 min-w-0">
             <div className="sticky top-20 space-y-6">
               {/* Sidebar header image. Source priority mirrors the park
                   card (OP-90 + operator hero selection):


### PR DESCRIPTION
## Follow-up to #152

#152 addressed several element-level overflows (header, tab list `overflow-x-auto`, title band), but the park detail **body** still exceeded the viewport on narrow phones (reported on iPhone 17 Pro, ~402px): the Overview content, Terrain Types card, and the Overview/Photos/Reviews/Location tab bar all ran past the screen edge together.

## Root cause
The two-column layout used `grid lg:grid-cols-3` with **no explicit mobile column**. With `display:grid` and no column template, the single implicit column is `auto`-sized (max-content), so it grows to its widest child and drags every sibling — the tab bar, the Overview stat grid, the Terrain card — past the viewport with it. Because they all share that one over-wide column, they all overflow to the same right edge (which is exactly the symptom reported).

## Fix
- `grid grid-cols-1 lg:grid-cols-3` — the mobile column is now `minmax(0,1fr)`, bounded to the viewport and able to shrink.
- `min-w-0` on both the main (`lg:col-span-2`) and sidebar (`lg:col-span-1`) columns so a wide child can't force them wider than their track.

Once the column is viewport-bounded, the existing per-element handling does its job: the tab list scrolls internally, the terrain/amenity badges wrap, and the Overview `minmax(0,1fr)` grids stay in bounds.

## Verification
- `npm run lint` (0 errors), `npx tsc --noEmit` (clean), park-detail test suite green.
- Visual check at 402px on the preview deployment pending (see PR preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)