### PR TITLE
feat(alerts): separate weather + official closure categories, surface on cards

### DIFF
--- a/prisma/migrations/20260721000000_park_alert_category/migration.sql
+++ b/prisma/migrations/20260721000000_park_alert_category/migration.sql
@@ -1,0 +1,17 @@
+-- CreateEnum
+CREATE TYPE "ParkAlertCategory" AS ENUM ('OPERATOR', 'OFFICIAL_CLOSURE');
+
+-- AlterTable: new column defaults to OPERATOR so every existing row is valid.
+ALTER TABLE "ParkAlert" ADD COLUMN "category" "ParkAlertCategory" NOT NULL DEFAULT 'OPERATOR';
+
+-- CreateIndex
+CREATE INDEX "ParkAlert_parkId_category_isActive_idx" ON "ParkAlert"("parkId", "category", "isActive");
+
+-- Backfill: every alert authored by the Iowa DNR OHV scraper's system user is an
+-- official agency closure. That bot user id has always been the scraper's source
+-- marker (see src/lib/iowa-ohv/sync.ts), so this is a safe, exact reclassification.
+UPDATE "ParkAlert"
+SET "category" = 'OFFICIAL_CLOSURE'
+WHERE "userId" IN (
+    SELECT "id" FROM "User" WHERE "email" = 'iowa-dnr-ohv-bot@system.offroadparks.com'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -853,13 +853,23 @@ enum ParkAlertSeverity {
   SUCCESS
 }
 
+// What kind of alert this is — drives the icon/category shown in the UI and
+// keeps automated agency closures visually distinct from human operator posts.
+// (NWS weather alerts are never stored here; they are live-fetched. See
+// src/lib/weather — the "weather" category exists only at the display layer.)
+enum ParkAlertCategory {
+  OPERATOR // human operator-posted alert (events, notices, closures they set)
+  OFFICIAL_CLOSURE // automated agency closure, e.g. the Iowa DNR OHV scraper
+}
+
 model ParkAlert {
   id        String            @id @default(cuid())
   parkId    String
-  userId    String            // operator user who posted
+  userId    String            // operator user who posted (or the source system bot)
   title     String
   body      String?           @db.Text
   severity  ParkAlertSeverity @default(INFO)
+  category  ParkAlertCategory @default(OPERATOR)
   startsAt  DateTime?         // null = active immediately
   expiresAt DateTime?         // null = indefinite
   isActive  Boolean           @default(true)
@@ -871,5 +881,6 @@ model ParkAlert {
   updatedAt DateTime @updatedAt
 
   @@index([parkId, isActive])
+  @@index([parkId, category, isActive])
   @@index([expiresAt])
 }

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -146,6 +146,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
       title: true,
       body: true,
       severity: true,
+      category: true,
       startsAt: true,
       expiresAt: true,
       isActive: true,
@@ -159,6 +160,7 @@ export default async function ParkPage({ params }: ParkPageProps) {
     title: a.title,
     body: a.body,
     severity: a.severity,
+    category: a.category,
     createdAt: a.createdAt.toISOString(),
   }));
 

--- a/src/components/parks/ParkAlertBadges.tsx
+++ b/src/components/parks/ParkAlertBadges.tsx
@@ -1,0 +1,85 @@
+/**
+ * Compact alert pills for park cards. Surfaces the two automated alert
+ * categories a browsing user most needs to see before clicking in:
+ *
+ *   - Official closure (red/amber, "no-entry" icon) — an agency closure from
+ *     the cron scraper (e.g. Iowa DNR OHV). Deliberately the loudest badge.
+ *   - Severe weather (amber/orange, weather icon) — an active Severe/Extreme
+ *     NWS alert at the park's coordinates.
+ *
+ * Kept intentionally distinct from RainBadge (Droplets) and ConditionBadge so
+ * a closure never reads as "just rain." Renders nothing when neither applies.
+ */
+import { Ban, CloudLightning } from "lucide-react";
+import type { ParkCardAlertSummary } from "@/lib/types";
+
+interface ParkAlertBadgesProps {
+  summary: ParkCardAlertSummary | null | undefined;
+}
+
+function ClosureBadge({
+  closure,
+}: {
+  closure: NonNullable<ParkCardAlertSummary["officialClosure"]>;
+}) {
+  const closed = closure.severity === "DANGER";
+  const classes = closed
+    ? "bg-red-600 text-white ring-red-700/50"
+    : "bg-amber-500 text-white ring-amber-600/50";
+  const label = closed ? "Closed" : "Limited";
+  const aria = closed
+    ? "Official closure — park closed"
+    : "Official closure — limited use";
+  return (
+    <div
+      data-testid="closure-badge"
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold shadow-sm ring-1 ${classes}`}
+      aria-label={aria}
+      title={aria}
+    >
+      <Ban className="w-3 h-3" aria-hidden="true" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function WeatherBadge({
+  weather,
+}: {
+  weather: NonNullable<ParkCardAlertSummary["severeWeather"]>;
+}) {
+  const extreme = weather.severity === "Extreme";
+  const classes = extreme
+    ? "bg-orange-600 text-white ring-orange-700/50"
+    : "bg-amber-100 text-amber-900 ring-amber-300/60 dark:bg-amber-900/70 dark:text-amber-100 dark:ring-amber-700/60";
+  const aria = `${weather.count} active ${
+    extreme ? "extreme" : "severe"
+  } weather ${weather.count === 1 ? "alert" : "alerts"}`;
+  return (
+    <div
+      data-testid="weather-badge"
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shadow-sm ring-1 ${classes}`}
+      aria-label={aria}
+      title={aria}
+    >
+      <CloudLightning className="w-3 h-3" aria-hidden="true" />
+      <span>Weather{weather.count > 1 ? ` ×${weather.count}` : ""}</span>
+    </div>
+  );
+}
+
+export function ParkAlertBadges({ summary }: ParkAlertBadgesProps) {
+  if (!summary) return null;
+  const { officialClosure, severeWeather } = summary;
+  if (!officialClosure && !severeWeather) return null;
+
+  return (
+    <div
+      className="flex flex-col items-start gap-1"
+      data-testid="park-alert-badges"
+    >
+      {officialClosure && <ClosureBadge closure={officialClosure} />}
+      {severeWeather && <WeatherBadge weather={severeWeather} />}
+    </div>
+  );
+}

