### PR TITLE
feat(alerts): name weather alert on cards; hide empty detail sections

### DIFF
--- a/src/components/parks/ParkAlertBadges.tsx
+++ b/src/components/parks/ParkAlertBadges.tsx
@@ -52,18 +52,21 @@ function WeatherBadge({
   const classes = extreme
     ? "bg-orange-600 text-white ring-orange-700/50"
     : "bg-amber-100 text-amber-900 ring-amber-300/60 dark:bg-amber-900/70 dark:text-amber-100 dark:ring-amber-700/60";
-  const aria = `${weather.count} active ${
-    extreme ? "extreme" : "severe"
-  } weather ${weather.count === 1 ? "alert" : "alerts"}`;
+  const more = weather.count - 1;
+  const aria =
+    `${weather.event} — ${weather.count} active ${
+      extreme ? "extreme" : "severe"
+    } weather ${weather.count === 1 ? "alert" : "alerts"}`;
   return (
     <div
       data-testid="weather-badge"
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shadow-sm ring-1 ${classes}`}
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shadow-sm ring-1 max-w-[12rem] ${classes}`}
       aria-label={aria}
       title={aria}
     >
-      <CloudLightning className="w-3 h-3" aria-hidden="true" />
-      <span>Weather{weather.count > 1 ? ` ×${weather.count}` : ""}</span>
+      <CloudLightning className="w-3 h-3 shrink-0" aria-hidden="true" />
+      <span className="truncate">{weather.event}</span>
+      {more > 0 && <span className="shrink-0 opacity-80">+{more}</span>}
     </div>
   );
 }

