### PR TITLE
feat(alerts): daily Iowa DNR OHV closure scraper

### DIFF
--- a/scripts/check-iowa-ohv-alerts.ts
+++ b/scripts/check-iowa-ohv-alerts.ts
@@ -1,0 +1,65 @@
+/**
+ * Read-only preview of the Iowa DNR OHV alerts cron. Fetches the live alerts
+ * page and shows how each alert matches against the Iowa parks already in the
+ * DB — WITHOUT writing anything. Run this against prod (or dev) to confirm the
+ * daily cron will attach alerts to the right parks before it runs for real.
+ *
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/check-iowa-ohv-alerts.ts
+ *
+ * Reads POSTGRES_* from the env files, same as the other db:* scripts. No
+ * mutations, no bot user created — safe to run against production.
+ */
+import { prisma } from "../src/lib/prisma";
+import { fetchIowaOhvAlerts } from "../src/lib/iowa-ohv/parse";
+import { matchPark } from "../src/lib/iowa-ohv/sync";
+
+async function main() {
+  const iowaParks = await prisma.park.findMany({
+    where: {
+      status: "APPROVED",
+      address: { state: { in: ["Iowa", "IA"] } },
+    },
+    select: { id: true, name: true, address: { select: { county: true } } },
+    orderBy: { name: "asc" },
+  });
+
+  console.log(`\n🏞  Approved Iowa parks in DB: ${iowaParks.length}`);
+  for (const p of iowaParks) {
+    console.log(`   • ${p.name}${p.address?.county ? `  (${p.address.county})` : ""}`);
+  }
+
+  const alerts = await fetchIowaOhvAlerts();
+  console.log(`\n🚨 Live alerts on the Iowa DNR page: ${alerts.length}\n`);
+
+  let matched = 0;
+  const unmatched: string[] = [];
+  for (const a of alerts) {
+    const park = matchPark(a, iowaParks);
+    if (park) {
+      matched++;
+      console.log(`   ✅ "${a.parkName}" (${a.county}) → ${park.name}  [${a.statusLabel}]`);
+    } else {
+      unmatched.push(a.parkName);
+      console.log(`   ❌ "${a.parkName}" (${a.county}) → NO MATCH  [${a.statusLabel}]`);
+    }
+  }
+
+  console.log(`\nSummary: ${matched}/${alerts.length} matched.`);
+  if (unmatched.length) {
+    console.log(
+      `Unmatched: ${unmatched.join(", ")}\n` +
+        `  → If a park above IS in the DB list, the names differ too much — rename\n` +
+        `    the park or widen matching. If it's genuinely absent, seed it\n` +
+        `    (scripts/data/iowa-ohv-parks.json) — but check for near-duplicates first.`
+    );
+  } else if (alerts.length) {
+    console.log("All live alerts matched a park. The cron is good to go. 🎉");
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/data/iowa-ohv-parks.json
+++ b/scripts/data/iowa-ohv-parks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "River Valley OHV Park",
+    "city": "Council Bluffs",
+    "county": "Pottawattamie",
+    "lat": 41.208739,
+    "lng": -95.917785,
+    "url": "https://www.iowadnr.gov/locations/river-valley-closed"
+  }
+]

--- a/scripts/promote-to-prod.ts
+++ b/scripts/promote-to-prod.ts
@@ -13,17 +13,23 @@
  *    review aggregates are NOT copied.
  *  - Dry-run by default. Pass --commit to actually write.
  *
- *   # preview (writes nothing):
+ *  - Which parks: pass one or more exact park names as CLI args to promote just
+ *    those; with no names it falls back to DEFAULT_PROMOTE (the Arkansas batch).
+ *
+ *   # preview the default batch (writes nothing):
  *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts
+ *   # preview specific parks:
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts "River Valley OHV Park"
  *   # execute:
- *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts --commit
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/promote-to-prod.ts "River Valley OHV Park" --commit
  */
 import { PrismaClient } from "@prisma/client";
 import { prisma as dev } from "../src/lib/prisma";
 