--- a/src/components/parks/ParkAlertsBanner.tsx
+++ b/src/components/parks/ParkAlertsBanner.tsx
@@ -4,11 +4,13 @@ import { useEffect, useState } from "react";
 import {
   AlertOctagon,
   AlertTriangle,
+  Ban,
   CheckCircle2,
   Info,
   X,
 } from "lucide-react";
-import type { ParkAlertSeverity } from "@prisma/client";
+import type { ParkAlertCategory, ParkAlertSeverity } from "@prisma/client";
+import { PARK_ALERT_CATEGORY_LABEL } from "@/lib/park-alerts";
 
 const SEVERITY_CLASSES: Record<
   ParkAlertSeverity,
@@ -52,7 +54,15 @@ export interface ParkAlertDisplay {
   title: string;
   body: string | null;
   severity: ParkAlertSeverity;
+  category: ParkAlertCategory;
   createdAt: string | Date;
+}
+
+/** Official agency closures get a dedicated "no-entry" icon so they read
+ *  differently from a park's own operator notices, regardless of severity. */
+function iconFor(alert: ParkAlertDisplay): typeof Info {
+  if (alert.category === "OFFICIAL_CLOSURE") return Ban;
+  return SEVERITY_ICON[alert.severity];
 }
 
 export const ALERT_DISMISS_KEY_PREFIX = "park-alert-dismissed:";