--- a/src/features/parks/detail/components/ParkAttributesCards.tsx
+++ b/src/features/parks/detail/components/ParkAttributesCards.tsx
@@ -10,41 +10,45 @@ interface ParkAttributesCardsProps {
 export function ParkAttributesCards({ park }: ParkAttributesCardsProps) {
   return (
     <>
-      {/* Terrain Card */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Terrain Types</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {park.terrain.map((terrain) => (
-              <Badge
-                key={terrain}
-                variant="outline"
-                className="text-sm"
-              >
-                {formatTerrain(terrain as Terrain)}
-              </Badge>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      {/* Terrain Card — hidden when the park has no terrain data */}
+      {park.terrain.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Terrain Types</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {park.terrain.map((terrain) => (
+                <Badge
+                  key={terrain}
+                  variant="outline"
+                  className="text-sm"
+                >
+                  {formatTerrain(terrain as Terrain)}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
-      {/* Amenities Card */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Amenities</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-2">
-            {park.amenities.map((amenity) => (
-              <Badge key={amenity} className="text-sm">
-                {formatAmenity(amenity as Amenity)}
-              </Badge>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      {/* Amenities Card — hidden when the park has no amenities */}
+      {park.amenities.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Amenities</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {park.amenities.map((amenity) => (
+                <Badge key={amenity} className="text-sm">
+                  {formatAmenity(amenity as Amenity)}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Vehicle Types Card */}
       {park.vehicleTypes.length > 0 && (

--- a/src/features/parks/detail/components/ParkContactSidebar.tsx
+++ b/src/features/parks/detail/components/ParkContactSidebar.tsx
@@ -26,6 +26,16 @@ export function ParkContactSidebar({ park }: ParkContactSidebarProps) {
   const fullAddress = formatAddress(park.address);
   const hasStreetAddress = park.address.streetAddress || park.address.zipCode;
 
+  // Nothing actionable to show → hide the card entirely rather than render a
+  // "Contact & Links" header with only the generic disclaimer beneath it.
+  const hasAnyContact =
+    park.website ||
+    park.phone ||
+    park.contactEmail ||
+    (hasStreetAddress && fullAddress) ||
+    park.coords;
+  if (!hasAnyContact) return null;
+
   return (
     <Card>
       <CardHeader>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -257,9 +257,11 @@ export type ParkCardAlertSummary = {
     severity: "DANGER" | "WARNING";
     count: number;
   } | null;
-  /** Active Severe/Extreme NWS weather alert, if any. */
+  /** Active Severe/Extreme NWS weather alert, if any. `event` is the NWS
+   *  event name of the top alert (e.g. "Extreme Heat Warning"). */
   severeWeather: {
     severity: "Severe" | "Extreme";
+    event: string;
     count: number;
   } | null;
 };

--- a/src/lib/weather/batch.ts
+++ b/src/lib/weather/batch.ts
@@ -34,8 +34,14 @@ export interface CardWeather {
    * Severe/Extreme NWS alert summary for the card badge, or null when there
    * are no life-safety-grade alerts. Minor/Moderate advisories are omitted —
    * they stay on the detail page (matches the detail banner's Severe+ gate).
+   * `event` is the NWS event name of the top alert (e.g. "Extreme Heat
+   * Warning"), shown as the badge label.
    */
-  severeWeather: { severity: "Severe" | "Extreme"; count: number } | null;
+  severeWeather: {
+    severity: "Severe" | "Extreme";
+    event: string;
+    count: number;
+  } | null;
 }
 
 const EMPTY_CARD_WEATHER: CardWeather = { rainChance: null, severeWeather: null };
@@ -49,10 +55,14 @@ const SEVERE_CARD_SEVERITIES: ReadonlySet<AlertSeverity> = new Set([
 function summarizeSevere(alerts: WeatherAlert[]): CardWeather["severeWeather"] {
   const severe = alerts.filter((a) => SEVERE_CARD_SEVERITIES.has(a.severity));
   if (severe.length === 0) return null;
-  const severity = severe.some((a) => a.severity === "Extreme")
-    ? "Extreme"
-    : "Severe";
-  return { severity, count: severe.length };
+  // Prefer an Extreme alert's title (and severity) over a Severe one so the
+  // badge names the most serious active alert, e.g. "Extreme Heat Warning".
+  const top = severe.find((a) => a.severity === "Extreme") ?? severe[0];
+  return {
+    severity: top.severity as "Severe" | "Extreme",
+    event: top.event,
+    count: severe.length,
+  };
 }
 
 /**

--- a/test/components/parks/ParkAlertBadges.test.tsx
+++ b/test/components/parks/ParkAlertBadges.test.tsx
@@ -43,20 +43,42 @@ describe("ParkAlertBadges", () => {
     expect(screen.getByTestId("closure-badge")).toHaveTextContent("Limited");
   });
 
-  it("shows a weather badge with a count when >1 severe alert", () => {
+  it("shows the alert title, with a +N suffix when >1 severe alert", () => {
     render(
       <ParkAlertBadges
         summary={summary({
-          severeWeather: { severity: "Extreme", count: 3 },
+          severeWeather: {
+            severity: "Extreme",
+            event: "Extreme Heat Warning",
+            count: 3,
+          },
         })}
       />,
     );
     const badge = screen.getByTestId("weather-badge");
-    expect(badge).toHaveTextContent("Weather ×3");
+    expect(badge).toHaveTextContent("Extreme Heat Warning");
+    expect(badge).toHaveTextContent("+2");
     expect(badge).toHaveAttribute(
       "aria-label",
-      "3 active extreme weather alerts",
+      "Extreme Heat Warning — 3 active extreme weather alerts",
     );
+  });
+
+  it("shows just the title (no suffix) for a single alert", () => {
+    render(
+      <ParkAlertBadges
+        summary={summary({
+          severeWeather: {
+            severity: "Severe",
+            event: "Severe Thunderstorm Warning",
+            count: 1,
+          },
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("weather-badge");
+    expect(badge).toHaveTextContent("Severe Thunderstorm Warning");
+    expect(badge.textContent).not.toContain("+");
   });
 
   it("renders both badges together, closure first", () => {
@@ -64,7 +86,11 @@ describe("ParkAlertBadges", () => {
       <ParkAlertBadges
         summary={summary({
           officialClosure: { severity: "DANGER", count: 1 },
-          severeWeather: { severity: "Severe", count: 1 },
+          severeWeather: {
+            severity: "Severe",
+            event: "Severe Thunderstorm Warning",
+            count: 1,
+          },
         })}
       />,
     );

--- a/test/features/parks/detail/components/ParkAttributesCards.test.tsx
+++ b/test/features/parks/detail/components/ParkAttributesCards.test.tsx
@@ -90,23 +90,24 @@ describe("ParkAttributesCards", () => {
     expect(screen.getByText("Picnic Table")).toBeInTheDocument();
   });
 
-  it("should handle empty terrain array", () => {
+  it("hides the Terrain card when terrain is empty", () => {
     const parkNoTerrain = { ...mockPark, terrain: [] };
     render(<ParkAttributesCards park={parkNoTerrain} />);
 
-    expect(screen.getByText("Terrain Types")).toBeInTheDocument();
-    expect(screen.queryByText("Sand")).not.toBeInTheDocument();
+    expect(screen.queryByText("Terrain Types")).not.toBeInTheDocument();
+    // Amenities still has data, so its card remains.
+    expect(screen.getByText("Amenities")).toBeInTheDocument();
   });
 
-  it("should handle empty amenities array", () => {
+  it("hides the Amenities card when amenities is empty", () => {
     const parkNoAmenities = { ...mockPark, amenities: [] };
     render(<ParkAttributesCards park={parkNoAmenities} />);
 
-    expect(screen.getByText("Amenities")).toBeInTheDocument();
-    expect(screen.queryByText("Restrooms")).not.toBeInTheDocument();
+    expect(screen.queryByText("Amenities")).not.toBeInTheDocument();
+    expect(screen.getByText("Terrain Types")).toBeInTheDocument();
   });
 
-  it("should handle park with all empty arrays", () => {
+  it("renders nothing when a park has no terrain, amenities, or vehicle types", () => {
     const minimalPark: Park = {
       id: "minimal",
       name: "Minimal Park",
@@ -118,10 +119,11 @@ describe("ParkAttributesCards", () => {
       vehicleTypes: [],
     };
 
-    render(<ParkAttributesCards park={minimalPark} />);
+    const { container } = render(<ParkAttributesCards park={minimalPark} />);
 
-    expect(screen.getByText("Terrain Types")).toBeInTheDocument();
-    expect(screen.getByText("Amenities")).toBeInTheDocument();
+    expect(screen.queryByText("Terrain Types")).not.toBeInTheDocument();
+    expect(screen.queryByText("Amenities")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("should render single item in each category with formatted labels", () => {

--- a/test/features/parks/detail/components/ParkContactSidebar.test.tsx
+++ b/test/features/parks/detail/components/ParkContactSidebar.test.tsx
@@ -144,6 +144,23 @@ describe("ParkContactSidebar", () => {
     expect(screen.queryByText("Official Website")).not.toBeInTheDocument();
   });
 
+  it("renders nothing when a park has no contact info at all", () => {
+    const emptyPark: Park = {
+      id: "empty",
+      name: "Empty Park",
+      address: { state: "Texas" },
+      terrain: [],
+      amenities: [],
+      camping: [],
+      vehicleTypes: [],
+    };
+
+    const { container } = render(<ParkContactSidebar park={emptyPark} />);
+
+    expect(screen.queryByText("Contact & Links")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("should display email link when contactEmail provided", () => {
     const park = { ...basePark, contactEmail: "info@testpark.com" };
     render(<ParkContactSidebar park={park} />);

--- a/test/lib/weather/batch.test.ts
+++ b/test/lib/weather/batch.test.ts
@@ -29,10 +29,11 @@ function forecastWithRain(probability: number | null) {
 function alert(
   severity: WeatherAlert["severity"],
   id: string = severity,
+  event = "Test Warning",
 ): WeatherAlert {
   return {
     id,
-    event: "Test Warning",
+    event,
     severity,
     headline: null,
     description: "",
@@ -66,9 +67,9 @@ describe("getBatchParkCardWeather", () => {
   it("summarizes only Severe/Extreme alerts, ignoring Minor/Moderate", async () => {
     mockGetForecast.mockResolvedValue(forecastWithRain(10));
     mockGetActiveAlerts.mockResolvedValueOnce([
-      alert("Minor", "a"),
-      alert("Severe", "b"),
-      alert("Moderate", "c"),
+      alert("Minor", "a", "Frost Advisory"),
+      alert("Severe", "b", "Severe Thunderstorm Warning"),
+      alert("Moderate", "c", "Wind Advisory"),
     ]);
 
     const result = await getBatchParkCardWeather([
@@ -77,15 +78,19 @@ describe("getBatchParkCardWeather", () => {
 
     expect(result.get("p1")).toEqual({
       rainChance: 10,
-      severeWeather: { severity: "Severe", count: 1 },
+      severeWeather: {
+        severity: "Severe",
+        event: "Severe Thunderstorm Warning",
+        count: 1,
+      },
     });
   });
 
-  it("reports Extreme when any severe-plus alert is Extreme, counting all severe-plus", async () => {
+  it("reports the Extreme alert's title/severity, counting all severe-plus", async () => {
     mockGetForecast.mockResolvedValue(forecastWithRain(null));
     mockGetActiveAlerts.mockResolvedValueOnce([
-      alert("Severe", "a"),
-      alert("Extreme", "b"),
+      alert("Severe", "a", "Severe Thunderstorm Warning"),
+      alert("Extreme", "b", "Extreme Heat Warning"),
     ]);
 
     const result = await getBatchParkCardWeather([
@@ -94,7 +99,11 @@ describe("getBatchParkCardWeather", () => {
 
     expect(result.get("p1")).toEqual({
       rainChance: null,
-      severeWeather: { severity: "Extreme", count: 2 },
+      severeWeather: {
+        severity: "Extreme",
+        event: "Extreme Heat Warning",
+        count: 2,
+      },
     });
   });
 
@@ -123,7 +132,9 @@ describe("getBatchParkCardWeather", () => {
 
   it("degrades a rejected forecast to null rain but still returns alerts", async () => {
     mockGetForecast.mockRejectedValueOnce(new Error("nws 500"));
-    mockGetActiveAlerts.mockResolvedValueOnce([alert("Extreme")]);
+    mockGetActiveAlerts.mockResolvedValueOnce([
+      alert("Extreme", "x", "Extreme Heat Warning"),
+    ]);
 
     const result = await getBatchParkCardWeather([
       { parkId: "p1", latitude: 39, longitude: -104 },
@@ -131,7 +142,11 @@ describe("getBatchParkCardWeather", () => {
 
     expect(result.get("p1")).toEqual({
       rainChance: null,
-      severeWeather: { severity: "Extreme", count: 1 },
+      severeWeather: {
+        severity: "Extreme",
+        event: "Extreme Heat Warning",
+        count: 1,
+      },
     });
   });
 


### PR DESCRIPTION
Two small follow-ups to #158.

## 1. Name the weather alert on the card
The homepage card weather badge showed a generic "Weather" label. It now shows the **NWS event title** (e.g. "Extreme Heat Warning") — matching what you see when you open the park detail page.

- Prefers the most serious active alert (an Extreme alert's title over a Severe one).
- Truncates long titles with a hover tooltip (full text in `title`/`aria-label`).
- Appends `+N` when more than one Severe/Extreme alert is active.
- Threaded via `getBatchParkCardWeather` → `ParkCardAlertSummary.severeWeather.event`.

## 2. Hide empty sections on the park detail page
Parks with no data were rendering empty cards.

- `ParkAttributesCards`: the **Terrain Types** and **Amenities** cards now hide when their list is empty (previously rendered unconditionally; only Vehicle Types was guarded).
- `ParkContactSidebar`: the **Contact & Links** card now hides entirely when a park has no website/phone/email/street-address/coords (previously showed a header + the generic disclaimer alone).
- `ParkOperationalCard` and `CampingInfoCard` already self-hid; no change.
- Photos/Reviews tabs are intentionally **kept** at zero count — they're the "add the first photo/review" entry points.

## Testing
- Typecheck + ESLint clean.
- Full suite passes; updated batch/badge tests for the new `event` field, updated the three `ParkAttributesCards` empty-case tests to assert the cards now hide, and added a `ParkContactSidebar` no-contact null-render test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)