-// The 15 verified, new-to-prod Arkansas parks (excludes the 3 known prod dupes:
-// 3B/Eureka Springs Adventure Park, Hot Springs Off-Road Park, Wolf Pen Gap).
-const PROMOTE = [
+// Default batch when no park names are passed on the CLI: the 15 verified,
+// new-to-prod Arkansas parks (excludes the 3 known prod dupes: 3B/Eureka
+// Springs Adventure Park, Hot Springs Off-Road Park, Wolf Pen Gap).
+const DEFAULT_PROMOTE = [
   "Buckhorn OHV Trails",
   "Mill Creek OHV Trail",
   "Brock Creek Trails",
@@ -62,6 +68,8 @@ function generateSlug(name: string): string {
 
 async function main() {
   const commit = process.argv.includes("--commit");
+  const cliNames = process.argv.slice(2).filter((a) => !a.startsWith("--"));
+  const PROMOTE = cliNames.length > 0 ? cliNames : DEFAULT_PROMOTE;
   const prodUrl = process.env.PROD_POSTGRES_URL ?? process.env.PROD_POSTGRES_PRISMA_URL;
   if (!prodUrl) {
     console.error(

--- a/src/app/api/cron/iowa-ohv-alerts/route.ts
+++ b/src/app/api/cron/iowa-ohv-alerts/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { syncIowaOhvAlerts } from "@/lib/iowa-ohv/sync";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+// The scrape + reconcile is quick, but give it headroom over the DNR fetch.
+export const maxDuration = 60;
+
+/**
+ * Daily cron: scrape the Iowa DNR OHV alerts page and reconcile park-closure
+ * banners. Wired up in vercel.json `crons`. Vercel attaches
+ * `Authorization: Bearer $CRON_SECRET` to scheduled invocations; we reject
+ * anything else once CRON_SECRET is configured.
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const summary = await syncIowaOhvAlerts({ prisma });
+    return NextResponse.json({ ok: true, ...summary });
+  } catch (error) {
+    console.error("[cron/iowa-ohv-alerts] sync failed", error);
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "sync failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/iowa-ohv/parse.ts
+++ b/src/lib/iowa-ohv/parse.ts
@@ -1,0 +1,133 @@
+import * as cheerio from "cheerio";
+
+/**
+ * Iowa DNR "All Active OHV Alerts" page. Lists current closures / usage
+ * limitations for state OHV parks. Server-rendered ASP.NET page with a stable,
+ * class-based layout — each alert is a bordered `.p-2` box containing a
+ * `.font-weight-bold` header (park name, "Effective:" date, status line, and
+ * county) plus an optional `.pt-1` extended-description block.
+ */
+export const IOWA_OHV_ALERTS_URL =
+  "https://programs.iowadnr.gov/parkforms/pages/ViewOHVAlerts";
+
+export interface IowaOhvAlert {
+  /** Park name exactly as printed, e.g. "Nicholson-Ford OHV Park". */
+  parkName: string;
+  /** County name without the "County" suffix, e.g. "Marshall". May be "". */
+  county: string;
+  /** Status heading, e.g. "PARK CLOSED" or "PARK OPEN BUT USE IS LIMITED". */
+  statusLabel: string;
+  /** Short reason printed after the status label, e.g. "Wet trail conditions". */
+  reason: string;
+  /** Extended description from the `.pt-1` block, if any. */
+  extraBody: string;
+  /** Raw "Effective:" date string as printed, e.g. "7/20/2026". */
+  effectiveDate: string | null;
+  /** True when the whole park is closed (vs. merely limited). */
+  closed: boolean;
+  /** True when the park is open but usage is restricted. */
+  limited: boolean;
+}
+
+function stripCounty(text: string): string {
+  return text.replace(/\bcounty\b/i, "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Parse the OHV alerts page HTML into structured alerts. Pure and testable —
+ * `fetchIowaOhvAlerts` handles the network call.
+ */
+export function parseIowaOhvAlerts(html: string): IowaOhvAlert[] {
+  const $ = cheerio.load(html);
+  const alerts: IowaOhvAlert[] = [];
+
+  $("div.p-2").each((_, box) => {
+    const $box = $(box);
+    const $header = $box.find("div.font-weight-bold").first();
+    if ($header.length === 0) return;
+
+    // The name/status block is the inline-block that is NOT the county float.
+    const $nameBlock = $header
+      .find("div.d-inline-block")
+      .not(".float-right")
+      .first();
+    if ($nameBlock.length === 0) return;
+
+    // Park name = leading text of the block, with the child <span>/<br> removed.
+    const $nameOnly = $nameBlock.clone();
+    $nameOnly.find("span, br").remove();
+    const parkName = $nameOnly
+      .text()
+      .replace(/[-–—]\s*$/, "")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (!parkName) return;
+
+    const spanTexts = $nameBlock
+      .find("span")
+      .map((_i, el) => $(el).text().trim())
+      .get()
+      .filter(Boolean);
+
+    const effectiveRaw = spanTexts.find((s) => /effective/i.test(s)) ?? null;
+    const effectiveDate = effectiveRaw
+      ? effectiveRaw.replace(/effective:?/i, "").trim() || null
+      : null;
+
+    // Status line = the last non-"Effective" span (falls back to full text).
+    const statusLine =
+      [...spanTexts].reverse().find((s) => !/effective/i.test(s)) ?? "";
+
+    const sep = statusLine.indexOf(" - ");
+    const statusLabel = (sep >= 0 ? statusLine.slice(0, sep) : statusLine).trim();
+    const reason = sep >= 0 ? statusLine.slice(sep + 3).trim() : "";
+
+    const county = stripCounty($header.find(".float-right").first().text());
+    const extraBody = $box
+      .find("div.pt-1")
+      .first()
+      .text()
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const closed = /\bclosed\b/i.test(statusLabel);
+    const limited = !closed && /(limited|open but)/i.test(statusLabel);
+
+    alerts.push({
+      parkName,
+      county,
+      statusLabel,
+      reason,
+      extraBody,
+      effectiveDate,
+      closed,
+      limited,
+    });
+  });
+
+  return alerts;
+}
+
+/**
+ * Fetch and parse the live Iowa DNR OHV alerts page.
+ */
+export async function fetchIowaOhvAlerts(
+  url: string = IOWA_OHV_ALERTS_URL
+): Promise<IowaOhvAlert[]> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(15_000),
+    headers: {
+      "User-Agent":
+        "OffroadParksBot/1.0 (park closure alerts; https://offroadparks.com)",
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Iowa OHV alerts: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return parseIowaOhvAlerts(await response.text());
+}

--- a/src/lib/iowa-ohv/sync.ts
+++ b/src/lib/iowa-ohv/sync.ts
@@ -1,0 +1,307 @@
+import type { PrismaClient, ParkAlertSeverity } from "@prisma/client";
+import {
+  fetchIowaOhvAlerts,
+  type IowaOhvAlert,
+} from "@/lib/iowa-ohv/parse";
+
+/**
+ * All Iowa DNR OHV alerts are posted under a single dedicated system user. That
+ * user id doubles as the "source" marker: any ParkAlert authored by it was
+ * created by this scraper (never by a human operator), so the daily sync can
+ * safely update / deactivate its own alerts without ever touching operator-
+ * authored ones.
+ */
+export const IOWA_OHV_BOT_EMAIL = "iowa-dnr-ohv-bot@system.offroadparks.com";
+export const IOWA_OHV_BOT_NAME = "Iowa DNR OHV Alerts";
+
+/** State values that identify an Iowa park in the Address table. */
+const IOWA_STATE_VALUES = ["Iowa", "IA"];
+
+/** Words dropped when normalizing park names for matching. */
+const NAME_STOPWORDS = new Set([
+  "ohv",
+  "orv",
+  "park",
+  "area",
+  "recreation",
+  "wildlife",
+  "state",
+  "the",
+  "and",
+  "of",
+]);
+
+export interface IowaOhvSyncSummary {
+  scraped: number;
+  matched: number;
+  created: number;
+  updated: number;
+  unchanged: number;
+  deactivated: number;
+  /** Park names from the DNR page that did not match a park in our DB. */
+  unmatched: string[];
+}
+
+/**
+ * Normalize a park name to a set of significant tokens for fuzzy matching.
+ * Lowercases, splits on non-alphanumerics (so "Nicholson-Ford" → nicholson,
+ * ford), and drops generic stopwords like "OHV" / "Park".
+ */
+function nameTokens(name: string): string[] {
+  return name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .filter((t) => t && !NAME_STOPWORDS.has(t));
+}
+
+function tokenKey(name: string): string {
+  return nameTokens(name).sort().join(" ");
+}
+
+type MatchablePark = {
+  id: string;
+  name: string;
+  address: { county: string | null } | null;
+};
+
+/**
+ * Find the park in `parks` that best matches a scraped DNR alert. Requires a
+ * confident match (identical significant-token set, or one token set fully
+ * containing the other with the county in agreement). Returns null otherwise,
+ * so ambiguous entries are logged as unmatched rather than mis-attributed.
+ */
+export function matchPark(
+  alert: IowaOhvAlert,
+  parks: MatchablePark[]
+): MatchablePark | null {
+  const alertKey = tokenKey(alert.parkName);
+  const alertTokens = new Set(nameTokens(alert.parkName));
+
+  // 1. Exact significant-token match.
+  const exact = parks.filter((p) => tokenKey(p.name) === alertKey);
+  if (exact.length === 1) return exact[0];
+
+  // 2. Subset/superset containment, disambiguated by county when needed.
+  const countyMatch = (p: MatchablePark) =>
+    !!alert.county &&
+    !!p.address?.county &&
+    p.address.county.toLowerCase().replace(/\s+county$/i, "").trim() ===
+      alert.county.toLowerCase().trim();
+
+  const contains = parks.filter((p) => {
+    const pTokens = new Set(nameTokens(p.name));
+    if (pTokens.size === 0 || alertTokens.size === 0) return false;
+    const aInP = [...alertTokens].every((t) => pTokens.has(t));
+    const pInA = [...pTokens].every((t) => alertTokens.has(t));
+    return aInP || pInA;
+  });
+
+  if (contains.length === 1) return contains[0];
+  if (contains.length > 1) {
+    const byCounty = contains.filter(countyMatch);
+    if (byCounty.length === 1) return byCounty[0];
+  }
+
+  if (exact.length > 1) {
+    const byCounty = exact.filter(countyMatch);
+    if (byCounty.length === 1) return byCounty[0];
+  }
+
+  return null;
+}
+
+/** Map a DNR status label to a ParkAlert severity. */
+export function severityForAlert(alert: IowaOhvAlert): ParkAlertSeverity {
+  if (alert.closed) return "DANGER";
+  return "WARNING";
+}
+
+/** Build a concise banner title (≤200 chars) from a status label. */
+export function alertTitle(alert: IowaOhvAlert): string {
+  const label = alert.closed
+    ? "Park Closed"
+    : alert.limited
+      ? "Park Open — Limited Use"
+      : titleCase(alert.statusLabel);
+  return label.slice(0, 200);
+}
+
+/** Build the banner body: reason, extended note, effective date, attribution. */
+export function alertBody(alert: IowaOhvAlert): string {
+  const parts: string[] = [];
+  if (alert.reason) parts.push(alert.reason);
+  if (alert.extraBody && alert.extraBody !== alert.reason)
+    parts.push(alert.extraBody);
+  if (alert.effectiveDate) parts.push(`Effective ${alert.effectiveDate}.`);
+  parts.push("Source: Iowa DNR OHV Alerts.");
+  return parts.join(" ").trim();
+}
+
+function titleCase(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+/** Parse a M/D/YYYY effective date to a Date, or null if unparseable. */
+function parseEffectiveDate(raw: string | null): Date | null {
+  if (!raw) return null;
+  const m = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!m) return null;
+  const [, month, day, year] = m;
+  const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+  return isNaN(date.getTime()) ? null : date;
+}
+
+/** Upsert the dedicated system user that owns all scraped OHV alerts. */
+export async function getOrCreateOhvBotUser(
+  prisma: Pick<PrismaClient, "user">
+): Promise<string> {
+  const user = await prisma.user.upsert({
+    where: { email: IOWA_OHV_BOT_EMAIL },
+    update: {},
+    create: { email: IOWA_OHV_BOT_EMAIL, name: IOWA_OHV_BOT_NAME },
+    select: { id: true },
+  });
+  return user.id;
+}
+
+type SyncPrisma = Pick<PrismaClient, "user" | "park" | "parkAlert">;
+
+export interface SyncOptions {
+  prisma: SyncPrisma;
+  /** Injectable for tests; defaults to the live DNR fetch. */
+  fetcher?: () => Promise<IowaOhvAlert[]>;
+}
+
+/**
+ * Fetch the live Iowa DNR OHV alerts, match each to an approved Iowa park, and
+ * reconcile ParkAlert banners:
+ *   - matched park with no active bot alert  → create
+ *   - matched park with a stale bot alert    → update (title/body/severity)
+ *   - matched park with an up-to-date alert  → leave as-is
+ *   - active bot alert whose park dropped off → deactivate (closure lifted)
+ *
+ * Idempotent: running twice with the same page is a no-op after the first run.
+ */
+export async function syncIowaOhvAlerts({
+  prisma,
+  fetcher = fetchIowaOhvAlerts,
+}: SyncOptions): Promise<IowaOhvSyncSummary> {
+  const scraped = await fetcher();
+
+  const botUserId = await getOrCreateOhvBotUser(prisma);
+
+  const iowaParks = await prisma.park.findMany({
+    where: {
+      status: "APPROVED",
+      address: { state: { in: IOWA_STATE_VALUES } },
+    },
+    select: {
+      id: true,
+      name: true,
+      address: { select: { county: true } },
+    },
+  });
+
+  // All currently-active alerts this bot owns, keyed by park.
+  const activeBotAlerts = await prisma.parkAlert.findMany({
+    where: { userId: botUserId, isActive: true },
+    select: {
+      id: true,
+      parkId: true,
+      title: true,
+      body: true,
+      severity: true,
+    },
+  });
+  const activeByPark = new Map<string, (typeof activeBotAlerts)[number][]>();
+  for (const a of activeBotAlerts) {
+    const list = activeByPark.get(a.parkId) ?? [];
+    list.push(a);
+    activeByPark.set(a.parkId, list);
+  }
+
+  const summary: IowaOhvSyncSummary = {
+    scraped: scraped.length,
+    matched: 0,
+    created: 0,
+    updated: 0,
+    unchanged: 0,
+    deactivated: 0,
+    unmatched: [],
+  };
+
+  const seenParkIds = new Set<string>();
+
+  for (const alert of scraped) {
+    const park = matchPark(alert, iowaParks);
+    if (!park) {
+      summary.unmatched.push(alert.parkName);
+      continue;
+    }
+    summary.matched += 1;
+    seenParkIds.add(park.id);
+
+    const title = alertTitle(alert);
+    const body = alertBody(alert);
+    const severity = severityForAlert(alert);
+    const startsAt = parseEffectiveDate(alert.effectiveDate);
+
+    const existing = activeByPark.get(park.id) ?? [];
+    if (existing.length === 0) {
+      await prisma.parkAlert.create({
+        data: {
+          parkId: park.id,
+          userId: botUserId,
+          title,
+          body,
+          severity,
+          startsAt,
+          isActive: true,
+        },
+      });
+      summary.created += 1;
+      continue;
+    }
+
+    // Keep the first active alert current; deactivate any accidental duplicates.
+    const [primary, ...dupes] = existing;
+    const changed =
+      primary.title !== title ||
+      primary.body !== body ||
+      primary.severity !== severity;
+    if (changed) {
+      await prisma.parkAlert.update({
+        where: { id: primary.id },
+        data: { title, body, severity, startsAt },
+      });
+      summary.updated += 1;
+    } else {
+      summary.unchanged += 1;
+    }
+    for (const dupe of dupes) {
+      await prisma.parkAlert.update({
+        where: { id: dupe.id },
+        data: { isActive: false },
+      });
+      summary.deactivated += 1;
+    }
+  }
+
+  // Any active bot alert whose park is no longer listed → closure lifted.
+  for (const alert of activeBotAlerts) {
+    if (!seenParkIds.has(alert.parkId)) {
+      await prisma.parkAlert.update({
+        where: { id: alert.id },
+        data: { isActive: false },
+      });
+      summary.deactivated += 1;
+    }
+  }
+
+  return summary;
+}

--- a/test/lib/iowa-ohv/parse.test.ts
+++ b/test/lib/iowa-ohv/parse.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { parseIowaOhvAlerts } from "@/lib/iowa-ohv/parse";
+
+// Faithful to the live Iowa DNR "ViewOHVAlerts" markup (bordered .p-2 boxes).
+const FIXTURE = `
+<div class="row">
+  <div class="col-12 m-2">
+    <div class="p-2" style="border: 3px solid red; border-radius: 10px;">
+      <div class="font-weight-bold" style="border-radius: 10px;">
+        <div class="d-inline-block" style="font-size: 1.5rem;">
+          Nicholson-Ford OHV Park - <span style="font-size: 1.25rem;">Effective: 7/4/2026</span><br />
+          <span style="font-size: 1.1rem;">PARK OPEN BUT USE IS LIMITED - Some trails are closed due to tree hazards</span>
+        </div>
+        <div class="float-right d-inline-block py-1" style="font-size: 1.25rem;">
+          Marshall County
+        </div>
+      </div>
+      <div class="pt-1" style="font-size: 1rem;"></div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12 m-2">
+    <div class="p-2" style="border: 3px solid red; border-radius: 10px;">
+      <div class="font-weight-bold" style="border-radius: 10px;">
+        <div class="d-inline-block" style="font-size: 1.5rem;">
+          Rathbun OHV Park - <span style="font-size: 1.25rem;">Effective: 7/20/2026</span><br />
+          <span style="font-size: 1.1rem;">PARK CLOSED - Wet trail conditions</span>
+        </div>
+        <div class="float-right d-inline-block py-1" style="font-size: 1.25rem;">
+          Appanoose County
+        </div>
+      </div>
+      <div class="pt-1" style="font-size: 1rem;"></div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-12 m-2">
+    <div class="p-2" style="border: 3px solid red; border-radius: 10px;">
+      <div class="font-weight-bold" style="border-radius: 10px;">
+        <div class="d-inline-block" style="font-size: 1.5rem;">
+          River Valley OHV Park - <span style="font-size: 1.25rem;">Effective: 3/19/2026</span><br />
+          <span style="font-size: 1.1rem;">PARK CLOSED - Major construction project</span>
+        </div>
+        <div class="float-right d-inline-block py-1" style="font-size: 1.25rem;">
+          Pottawattamie County
+        </div>
+      </div>
+      <div class="pt-1" style="font-size: 1rem;">
+        The park is currently closed to public use.  This closure alert will be updated with any changes in park status.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+describe("parseIowaOhvAlerts", () => {
+  const alerts = parseIowaOhvAlerts(FIXTURE);
+
+  it("parses every alert box", () => {
+    expect(alerts).toHaveLength(3);
+  });
+
+  it("extracts park name, county, status, reason, and effective date", () => {
+    expect(alerts[0]).toMatchObject({
+      parkName: "Nicholson-Ford OHV Park",
+      county: "Marshall",
+      statusLabel: "PARK OPEN BUT USE IS LIMITED",
+      reason: "Some trails are closed due to tree hazards",
+      effectiveDate: "7/4/2026",
+      closed: false,
+      limited: true,
+    });
+  });
+
+  it("flags full closures", () => {
+    expect(alerts[1]).toMatchObject({
+      parkName: "Rathbun OHV Park",
+      county: "Appanoose",
+      statusLabel: "PARK CLOSED",
+      reason: "Wet trail conditions",
+      closed: true,
+      limited: false,
+    });
+  });
+
+  it("captures the extended description block", () => {
+    expect(alerts[2].parkName).toBe("River Valley OHV Park");
+    expect(alerts[2].extraBody).toContain("currently closed to public use");
+    expect(alerts[2].closed).toBe(true);
+  });
+
+  it("returns no alerts for an empty page", () => {
+    expect(parseIowaOhvAlerts("<html><body></body></html>")).toEqual([]);
+  });
+});

--- a/test/lib/iowa-ohv/sync.test.ts
+++ b/test/lib/iowa-ohv/sync.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  matchPark,
+  severityForAlert,
+  alertTitle,
+  alertBody,
+  syncIowaOhvAlerts,
+} from "@/lib/iowa-ohv/sync";
+import type { IowaOhvAlert } from "@/lib/iowa-ohv/parse";
+
+function makeAlert(overrides: Partial<IowaOhvAlert> = {}): IowaOhvAlert {
+  return {
+    parkName: "Rathbun OHV Park",
+    county: "Appanoose",
+    statusLabel: "PARK CLOSED",
+    reason: "Wet trail conditions",
+    extraBody: "",
+    effectiveDate: "7/20/2026",
+    closed: true,
+    limited: false,
+    ...overrides,
+  };
+}
+
+describe("matchPark", () => {
+  const parks = [
+    { id: "p-rathbun", name: "Rathbun OHV Park", address: { county: "Appanoose" } },
+    {
+      id: "p-nf",
+      name: "Nicholson-Ford OHV Area",
+      address: { county: "Marshall" },
+    },
+    { id: "p-river", name: "River Valley Park", address: { county: null } },
+  ];
+
+  it("matches on significant-token equality, ignoring OHV/Park", () => {
+    expect(matchPark(makeAlert(), parks)?.id).toBe("p-rathbun");
+  });
+
+  it("matches across name variants (hyphen + Park vs Area)", () => {
+    const alert = makeAlert({ parkName: "Nicholson-Ford OHV Park", county: "Marshall" });
+    expect(matchPark(alert, parks)?.id).toBe("p-nf");
+  });
+
+  it("matches via token containment", () => {
+    const alert = makeAlert({ parkName: "River Valley OHV Park", county: "" });
+    expect(matchPark(alert, parks)?.id).toBe("p-river");
+  });
+
+  it("returns null when nothing matches", () => {
+    const alert = makeAlert({ parkName: "Gypsum City OHV Park", county: "Webster" });
+    expect(matchPark(alert, parks)).toBeNull();
+  });
+});
+
+describe("severity / title / body", () => {
+  it("maps closures to DANGER and limited use to WARNING", () => {
+    expect(severityForAlert(makeAlert({ closed: true }))).toBe("DANGER");
+    expect(
+      severityForAlert(makeAlert({ closed: false, limited: true }))
+    ).toBe("WARNING");
+  });
+
+  it("builds a concise title", () => {
+    expect(alertTitle(makeAlert({ closed: true }))).toBe("Park Closed");
+    expect(
+      alertTitle(makeAlert({ closed: false, limited: true }))
+    ).toBe("Park Open — Limited Use");
+  });
+
+  it("builds a body with reason, effective date, and attribution", () => {
+    const body = alertBody(makeAlert());
+    expect(body).toContain("Wet trail conditions");
+    expect(body).toContain("Effective 7/20/2026.");
+    expect(body).toContain("Source: Iowa DNR OHV Alerts.");
+  });
+});
+
+describe("syncIowaOhvAlerts", () => {
+  function makePrisma(opts: {
+    parks: Array<{ id: string; name: string; address: { county: string | null } | null }>;
+    activeBotAlerts: Array<{
+      id: string;
+      parkId: string;
+      title: string;
+      body: string;
+      severity: string;
+    }>;
+  }) {
+    return {
+      user: { upsert: vi.fn().mockResolvedValue({ id: "bot-user" }) },
+      park: { findMany: vi.fn().mockResolvedValue(opts.parks) },
+      parkAlert: {
+        findMany: vi.fn().mockResolvedValue(opts.activeBotAlerts),
+        create: vi.fn().mockResolvedValue({}),
+        update: vi.fn().mockResolvedValue({}),
+      },
+    };
+  }
+
+  const parks = [
+    { id: "p-rathbun", name: "Rathbun OHV Park", address: { county: "Appanoose" } },
+    { id: "p-nf", name: "Nicholson-Ford OHV Park", address: { county: "Marshall" } },
+  ];
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates alerts for newly-closed parks and reports unmatched ones", async () => {
+    const prisma = makePrisma({ parks, activeBotAlerts: [] });
+    const fetcher = vi.fn().mockResolvedValue([
+      makeAlert({ parkName: "Rathbun OHV Park", county: "Appanoose" }),
+      makeAlert({ parkName: "Ghost OHV Park", county: "Nowhere" }),
+    ]);
+
+    const summary = await syncIowaOhvAlerts({ prisma: prisma as never, fetcher });
+
+    expect(summary.scraped).toBe(2);
+    expect(summary.matched).toBe(1);
+    expect(summary.created).toBe(1);
+    expect(summary.unmatched).toEqual(["Ghost OHV Park"]);
+    expect(prisma.parkAlert.create).toHaveBeenCalledOnce();
+    expect(prisma.parkAlert.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          parkId: "p-rathbun",
+          userId: "bot-user",
+          severity: "DANGER",
+          isActive: true,
+        }),
+      })
+    );
+  });
+
+  it("is a no-op when the existing alert is already current", async () => {
+    const alert = makeAlert({ parkName: "Rathbun OHV Park" });
+    const prisma = makePrisma({
+      parks,
+      activeBotAlerts: [
+        {
+          id: "a1",
+          parkId: "p-rathbun",
+          title: alertTitle(alert),
+          body: alertBody(alert),
+          severity: severityForAlert(alert),
+        },
+      ],
+    });
+    const fetcher = vi.fn().mockResolvedValue([alert]);
+
+    const summary = await syncIowaOhvAlerts({ prisma: prisma as never, fetcher });
+
+    expect(summary.unchanged).toBe(1);
+    expect(summary.created).toBe(0);
+    expect(summary.updated).toBe(0);
+    expect(prisma.parkAlert.create).not.toHaveBeenCalled();
+    expect(prisma.parkAlert.update).not.toHaveBeenCalled();
+  });
+
+  it("updates an alert whose text changed", async () => {
+    const prisma = makePrisma({
+      parks,
+      activeBotAlerts: [
+        {
+          id: "a1",
+          parkId: "p-rathbun",
+          title: "Park Closed",
+          body: "stale body",
+          severity: "DANGER",
+        },
+      ],
+    });
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue([makeAlert({ parkName: "Rathbun OHV Park" })]);
+
+    const summary = await syncIowaOhvAlerts({ prisma: prisma as never, fetcher });
+
+    expect(summary.updated).toBe(1);
+    expect(prisma.parkAlert.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "a1" } })
+    );
+  });
+
+  it("deactivates alerts for parks that dropped off the page (reopened)", async () => {
+    const prisma = makePrisma({
+      parks,
+      activeBotAlerts: [
+        {
+          id: "a-old",
+          parkId: "p-nf",
+          title: "Park Closed",
+          body: "old",
+          severity: "DANGER",
+        },
+      ],
+    });
+    // DNR page now only lists Rathbun; Nicholson-Ford reopened.
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue([makeAlert({ parkName: "Rathbun OHV Park" })]);
+
+    const summary = await syncIowaOhvAlerts({ prisma: prisma as never, fetcher });
+
+    expect(summary.created).toBe(1);
+    expect(summary.deactivated).toBe(1);
+    expect(prisma.parkAlert.update).toHaveBeenCalledWith({
+      where: { id: "a-old" },
+      data: { isActive: false },
+    });
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
   "buildCommand": "npm run build",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
+  "crons": [
+    {
+      "path": "/api/cron/iowa-ohv-alerts",
+      "schedule": "0 12 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds a once-daily job that scrapes the [Iowa DNR OHV alerts page](https://programs.iowadnr.gov/parkforms/pages/ViewOHVAlerts) and posts a closure/limited-use banner for each affected Iowa park.

## How

- **`src/lib/iowa-ohv/parse.ts`** — deterministic cheerio parse of the DNR page (stable class-based layout, no AI needed). Extracts park name, county, status, reason, effective date, closed/limited flags. Verified against the live page.
- **`src/lib/iowa-ohv/sync.ts`** — matches each alert to an approved Iowa park (token-based fuzzy match that ignores "OHV"/"Park"/"Area", county as tiebreaker) and idempotently reconciles `ParkAlert` banners:
  - new closure → create · changed text → update · park drops off page → deactivate
  - all scraper alerts authored by a dedicated system user, whose id doubles as the source marker so operator-authored alerts are never touched. **No schema migration.**
- **`src/app/api/cron/iowa-ohv-alerts/route.ts` + `vercel.json`** — daily Vercel cron (`0 12 * * *`), guarded by `CRON_SECRET` (already set in Vercel env).
- **`scripts/check-iowa-ohv-alerts.ts`** — read-only preview of how live alerts match DB parks (safe to run against prod/dev).
- **`scripts/data/iowa-ohv-parks.json` + `scripts/promote-to-prod.ts`** — seed data for the one genuinely-missing park (River Valley), and `promote-to-prod` now accepts park names via CLI.

## Verification

- 16 unit tests (parse + sync) passing; lint + typecheck clean.
- Dry-run against dev: all 3 current DNR alerts (Nicholson-Ford, Rathbun, River Valley) match a park.
- River Valley OHV Park was seeded to dev and promoted to prod (the other 7 DNR parks already exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)