@@ -118,7 +128,8 @@ export function ParkAlertsBanner({ alerts }: ParkAlertsBannerProps) {
     <div className="space-y-2" role="region" aria-label="Park alerts">
       {visible.map((alert) => {
         const classes = SEVERITY_CLASSES[alert.severity];
-        const Icon = SEVERITY_ICON[alert.severity];
+        const Icon = iconFor(alert);
+        const isOfficial = alert.category === "OFFICIAL_CLOSURE";
         return (
           <div
             key={alert.id}
@@ -128,7 +139,14 @@ export function ParkAlertsBanner({ alerts }: ParkAlertsBannerProps) {
           >
             <Icon className={`w-5 h-5 flex-shrink-0 mt-0.5 ${classes.icon}`} aria-hidden="true" />
             <div className="flex-1 min-w-0">
-              <p className={`text-sm font-semibold ${classes.title}`}>{alert.title}</p>
+              <div className="flex items-center flex-wrap gap-2">
+                <p className={`text-sm font-semibold ${classes.title}`}>{alert.title}</p>
+                {isOfficial && (
+                  <span className="text-[10px] uppercase tracking-wide font-medium rounded px-1.5 py-0.5 bg-red-200 text-red-900 dark:bg-red-900 dark:text-red-100">
+                    {PARK_ALERT_CATEGORY_LABEL.OFFICIAL_CLOSURE}
+                  </span>
+                )}
+              </div>
               {alert.body && (
                 <p className="text-sm mt-1 whitespace-pre-wrap">{alert.body}</p>
               )}

--- a/src/components/parks/ParkCard.tsx
+++ b/src/components/parks/ParkCard.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import { ParkMapHero } from "@/components/parks/ParkMapHero";
 import { ConditionBadge } from "@/features/trail-conditions/ConditionBadge";
 import { RainBadge } from "@/components/parks/RainBadge";
+import { ParkAlertBadges } from "@/components/parks/ParkAlertBadges";
 import type { TrailConditionStatus } from "@/lib/trail-conditions";
 import { isConditionFresh } from "@/lib/trail-conditions";
 
@@ -84,6 +85,11 @@ export function ParkCard({
                 )}
               </Button>
             </div>
+            {/* Alert badges get the prime top-left corner — closures especially
+                need to be seen before a user clicks in. */}
+            <div className="absolute top-2 left-2 z-10">
+              <ParkAlertBadges summary={park.alertSummary} />
+            </div>
             {freshCondition && (
               <div className="absolute bottom-2 left-2 z-10">
                 <ConditionBadge
@@ -115,8 +121,19 @@ export function ParkCard({
                 )}
               </Button>
             </div>
-            {freshCondition && (
-              <div className={`absolute ${conditionOnTop ? "top-2 left-2" : "bottom-2 left-2"} z-10`}>
+            {/* Top-left stack: alert badges, plus the condition badge when the
+                map legend forces it off the bottom-left (conditionOnTop). */}
+            <div className="absolute top-2 left-2 z-10 flex flex-col items-start gap-1">
+              <ParkAlertBadges summary={park.alertSummary} />
+              {freshCondition && conditionOnTop && (
+                <ConditionBadge
+                  status={freshCondition.status as TrailConditionStatus}
+                  size="xs"
+                />
+              )}
+            </div>
+            {freshCondition && !conditionOnTop && (
+              <div className="absolute bottom-2 left-2 z-10">
                 <ConditionBadge
                   status={freshCondition.status as TrailConditionStatus}
                   size="xs"
@@ -145,6 +162,9 @@ export function ParkCard({
                   <StarOff className="w-4 h-4" />
                 )}
               </Button>
+            </div>
+            <div className="absolute top-2 left-2 z-10">
+              <ParkAlertBadges summary={park.alertSummary} />
             </div>
             {freshCondition && (
               <div className="absolute bottom-2 left-2 z-10">

--- a/src/components/parks/WeatherAlertsBanner.tsx
+++ b/src/components/parks/WeatherAlertsBanner.tsx
@@ -18,7 +18,13 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import type { AlertSeverity, WeatherAlert } from "@/lib/weather/types";
-import { AlertOctagon, AlertTriangle, ExternalLink, Info } from "lucide-react";
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudLightning,
+  CloudRain,
+  ExternalLink,
+} from "lucide-react";
 import { useState } from "react";
 
 // Severity sort order — Extreme first, Unknown last.
@@ -68,12 +74,14 @@ const SEVERITY_CLASSES: Record<
   },
 };
 
-const SEVERITY_ICON: Record<AlertSeverity, typeof Info> = {
-  Extreme: AlertOctagon,
-  Severe: AlertOctagon,
-  Moderate: AlertTriangle,
-  Minor: Info,
-  Unknown: Info,
+// Weather-specific icons give NWS alerts their own visual identity, distinct
+// from the alert-triangle/octagon family used by operator + closure banners.
+const SEVERITY_ICON: Record<AlertSeverity, typeof Cloud> = {
+  Extreme: CloudLightning,
+  Severe: CloudLightning,
+  Moderate: CloudRain,
+  Minor: CloudDrizzle,
+  Unknown: Cloud,
 };
 
 interface WeatherAlertsBannerProps {

--- a/src/lib/iowa-ohv/sync.ts
+++ b/src/lib/iowa-ohv/sync.ts
@@ -260,6 +260,9 @@ export async function syncIowaOhvAlerts({
           title,
           body,
           severity,
+          // Scraper output is always an official agency closure — this is what
+          // gives the alert its distinct closure icon/category in the UI.
+          category: "OFFICIAL_CLOSURE",
           startsAt,
           isActive: true,
         },
@@ -277,7 +280,9 @@ export async function syncIowaOhvAlerts({
     if (changed) {
       await prisma.parkAlert.update({
         where: { id: primary.id },
-        data: { title, body, severity, startsAt },
+        // Re-assert the closure category so any legacy bot alert created before
+        // the category column existed gets reclassified on its next update.
+        data: { title, body, severity, category: "OFFICIAL_CLOSURE", startsAt },
       });
       summary.updated += 1;
     } else {

--- a/src/lib/park-alerts.ts
+++ b/src/lib/park-alerts.ts
@@ -1,4 +1,4 @@
-import type { ParkAlertSeverity } from "@prisma/client";
+import type { ParkAlertCategory, ParkAlertSeverity } from "@prisma/client";
 
 export const PARK_ALERT_SEVERITIES: ParkAlertSeverity[] = [
   "INFO",
@@ -6,6 +6,16 @@ export const PARK_ALERT_SEVERITIES: ParkAlertSeverity[] = [
   "DANGER",
   "SUCCESS",
 ];
+
+/**
+ * Short human label for each stored alert category. Rendered as the category
+ * chip on the detail-page banner so an automated agency closure reads clearly
+ * differently from a park's own operator notice.
+ */
+export const PARK_ALERT_CATEGORY_LABEL: Record<ParkAlertCategory, string> = {
+  OPERATOR: "Park notice",
+  OFFICIAL_CLOSURE: "Official closure",
+};
 
 /**
  * Priority ordering for alert stacking — higher value surfaces first.

--- a/src/lib/park-query.ts
+++ b/src/lib/park-query.ts
@@ -7,8 +7,13 @@
  */
 import { prisma } from "@/lib/prisma";
 import { resolveParkHeroImage } from "@/lib/park-hero";
-import { transformDbPark, type DbPark, type Park } from "@/lib/types";
-import { getBatchRainProbabilities } from "@/lib/weather";
+import {
+  transformDbPark,
+  type DbPark,
+  type Park,
+  type ParkCardAlertSummary,
+} from "@/lib/types";
+import { getBatchParkCardWeather } from "@/lib/weather";
 import { haversineDistance } from "@/lib/geo";
 import {
   buildParkOrderBy,
@@ -50,9 +55,50 @@ export interface ParkPage {
   total: number;
 }
 
-/** Shape hero image + today's rain onto a page of raw Prisma parks. The
- *  expensive weather fan-out is bounded to just this page. */
-async function decorateParks(dbParks: unknown[]): Promise<Park[]> {
+/**
+ * Active official-closure alerts for a set of park DB ids, aggregated per park
+ * into the card badge shape. One indexed query for the whole page — cheap
+ * relative to the weather fan-out. Uses the same active predicate as the detail
+ * page (isActive + not-expired + already-started).
+ */
+async function getBatchOfficialClosures(
+  parkDbIds: string[],
+): Promise<Map<string, ParkCardAlertSummary["officialClosure"]>> {
+  const out = new Map<string, ParkCardAlertSummary["officialClosure"]>();
+  if (parkDbIds.length === 0) return out;
+
+  const now = new Date();
+  const rows = await prisma.parkAlert.findMany({
+    where: {
+      parkId: { in: parkDbIds },
+      category: "OFFICIAL_CLOSURE",
+      isActive: true,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+      AND: [{ OR: [{ startsAt: null }, { startsAt: { lte: now } }] }],
+    },
+    select: { parkId: true, severity: true },
+  });
+
+  for (const r of rows) {
+    // DANGER (full closure) outranks WARNING (limited use) for the badge.
+    const severity: "DANGER" | "WARNING" =
+      r.severity === "DANGER" ? "DANGER" : "WARNING";
+    const prev = out.get(r.parkId);
+    out.set(r.parkId, {
+      severity:
+        prev?.severity === "DANGER" || severity === "DANGER"
+          ? "DANGER"
+          : "WARNING",
+      count: (prev?.count ?? 0) + 1,
+    });
+  }
+  return out;
+}
+
+/** Shape hero image + today's rain + alert badges onto a page of raw Prisma
+ *  parks. The expensive weather fan-out is bounded to just this page; the
+ *  closure lookup is a single indexed query. */
+export async function decorateParks(dbParks: unknown[]): Promise<Park[]> {
   const rows = dbParks as Array<
     DbPark & {
       latitude: number | null;
@@ -61,19 +107,29 @@ async function decorateParks(dbParks: unknown[]): Promise<Park[]> {
     }
   >;
 
-  const rainByParkId = await getBatchRainProbabilities(
-    rows.map((p) => ({
-      parkId: p.id,
-      latitude: p.latitude ?? p.address?.latitude ?? null,
-      longitude: p.longitude ?? p.address?.longitude ?? null,
-    })),
-  );
+  const [cardWeather, closures] = await Promise.all([
+    getBatchParkCardWeather(
+      rows.map((p) => ({
+        parkId: p.id,
+        latitude: p.latitude ?? p.address?.latitude ?? null,
+        longitude: p.longitude ?? p.address?.longitude ?? null,
+      })),
+    ),
+    getBatchOfficialClosures(rows.map((p) => p.id)),
+  ]);
 
-  return rows.map((park) => ({
-    ...transformDbPark(park),
-    heroImage: resolveParkHeroImage(park as never),
-    todaysRainChance: rainByParkId.get(park.id) ?? null,
-  }));
+  return rows.map((park) => {
+    const weather = cardWeather.get(park.id);
+    return {
+      ...transformDbPark(park),
+      heroImage: resolveParkHeroImage(park as never),
+      todaysRainChance: weather?.rainChance ?? null,
+      alertSummary: {
+        officialClosure: closures.get(park.id) ?? null,
+        severeWeather: weather?.severeWeather ?? null,
+      },
+    };
+  });
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -239,8 +239,29 @@ export type Park = {
   // parks-list server page via NWS forecast. Null when no forecast is
   // available (no coords / outside coverage / fetch timeout).
   todaysRainChance?: number | null;
+  // Compact alert summary rendered as badges on the card. Populated by the
+  // list decoration step, not transformDbPark. Official closures come from
+  // active OFFICIAL_CLOSURE ParkAlerts; severeWeather from live NWS alerts.
+  alertSummary?: ParkCardAlertSummary | null;
   // Operator
   hasOperator?: boolean;
+};
+
+/** Compact alert state shown as pills on a park card. */
+export type ParkCardAlertSummary = {
+  /**
+   * Active official agency closure, if any (e.g. Iowa DNR OHV scraper).
+   * `severity` is DANGER for a full closure, WARNING for limited use.
+   */
+  officialClosure: {
+    severity: "DANGER" | "WARNING";
+    count: number;
+  } | null;
+  /** Active Severe/Extreme NWS weather alert, if any. */
+  severeWeather: {
+    severity: "Severe" | "Extreme";
+    count: number;
+  } | null;
 };
 
 // Database review type - matches Prisma ParkReview model with includes

--- a/src/lib/weather/batch.ts
+++ b/src/lib/weather/batch.ts
@@ -1,13 +1,17 @@
 /**
- * Batch helpers for OP-55 — page-grid rain badges fetched per visible card.
+ * Batch helpers for the park-grid cards (OP-55 rain badge + severe-weather
+ * badge).
  *
- * NWS does not expose a multi-point endpoint, so the parks-list page fans
- * out one `getForecast` call per park. To keep first-render latency
- * bounded we cap concurrency *and* apply a per-park timeout — late
- * responses return null and the badge simply doesn't render. Subsequent
- * page loads hit the 6h forecast cache and resolve immediately.
+ * NWS does not expose a multi-point endpoint, so the parks-list page fans out
+ * per park. Each worker fetches the forecast (for today's rain) AND the active
+ * alerts (for the severe-weather badge) *in parallel*, so adding the weather
+ * badge does not add a second fan-out pass. To keep first-render latency
+ * bounded we cap concurrency and apply a per-park timeout — late responses
+ * return empty and the badges simply don't render. Subsequent page loads hit
+ * the NWS fetch cache (6h forecast / 10min alerts) and resolve immediately.
  */
-import { getForecast } from "./nws-client";
+import { getActiveAlerts, getForecast } from "./nws-client";
+import type { AlertSeverity, WeatherAlert } from "./types";
 
 interface BatchInput {
   parkId: string;
@@ -22,19 +26,48 @@ interface BatchOptions {
   timeoutMs?: number;
 }
 
+/** Compact per-card weather summary. */
+export interface CardWeather {
+  /** Today's max precipitation probability (0–100), or null. */
+  rainChance: number | null;
+  /**
+   * Severe/Extreme NWS alert summary for the card badge, or null when there
+   * are no life-safety-grade alerts. Minor/Moderate advisories are omitted —
+   * they stay on the detail page (matches the detail banner's Severe+ gate).
+   */
+  severeWeather: { severity: "Severe" | "Extreme"; count: number } | null;
+}
+
+const EMPTY_CARD_WEATHER: CardWeather = { rainChance: null, severeWeather: null };
+
+/** Alert severities prominent enough to earn a badge on the card. */
+const SEVERE_CARD_SEVERITIES: ReadonlySet<AlertSeverity> = new Set([
+  "Severe",
+  "Extreme",
+]);
+
+function summarizeSevere(alerts: WeatherAlert[]): CardWeather["severeWeather"] {
+  const severe = alerts.filter((a) => SEVERE_CARD_SEVERITIES.has(a.severity));
+  if (severe.length === 0) return null;
+  const severity = severe.some((a) => a.severity === "Extreme")
+    ? "Extreme"
+    : "Severe";
+  return { severity, count: severe.length };
+}
+
 /**
- * Fetch today's max precipitation probability for each park. Returns a
- * Map<parkId, probability | null>. Parks without coords, parks whose call
- * exceeded the per-park timeout, and parks outside NWS coverage all map
- * to null (the consuming UI hides the badge in that case).
+ * Fetch today's rain probability + any Severe/Extreme weather alert for each
+ * park. Returns a Map<parkId, CardWeather>. Parks without coords, parks whose
+ * calls exceeded the per-park timeout, and parks outside NWS coverage all map
+ * to an empty summary (the consuming UI hides both badges in that case).
  */
-export async function getBatchRainProbabilities(
+export async function getBatchParkCardWeather(
   parks: readonly BatchInput[],
   opts: BatchOptions = {},
-): Promise<Map<string, number | null>> {
+): Promise<Map<string, CardWeather>> {
   const concurrency = opts.concurrency ?? 12;
   const timeoutMs = opts.timeoutMs ?? 2000;
-  const results = new Map<string, number | null>();
+  const results = new Map<string, CardWeather>();
   let cursor = 0;
 
   async function worker(): Promise<void> {
@@ -42,14 +75,21 @@ export async function getBatchRainProbabilities(
       const i = cursor++;
       const park = parks[i];
       if (park.latitude == null || park.longitude == null) {
-        results.set(park.parkId, null);
+        results.set(park.parkId, { ...EMPTY_CARD_WEATHER });
         continue;
       }
-      const fetched = getForecast(park.parkId, park.latitude, park.longitude)
-        .then((f) => f[0]?.precipProbability ?? null)
-        .catch(() => null);
-      const timed = new Promise<null>((resolve) =>
-        setTimeout(() => resolve(null), timeoutMs),
+      const lat = park.latitude;
+      const lng = park.longitude;
+      const fetched: Promise<CardWeather> = Promise.all([
+        getForecast(park.parkId, lat, lng)
+          .then((f) => f[0]?.precipProbability ?? null)
+          .catch(() => null),
+        getActiveAlerts(park.parkId, lat, lng)
+          .then(summarizeSevere)
+          .catch(() => null),
+      ]).then(([rainChance, severeWeather]) => ({ rainChance, severeWeather }));
+      const timed = new Promise<CardWeather>((resolve) =>
+        setTimeout(() => resolve({ ...EMPTY_CARD_WEATHER }), timeoutMs),
       );
       const value = await Promise.race([fetched, timed]);
       results.set(park.parkId, value);

--- a/src/lib/weather/index.ts
+++ b/src/lib/weather/index.ts
@@ -5,7 +5,7 @@ export {
   getActiveAlerts,
   getParkWeather,
 } from "./nws-client";
-export { getBatchRainProbabilities } from "./batch";
+export { getBatchParkCardWeather, type CardWeather } from "./batch";
 export { weatherIconKey, type WeatherIconKey } from "./icons";
 export type {
   CurrentConditions,

--- a/test/components/parks/ParkAlertBadges.test.tsx
+++ b/test/components/parks/ParkAlertBadges.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ParkAlertBadges } from "@/components/parks/ParkAlertBadges";
+import type { ParkCardAlertSummary } from "@/lib/types";
+
+function summary(
+  overrides: Partial<ParkCardAlertSummary> = {},
+): ParkCardAlertSummary {
+  return { officialClosure: null, severeWeather: null, ...overrides };
+}
+
+describe("ParkAlertBadges", () => {
+  it("renders nothing when there is no summary", () => {
+    const { container } = render(<ParkAlertBadges summary={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when neither closure nor weather is present", () => {
+    const { container } = render(<ParkAlertBadges summary={summary()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a 'Closed' badge for a DANGER official closure", () => {
+    render(
+      <ParkAlertBadges
+        summary={summary({
+          officialClosure: { severity: "DANGER", count: 1 },
+        })}
+      />,
+    );
+    expect(screen.getByTestId("closure-badge")).toHaveTextContent("Closed");
+    expect(screen.queryByTestId("weather-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows a 'Limited' badge for a WARNING official closure", () => {
+    render(
+      <ParkAlertBadges
+        summary={summary({
+          officialClosure: { severity: "WARNING", count: 1 },
+        })}
+      />,
+    );
+    expect(screen.getByTestId("closure-badge")).toHaveTextContent("Limited");
+  });
+
+  it("shows a weather badge with a count when >1 severe alert", () => {
+    render(
+      <ParkAlertBadges
+        summary={summary({
+          severeWeather: { severity: "Extreme", count: 3 },
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("weather-badge");
+    expect(badge).toHaveTextContent("Weather ×3");
+    expect(badge).toHaveAttribute(
+      "aria-label",
+      "3 active extreme weather alerts",
+    );
+  });
+
+  it("renders both badges together, closure first", () => {
+    render(
+      <ParkAlertBadges
+        summary={summary({
+          officialClosure: { severity: "DANGER", count: 1 },
+          severeWeather: { severity: "Severe", count: 1 },
+        })}
+      />,
+    );
+    const group = screen.getByTestId("park-alert-badges");
+    const testids = Array.from(group.querySelectorAll("[data-testid]")).map(
+      (el) => el.getAttribute("data-testid"),
+    );
+    expect(testids).toEqual(["closure-badge", "weather-badge"]);
+  });
+});

--- a/test/components/parks/ParkAlertsBanner.test.tsx
+++ b/test/components/parks/ParkAlertsBanner.test.tsx
@@ -43,6 +43,7 @@ function makeAlert(overrides: Partial<ParkAlertDisplay> = {}): ParkAlertDisplay 
     title: "Main gate closed",
     body: "Use the north gate instead.",
     severity: "WARNING",
+    category: "OPERATOR",
     createdAt: new Date().toISOString(),
     ...overrides,
   };
@@ -117,5 +118,28 @@ describe("ParkAlertsBanner", () => {
     );
     expect(screen.getByText("Alert A")).toBeInTheDocument();
     expect(screen.getByText("Alert B")).toBeInTheDocument();
+  });
+
+  it("shows an 'Official closure' chip only for OFFICIAL_CLOSURE alerts", () => {
+    render(
+      <ParkAlertsBanner
+        alerts={[
+          makeAlert({
+            id: "closure",
+            title: "Park Closed",
+            severity: "DANGER",
+            category: "OFFICIAL_CLOSURE",
+          }),
+          makeAlert({
+            id: "operator",
+            title: "Trail work Saturday",
+            category: "OPERATOR",
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText("Official closure")).toBeInTheDocument();
+    // Only one chip — the operator alert must not get one.
+    expect(screen.getAllByText("Official closure")).toHaveLength(1);
   });
 });

--- a/test/lib/iowa-ohv/sync.test.ts
+++ b/test/lib/iowa-ohv/sync.test.ts
@@ -125,6 +125,7 @@ describe("syncIowaOhvAlerts", () => {
           parkId: "p-rathbun",
           userId: "bot-user",
           severity: "DANGER",
+          category: "OFFICIAL_CLOSURE",
           isActive: true,
         }),
       })

--- a/test/lib/park-query.test.ts
+++ b/test/lib/park-query.test.ts
@@ -6,7 +6,7 @@ import {
   toMarkerPark,
 } from "@/lib/park-query";
 import { prisma } from "@/lib/prisma";
-import { getBatchRainProbabilities } from "@/lib/weather";
+import { getBatchParkCardWeather } from "@/lib/weather";
 import type { ParkFilterParams } from "@/lib/park-filters";
 
 vi.mock("@/lib/prisma", () => ({
@@ -16,6 +16,9 @@ vi.mock("@/lib/prisma", () => ({
       count: vi.fn(),
       aggregate: vi.fn(),
     },
+    parkAlert: {
+      findMany: vi.fn(),
+    },
     address: {
       findMany: vi.fn(),
     },
@@ -23,7 +26,7 @@ vi.mock("@/lib/prisma", () => ({
 }));
 
 vi.mock("@/lib/weather", () => ({
-  getBatchRainProbabilities: vi.fn(),
+  getBatchParkCardWeather: vi.fn(),
 }));
 
 const params: ParkFilterParams = {
@@ -65,7 +68,8 @@ function dbPark(id: string, name: string, extra: Record<string, unknown> = {}) {
 describe("getParkPage (offset pagination)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getBatchRainProbabilities).mockResolvedValue(new Map());
+    vi.mocked(getBatchParkCardWeather).mockResolvedValue(new Map());
+    vi.mocked(prisma.parkAlert.findMany).mockResolvedValue([] as never);
   });
 
   it("returns a decorated page with pagination metadata", async () => {
@@ -112,7 +116,8 @@ describe("getParkPage (offset pagination)", () => {
 describe("getParkPage (distance sort)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getBatchRainProbabilities).mockResolvedValue(new Map());
+    vi.mocked(getBatchParkCardWeather).mockResolvedValue(new Map());
+    vi.mocked(prisma.parkAlert.findMany).mockResolvedValue([] as never);
   });
 
   it("orders by great-circle distance and paginates in JS", async () => {

--- a/test/lib/weather/batch.test.ts
+++ b/test/lib/weather/batch.test.ts
@@ -1,13 +1,16 @@
-import { getBatchRainProbabilities } from "@/lib/weather/batch";
+import { getBatchParkCardWeather } from "@/lib/weather/batch";
+import type { WeatherAlert } from "@/lib/weather/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Stub the nws-client module — batch.ts delegates to getForecast.
+// Stub the nws-client module — batch.ts delegates to getForecast + getActiveAlerts.
 vi.mock("@/lib/weather/nws-client", () => ({
   getForecast: vi.fn(),
+  getActiveAlerts: vi.fn(),
 }));
 
-import { getForecast } from "@/lib/weather/nws-client";
+import { getActiveAlerts, getForecast } from "@/lib/weather/nws-client";
 const mockGetForecast = vi.mocked(getForecast);
+const mockGetActiveAlerts = vi.mocked(getActiveAlerts);
 
 function forecastWithRain(probability: number | null) {
   return [
@@ -23,81 +26,140 @@ function forecastWithRain(probability: number | null) {
   ];
 }
 
+function alert(
+  severity: WeatherAlert["severity"],
+  id: string = severity,
+): WeatherAlert {
+  return {
+    id,
+    event: "Test Warning",
+    severity,
+    headline: null,
+    description: "",
+    effective: "2026-05-12T00:00:00Z",
+    expires: null,
+    urgency: "Expected",
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: no active alerts unless a test overrides.
+  mockGetActiveAlerts.mockResolvedValue([]);
 });
 
-describe("getBatchRainProbabilities", () => {
-  it("returns a Map keyed by parkId with today's precip probability", async () => {
+describe("getBatchParkCardWeather", () => {
+  it("returns rain probability and no severe weather when there are no alerts", async () => {
     mockGetForecast
       .mockResolvedValueOnce(forecastWithRain(20))
       .mockResolvedValueOnce(forecastWithRain(80));
 
-    const result = await getBatchRainProbabilities([
+    const result = await getBatchParkCardWeather([
       { parkId: "p1", latitude: 39, longitude: -104 },
       { parkId: "p2", latitude: 40, longitude: -105 },
     ]);
 
-    expect(result.get("p1")).toBe(20);
-    expect(result.get("p2")).toBe(80);
+    expect(result.get("p1")).toEqual({ rainChance: 20, severeWeather: null });
+    expect(result.get("p2")).toEqual({ rainChance: 80, severeWeather: null });
   });
 
-  it("maps parks without coordinates to null without calling getForecast", async () => {
-    const result = await getBatchRainProbabilities([
+  it("summarizes only Severe/Extreme alerts, ignoring Minor/Moderate", async () => {
+    mockGetForecast.mockResolvedValue(forecastWithRain(10));
+    mockGetActiveAlerts.mockResolvedValueOnce([
+      alert("Minor", "a"),
+      alert("Severe", "b"),
+      alert("Moderate", "c"),
+    ]);
+
+    const result = await getBatchParkCardWeather([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toEqual({
+      rainChance: 10,
+      severeWeather: { severity: "Severe", count: 1 },
+    });
+  });
+
+  it("reports Extreme when any severe-plus alert is Extreme, counting all severe-plus", async () => {
+    mockGetForecast.mockResolvedValue(forecastWithRain(null));
+    mockGetActiveAlerts.mockResolvedValueOnce([
+      alert("Severe", "a"),
+      alert("Extreme", "b"),
+    ]);
+
+    const result = await getBatchParkCardWeather([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toEqual({
+      rainChance: null,
+      severeWeather: { severity: "Extreme", count: 2 },
+    });
+  });
+
+  it("maps parks without coordinates to an empty summary without calling NWS", async () => {
+    const result = await getBatchParkCardWeather([
       { parkId: "no-coords", latitude: null, longitude: null },
       { parkId: "no-lat", latitude: null, longitude: -104 },
       { parkId: "no-lng", latitude: 39, longitude: null },
     ]);
 
-    expect(result.get("no-coords")).toBeNull();
-    expect(result.get("no-lat")).toBeNull();
-    expect(result.get("no-lng")).toBeNull();
+    expect(result.get("no-coords")).toEqual({
+      rainChance: null,
+      severeWeather: null,
+    });
+    expect(result.get("no-lat")).toEqual({
+      rainChance: null,
+      severeWeather: null,
+    });
+    expect(result.get("no-lng")).toEqual({
+      rainChance: null,
+      severeWeather: null,
+    });
     expect(mockGetForecast).not.toHaveBeenCalled();
+    expect(mockGetActiveAlerts).not.toHaveBeenCalled();
   });
 
-  it("maps parks whose forecast returned no precip probability to null", async () => {
-    mockGetForecast.mockResolvedValueOnce(forecastWithRain(null));
-
-    const result = await getBatchRainProbabilities([
-      { parkId: "p1", latitude: 39, longitude: -104 },
-    ]);
-
-    expect(result.get("p1")).toBeNull();
-  });
-
-  it("maps parks with empty forecast to null", async () => {
-    mockGetForecast.mockResolvedValueOnce([]);
-
-    const result = await getBatchRainProbabilities([
-      { parkId: "p1", latitude: 39, longitude: -104 },
-    ]);
-
-    expect(result.get("p1")).toBeNull();
-  });
-
-  it("maps parks whose getForecast call rejects to null (does not propagate)", async () => {
+  it("degrades a rejected forecast to null rain but still returns alerts", async () => {
     mockGetForecast.mockRejectedValueOnce(new Error("nws 500"));
+    mockGetActiveAlerts.mockResolvedValueOnce([alert("Extreme")]);
 
-    const result = await getBatchRainProbabilities([
+    const result = await getBatchParkCardWeather([
       { parkId: "p1", latitude: 39, longitude: -104 },
     ]);
 
-    expect(result.get("p1")).toBeNull();
+    expect(result.get("p1")).toEqual({
+      rainChance: null,
+      severeWeather: { severity: "Extreme", count: 1 },
+    });
   });
 
-  it("times out slow forecast calls to null", async () => {
+  it("degrades rejected alerts to null severeWeather but still returns rain", async () => {
+    mockGetForecast.mockResolvedValueOnce(forecastWithRain(55));
+    mockGetActiveAlerts.mockRejectedValueOnce(new Error("nws 500"));
+
+    const result = await getBatchParkCardWeather([
+      { parkId: "p1", latitude: 39, longitude: -104 },
+    ]);
+
+    expect(result.get("p1")).toEqual({ rainChance: 55, severeWeather: null });
+  });
+
+  it("times out slow calls to an empty summary", async () => {
     mockGetForecast.mockImplementation(
-      () => new Promise(() => {
-        // never resolves
-      }),
+      () =>
+        new Promise(() => {
+          // never resolves
+        }),
     );
 
-    const result = await getBatchRainProbabilities(
+    const result = await getBatchParkCardWeather(
       [{ parkId: "slow", latitude: 39, longitude: -104 }],
       { timeoutMs: 25 },
     );
 
-    expect(result.get("slow")).toBeNull();
+    expect(result.get("slow")).toEqual({ rainChance: null, severeWeather: null });
   });
 
   it("limits concurrency to the configured cap", async () => {
@@ -116,12 +178,12 @@ describe("getBatchRainProbabilities", () => {
       latitude: 39,
       longitude: -104,
     }));
-    await getBatchRainProbabilities(parks, { concurrency: 3, timeoutMs: 5000 });
+    await getBatchParkCardWeather(parks, { concurrency: 3, timeoutMs: 5000 });
 
     expect(peakInFlight).toBeLessThanOrEqual(3);
   });
 
-  it("returns a result for every input park (even when timeouts and errors mix)", async () => {
+  it("returns a result for every input park", async () => {
     mockGetForecast
       .mockResolvedValueOnce(forecastWithRain(40))
       .mockRejectedValueOnce(new Error("nws"))
@@ -132,11 +194,11 @@ describe("getBatchRainProbabilities", () => {
       { parkId: "b", latitude: 40, longitude: -105 },
       { parkId: "c", latitude: 41, longitude: -106 },
     ];
-    const result = await getBatchRainProbabilities(parks, { concurrency: 1 });
+    const result = await getBatchParkCardWeather(parks, { concurrency: 1 });
 
     expect(result.size).toBe(3);
-    expect(result.get("a")).toBe(40);
-    expect(result.get("b")).toBeNull();
-    expect(result.get("c")).toBe(70);
+    expect(result.get("a")?.rainChance).toBe(40);
+    expect(result.get("b")?.rainChance).toBeNull();
+    expect(result.get("c")?.rainChance).toBe(70);
   });
 });


### PR DESCRIPTION
## What

Splits park alerts into distinct **categories**, each with its own icon, and surfaces both automated alert types on the homepage park cards — official closures loudest.

Before, the daily Iowa DNR OHV scraper's closures and human operator posts were indistinguishable in the UI (same severity-driven icon/color), NWS weather shared the same alert-triangle icon family, and **no alerts appeared on cards at all**.

## Changes

- **Schema**: new `ParkAlertCategory` enum (`OPERATOR` | `OFFICIAL_CLOSURE`) + `category` column. Migration `20260721000000_park_alert_category` defaults existing rows to `OPERATOR` and backfills the Iowa DNR bot's rows to `OFFICIAL_CLOSURE`.
- **Iowa cron**: stamps `OFFICIAL_CLOSURE` on create/update.
- **Weather stays live-fetched** (never stored) — a display-only category with its own `CloudLightning` icon set, preserving the OP-65 rule that closures are never auto-driven from weather data.
- **Cards**: new `ParkAlertBadges` — a dominant red **Closed** / amber **Limited** official-closure pill and an amber **Weather** pill (Severe/Extreme NWS only), pinned to the top-left corner.
- **Batch**: `getBatchParkCardWeather` fetches rain + severe alerts in one worker pass (no extra fan-out); `getBatchOfficialClosures` is a single indexed query — both wired through `decorateParks`.
- **Detail banner**: distinct `Ban` icon + "Official closure" chip for closures; weather banner gets weather-themed icons.

## Data model note

NWS/weather is deliberately **not** in the DB enum — it's live-fetched from api.weather.gov with short TTLs. Persisting it would trade freshness (life-safety) for a modest read win and add expiry/cancellation reconciliation. See `memory` / PR discussion for the full tradeoff.

## Testing

- Typecheck clean, ESLint clean.
- Full suite passes (2164 tests), including new real-render tests for `ParkAlertBadges` and the "Official closure" chip, plus rewritten batch/sync tests.
- Deployed to production ahead of this PR; migration confirmed applied via build logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)