### PR TITLE
feat(seo): OpenGraph/Twitter cards + JSON-LD structured data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,11 +6,26 @@ import { SiteFooter } from "@/components/layout/SiteFooter";
 import { SITE_URL } from "@/lib/site";
 import type { Metadata } from "next";
 
+const SITE_TITLE = "Offroad Parks";
+const SITE_DESCRIPTION =
+  "Find UTV‑friendly parks and trails by state, terrain, and amenities.";
+
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: "Offroad Parks",
-  description:
-    "Find UTV‑friendly parks and trails by state, terrain, and amenities.",
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    siteName: SITE_TITLE,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -7,9 +7,22 @@ import { auth } from "@/lib/auth";
 import { isAlertActive, sortAlertsForDisplay } from "@/lib/park-alerts";
 import type { ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
 import { getActiveAlerts, getCurrentConditions, getForecast } from "@/lib/weather";
+import { SITE_URL } from "@/lib/site";
+import { JsonLd } from "@/components/seo/JsonLd";
 
 interface ParkPageProps {
   params: Promise<{ id: string }>;
+}
+
+/**
+ * Make a possibly-relative image/path URL absolute for use in social-card
+ * metadata and JSON-LD (crawlers require absolute URLs). Returns undefined
+ * when there is no URL to absolutize.
+ */
+function toAbsoluteUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  if (/^https?:\/\//i.test(url)) return url;
+  return `${SITE_URL}/${url.replace(/^\//, "")}`;
 }
 
 /* v8 ignore next - tested via E2E */
@@ -42,6 +55,7 @@ export async function generateMetadata({ params }: ParkPageProps) {
       camping: true,
       vehicleTypes: true,
       address: true,
+      heroPhoto: { select: { id: true, url: true, status: true } },
     },
   });
 
@@ -53,11 +67,45 @@ export async function generateMetadata({ params }: ParkPageProps) {
 
   const park = transformDbPark(dbPark);
 
+  const title = `${park.name} - Offroad Parks`;
+  const description =
+    park.notes ||
+    `Information about ${park.name} in ${park.address.city ? `${park.address.city}, ` : ""}${park.address.state}`;
+  const url = `${SITE_URL}/parks/${dbPark.slug}`;
+
+  // Resolve the operator-controlled hero image (same priority as the detail
+  // page), falling back to the generated map hero, and absolutize it so the
+  // social-card crawlers can fetch it.
+  const approvedPhotos = await prisma.parkPhoto.findMany({
+    where: { parkId: dbPark.id, status: "APPROVED" },
+    select: { id: true, url: true },
+    orderBy: { createdAt: "desc" },
+  });
+  const heroImage = resolveParkHeroImage({
+    heroSource: dbPark.heroSource,
+    heroPhotoId: dbPark.heroPhotoId,
+    heroPhoto: dbPark.heroPhoto,
+    photos: (approvedPhotos ?? []).map((p) => ({ id: p.id, url: p.url, status: "APPROVED" as const })),
+  });
+  const image = toAbsoluteUrl(heroImage ?? dbPark.mapHeroUrl);
+  const images = image ? [image] : undefined;
+
   return {
-    title: `${park.name} - Offroad Parks`,
-    description:
-      park.notes ||
-      `Information about ${park.name} in ${park.address.city ? `${park.address.city}, ` : ""}${park.address.state}`,
+    title,
+    description,
+    openGraph: {
+      type: "article",
+      title,
+      description,
+      url,
+      ...(images ? { images } : {}),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      ...(images ? { images } : {}),
+    },
   };
 }
 
@@ -201,7 +249,46 @@ export default async function ParkPage({ params }: ParkPageProps) {
         }))
       : false;
 
+  // Build schema.org TouristAttraction structured data for rich results.
+  const canonicalUrl = `${SITE_URL}/parks/${dbPark.slug}`;
+  const absoluteHero = toAbsoluteUrl(park.heroImage ?? park.mapHeroUrl);
+  const jsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "TouristAttraction",
+    name: park.name,
+    url: canonicalUrl,
+    ...(park.notes ? { description: park.notes } : {}),
+    ...(absoluteHero ? { image: absoluteHero } : {}),
+    address: {
+      "@type": "PostalAddress",
+      ...(park.address.streetAddress ? { streetAddress: park.address.streetAddress } : {}),
+      ...(park.address.city ? { addressLocality: park.address.city } : {}),
+      addressRegion: park.address.state,
+      ...(park.address.zipCode ? { postalCode: park.address.zipCode } : {}),
+    },
+    ...(park.coords
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: park.coords.lat,
+            longitude: park.coords.lng,
+          },
+        }
+      : {}),
+    ...(park.averageRating != null && (park.reviewCount ?? 0) > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: park.averageRating,
+            reviewCount: park.reviewCount,
+          },
+        }
+      : {}),
+  };
+
   return (
+    <>
+    <JsonLd data={jsonLd} />
     <ParkDetailPage
       park={park}
       photos={photos}
@@ -216,5 +303,6 @@ export default async function ParkPage({ params }: ParkPageProps) {
       weatherForecast={weatherForecast}
       weatherAlerts={weatherAlerts}
     />
+    </>
   );
 }

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,0 +1,15 @@
+/**
+ * Renders a JSON-LD structured-data script tag for SEO / rich results.
+ *
+ * Server component — the `data` object is serialized to JSON and injected as
+ * the body of a `<script type="application/ld+json">` tag. Callers build the
+ * schema.org object (e.g. TouristAttraction) and pass it in.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## What
Adds social-share and search-engine SEO amplifiers:

- **Root layout** (`src/app/layout.tsx`): site-level `openGraph` (type `website`, siteName "Offroad Parks", title/description/url) + `twitter` (`summary_large_image`) cards. `metadataBase` preserved. No hardcoded site OG image (deferred to rebrand).
- **Park detail `generateMetadata`** (`src/app/parks/[id]/page.tsx`): per-park `openGraph` (type `article`, canonical `${SITE_URL}/parks/${slug}`, absolute hero image) + `twitter` cards. Hero resolved via `resolveParkHeroImage` with a `mapHeroUrl` fallback, absolutized against `SITE_URL`. Existing title/description and "Park Not Found" branch preserved.
- **JSON-LD** (`src/components/seo/JsonLd.tsx`): tiny server component rendering `application/ld+json`. Park page emits schema.org `TouristAttraction` with name, description, url, image, `PostalAddress`, `GeoCoordinates` (when coords exist), and `AggregateRating` (only when `reviewCount > 0`).

## Why
Improves link previews on social platforms and enables rich results in search — no new dependencies, no rename.

## Files
- `src/app/layout.tsx`
- `src/app/parks/[id]/page.tsx`
- `src/components/seo/JsonLd.tsx` (new)

## Verification
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npx tsc --noEmit` — clean
- `npm test` — 2172 passed, 2 skipped, 0 failures

No DB in this environment (Postgres-backed, DB-driven pages), so verified via the mocked-Prisma test suite covering `generateMetadata` and the page render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)