### PR TITLE
feat(pages): About / Contact / For Operators + expanded footer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,206 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Compass,
+  Map,
+  MountainSnow,
+  CloudSun,
+  Star,
+  ClipboardCheck,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "About · Offroad Parks",
+  description:
+    "Offroad Parks helps riders discover UTV and OHV-friendly parks, trails, terrain, and trail conditions — and gives operators the tools to keep their listing accurate.",
+};
+
+export default async function AboutPage() {
+  const session = await auth();
+  const user = session?.user
+    ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        role: (session.user as { role?: string }).role,
+      }
+    : null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader user={user} showBackButton />
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        {/* Hero */}
+        <section className="mb-14">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary mb-3">
+            About
+          </p>
+          <h1 className="text-4xl font-extrabold text-foreground mb-4">
+            The map for where to ride.
+          </h1>
+          <p className="text-lg text-muted-foreground leading-8 max-w-2xl">
+            Offroad Parks is a free, community-driven guide to UTV and
+            OHV-friendly parks across the United States. We bring the trails,
+            terrain, amenities, current conditions, and honest rider reviews
+            into one place — so you can spend less time guessing and more time
+            riding.
+          </p>
+        </section>
+
+        {/* What it is */}
+        <section className="mb-14">
+          <h2 className="text-2xl font-bold text-foreground mb-6">
+            What Offroad Parks is
+          </h2>
+          <p className="text-muted-foreground leading-7 mb-8 max-w-2xl">
+            Finding a good place to ride usually means digging through scattered
+            forum threads, outdated PDFs, and social posts. We pull that
+            information together and keep it current, so every park page tells
+            you what you actually need to know before you load up the trailer.
+          </p>
+          <div className="grid gap-5 sm:grid-cols-2">
+            {[
+              {
+                icon: Compass,
+                title: "Discover parks",
+                body: "Browse UTV and OHV-friendly parks near you or anywhere in the country, with filters for the riding you want.",
+              },
+              {
+                icon: Map,
+                title: "Trails & routes",
+                body: "See trail networks, difficulty, and rider-shared routes so you know what you're getting into.",
+              },
+              {
+                icon: MountainSnow,
+                title: "Terrain & amenities",
+                body: "Understand the terrain, on-site amenities, and what each park offers before you go.",
+              },
+              {
+                icon: CloudSun,
+                title: "Conditions & weather",
+                body: "Check current trail conditions and weather so a wasted trip doesn't sneak up on you.",
+              },
+            ].map(({ icon: Icon, title, body }) => (
+              <div
+                key={title}
+                className="rounded-xl border border-border bg-card p-5"
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/15 text-primary">
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <h3 className="font-semibold text-foreground">{title}</h3>
+                </div>
+                <p className="text-sm text-muted-foreground leading-6">{body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* How it works */}
+        <section className="mb-14">
+          <h2 className="text-2xl font-bold text-foreground mb-6">
+            How it works
+          </h2>
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="rounded-xl border border-border bg-card p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/15 text-primary">
+                  <Star className="h-5 w-5" />
+                </span>
+                <h3 className="text-lg font-semibold text-foreground">
+                  For riders
+                </h3>
+              </div>
+              <p className="text-sm text-muted-foreground leading-6">
+                Discovery and reviews are free, always. Find parks, read and
+                leave reviews, share trail conditions, and save the routes you
+                love. Your reports help the next rider know what to expect.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border bg-card p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/15 text-primary">
+                  <ClipboardCheck className="h-5 w-5" />
+                </span>
+                <h3 className="text-lg font-semibold text-foreground">
+                  For operators
+                </h3>
+              </div>
+              <p className="text-sm text-muted-foreground leading-6">
+                Park owners and operators can claim their park from its detail
+                page to manage the listing, post real-time trail status, and
+                reach riders who are actively planning where to go next.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Values */}
+        <section className="mb-14">
+          <h2 className="text-2xl font-bold text-foreground mb-6">
+            Why we built it
+          </h2>
+          <div className="space-y-5 max-w-2xl">
+            <div className="flex gap-4">
+              <ShieldCheck className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+              <p className="text-muted-foreground leading-7">
+                <span className="font-semibold text-foreground">
+                  Accurate &amp; current.
+                </span>{" "}
+                Bad information wastes a whole weekend. We combine community
+                reporting with operator-managed listings to keep park details
+                trustworthy.
+              </p>
+            </div>
+            <div className="flex gap-4">
+              <Users className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+              <p className="text-muted-foreground leading-7">
+                <span className="font-semibold text-foreground">
+                  Built for the community.
+                </span>{" "}
+                Every review, trail-condition report, and shared route makes the
+                map better for the next rider.
+              </p>
+            </div>
+            <div className="flex gap-4">
+              <Compass className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+              <p className="text-muted-foreground leading-7">
+                <span className="font-semibold text-foreground">
+                  Free to explore.
+                </span>{" "}
+                Discovering where to ride should never be behind a paywall. It
+                isn&apos;t here, and it won&apos;t be.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="rounded-2xl border border-border bg-card p-8 text-center">
+          <h2 className="text-2xl font-bold text-foreground mb-2">
+            Ready to find your next ride?
+          </h2>
+          <p className="text-muted-foreground mb-6 max-w-xl mx-auto">
+            Browse parks near you, or if you run a park, claim your listing to
+            reach riders.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href="/">Browse parks</Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/for-operators">For operators</Link>
+            </Button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { LEGAL } from "@/lib/legal";
+import { Button } from "@/components/ui/button";
+import { Mail, MapPinned, Flag, Building2 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Contact · Offroad Parks",
+  description:
+    "Get in touch with Offroad Parks — claim or manage a park, report a data problem, or ask about operator tools.",
+};
+
+export default async function ContactPage() {
+  const session = await auth();
+  const user = session?.user
+    ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        role: (session.user as { role?: string }).role,
+      }
+    : null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader user={user} showBackButton />
+
+      <main className="max-w-3xl mx-auto px-6 py-12">
+        <section className="mb-10">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary mb-3">
+            Contact
+          </p>
+          <h1 className="text-4xl font-extrabold text-foreground mb-4">
+            Get in touch
+          </h1>
+          <p className="text-lg text-muted-foreground leading-8">
+            We&apos;re a small team and we read everything. The fastest way to
+            reach us is email — but check the guidance below first, since a few
+            common requests are handled right in the app.
+          </p>
+        </section>
+
+        {/* Email */}
+        <section className="mb-10 rounded-2xl border border-border bg-card p-6 sm:p-8">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/15 text-primary">
+              <Mail className="h-5 w-5" />
+            </span>
+            <h2 className="text-xl font-bold text-foreground">Email us</h2>
+          </div>
+          <p className="text-muted-foreground leading-7 mb-5">
+            Questions, feedback, corrections, or partnership ideas — send them
+            our way and we&apos;ll get back to you.
+          </p>
+          <Button asChild size="lg">
+            <a href={`mailto:${LEGAL.contactEmail}`}>
+              <Mail className="h-4 w-4" />
+              {LEGAL.contactEmail}
+            </a>
+          </Button>
+        </section>
+
+        {/* Guidance blocks */}
+        <section className="space-y-5">
+          <h2 className="text-2xl font-bold text-foreground">
+            Before you write
+          </h2>
+
+          <div className="rounded-xl border border-border bg-card p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <MapPinned className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold text-foreground">
+                Claim or manage a park
+              </h3>
+            </div>
+            <p className="text-sm text-muted-foreground leading-6">
+              You don&apos;t need to email us to manage a listing. Open your
+              park&apos;s page from{" "}
+              <Link href="/" className="text-primary underline">
+                Browse parks
+              </Link>{" "}
+              and click &ldquo;Claim this park.&rdquo; Once verified, you can
+              update details and post trail status yourself.
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <Flag className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold text-foreground">
+                Report a data problem
+              </h3>
+            </div>
+            <p className="text-sm text-muted-foreground leading-6">
+              Spot wrong hours, a closed park, or bad trail info? Email us at{" "}
+              <a
+                href={`mailto:${LEGAL.contactEmail}`}
+                className="text-primary underline"
+              >
+                {LEGAL.contactEmail}
+              </a>{" "}
+              with the park name and what&apos;s off, and we&apos;ll fix it.
+            </p>
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-6">
+            <div className="flex items-center gap-3 mb-2">
+              <Building2 className="h-5 w-5 text-primary" />
+              <h3 className="font-semibold text-foreground">
+                Operator inquiries
+              </h3>
+            </div>
+            <p className="text-sm text-muted-foreground leading-6">
+              Run a park and want to know what claiming gets you? See{" "}
+              <Link href="/for-operators" className="text-primary underline">
+                For operators
+              </Link>{" "}
+              for the full rundown, then claim your park to get started.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/for-operators/page.tsx
+++ b/src/app/for-operators/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { auth } from "@/lib/auth";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { Button } from "@/components/ui/button";
+import {
+  Radio,
+  PencilRuler,
+  Megaphone,
+  FileSignature,
+  Ticket,
+  MapPin,
+  ArrowRight,
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "For Operators · Offroad Parks",
+  description:
+    "Claim your park on Offroad Parks to manage your listing, post real-time trail status, and reach riders actively planning their next trip — for free.",
+};
+
+export default async function ForOperatorsPage() {
+  const session = await auth();
+  const user = session?.user
+    ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        role: (session.user as { role?: string }).role,
+      }
+    : null;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AppHeader user={user} showBackButton />
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        {/* Hero */}
+        <section className="mb-16 text-center">
+          <p className="text-sm font-semibold uppercase tracking-widest text-primary mb-3">
+            For operators
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-foreground mb-5 leading-tight">
+            Put your park in front of riders.
+          </h1>
+          <p className="text-lg text-muted-foreground leading-8 max-w-2xl mx-auto mb-8">
+            Riders come to Offroad Parks to decide where to ride next. Claim
+            your park to control your listing, share what&apos;s open today, and
+            get discovered by the people already looking for a place like yours.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href="/">
+                Claim your park
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <Link href="/contact">Talk to us</Link>
+            </Button>
+          </div>
+          <p className="text-sm text-muted-foreground mt-4">
+            Free to claim. No credit card required.
+          </p>
+        </section>
+
+        {/* Value props */}
+        <section className="mb-16">
+          <h2 className="text-2xl font-bold text-foreground mb-8 text-center">
+            Why claim your park
+          </h2>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {[
+              {
+                icon: Radio,
+                title: "Real-time trail status",
+                body: "Post open/closed status and trail conditions the moment they change. Cut down on the calls asking whether you're open after rain.",
+              },
+              {
+                icon: PencilRuler,
+                title: "Keep your listing accurate",
+                body: "Own your hours, amenities, terrain, pricing, and photos so riders always see the right information — not stale forum posts.",
+              },
+              {
+                icon: Megaphone,
+                title: "Free marketing & discovery",
+                body: "Get surfaced to riders actively searching for parks in your area. Reviews and exposure that bring new customers to your gate.",
+              },
+            ].map(({ icon: Icon, title, body }) => (
+              <div
+                key={title}
+                className="rounded-xl border border-border bg-card p-6"
+              >
+                <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-primary/15 text-primary mb-4">
+                  <Icon className="h-6 w-6" />
+                </span>
+                <h3 className="font-semibold text-foreground mb-2">{title}</h3>
+                <p className="text-sm text-muted-foreground leading-6">{body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Coming soon */}
+        <section className="mb-16">
+          <div className="rounded-2xl border border-border bg-card p-6 sm:p-8">
+            <div className="flex items-center gap-2 mb-4">
+              <span className="text-xs font-bold uppercase tracking-wider text-primary bg-primary/15 border border-primary/25 rounded-md px-2 py-0.5">
+                Coming soon
+              </span>
+              <h2 className="text-xl font-bold text-foreground">
+                More operator tools on the way
+              </h2>
+            </div>
+            <div className="grid gap-6 sm:grid-cols-2">
+              <div className="flex gap-4">
+                <FileSignature className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+                <div>
+                  <h3 className="font-semibold text-foreground mb-1">
+                    Digital waivers
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-6">
+                    Let riders sign your waiver online before they arrive — no
+                    clipboard at the gate.
+                  </p>
+                </div>
+              </div>
+              <div className="flex gap-4">
+                <Ticket className="h-5 w-5 shrink-0 text-primary mt-0.5" />
+                <div>
+                  <h3 className="font-semibold text-foreground mb-1">
+                    Day-pass ticketing
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-6">
+                    Sell day passes directly from your listing and manage
+                    entries without extra software.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* How to claim */}
+        <section className="mb-16">
+          <h2 className="text-2xl font-bold text-foreground mb-6 text-center">
+            How to claim your park
+          </h2>
+          <ol className="space-y-4 max-w-2xl mx-auto">
+            {[
+              {
+                step: "1",
+                title: "Find your park",
+                body: "Head to Browse parks and search for your park by name or location.",
+              },
+              {
+                step: "2",
+                title: "Click “Claim this park”",
+                body: "Open your park's detail page and use the claim button to start verification.",
+              },
+              {
+                step: "3",
+                title: "Manage your listing",
+                body: "Once verified, update details and post trail status any time.",
+              },
+            ].map(({ step, title, body }) => (
+              <li
+                key={step}
+                className="flex gap-4 rounded-xl border border-border bg-card p-5"
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground font-bold">
+                  {step}
+                </span>
+                <div>
+                  <h3 className="font-semibold text-foreground mb-1">{title}</h3>
+                  <p className="text-sm text-muted-foreground leading-6">
+                    {body}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        {/* Final CTA */}
+        <section className="rounded-2xl border border-border bg-primary/10 p-8 text-center">
+          <MapPin className="h-8 w-8 text-primary mx-auto mb-3" />
+          <h2 className="text-2xl font-bold text-foreground mb-2">
+            Your park is probably already listed.
+          </h2>
+          <p className="text-muted-foreground mb-6 max-w-xl mx-auto">
+            Find it on Offroad Parks and click &ldquo;Claim this park&rdquo; to
+            take control of your listing — it&apos;s free.
+          </p>
+          <Button asChild size="lg">
+            <Link href="/">
+              Claim your park
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -2,15 +2,45 @@ import Link from "next/link";
 
 /**
  * Global site footer. Provides always-available links to the legal pages
- * (required for the Google OAuth consent screen and general trust) plus a few
- * primary navigation destinations.
+ * (required for the Google OAuth consent screen and general trust) plus
+ * grouped navigation to the app's primary destinations.
  */
+const FOOTER_SECTIONS: {
+  heading: string;
+  links: { href: string; label: string }[];
+}[] = [
+  {
+    heading: "Explore",
+    links: [
+      { href: "/", label: "Browse parks" },
+      { href: "/reviews", label: "Reviews" },
+      { href: "/routes", label: "Routes" },
+      { href: "/submit", label: "Submit a park" },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { href: "/about", label: "About" },
+      { href: "/for-operators", label: "For operators" },
+      { href: "/contact", label: "Contact" },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { href: "/legal/privacy", label: "Privacy" },
+      { href: "/legal/terms", label: "Terms" },
+    ],
+  },
+];
+
 export function SiteFooter() {
   const year = new Date().getFullYear();
 
   return (
     <footer className="border-t border-border bg-card/50 mt-8">
-      <div className="max-w-7xl mx-auto px-6 py-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div className="max-w-7xl mx-auto px-6 py-10 grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <Link
             href="/"
@@ -18,46 +48,38 @@ export function SiteFooter() {
           >
             Offroad Parks
           </Link>
-          <p className="text-xs text-muted-foreground mt-1">
+          <p className="text-xs text-muted-foreground mt-2 max-w-xs">
             Find UTV-friendly parks and trails across the U.S.
           </p>
         </div>
 
-        <nav
-          aria-label="Footer"
-          className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground"
-        >
-          <Link
-            href="/reviews"
-            className="hover:text-foreground transition-colors"
-          >
-            Reviews
-          </Link>
-          <Link
-            href="/submit"
-            className="hover:text-foreground transition-colors"
-          >
-            Submit a Park
-          </Link>
-          <Link
-            href="/legal/privacy"
-            className="hover:text-foreground transition-colors"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="/legal/terms"
-            className="hover:text-foreground transition-colors"
-          >
-            Terms
-          </Link>
-        </nav>
+        {FOOTER_SECTIONS.map((section) => (
+          <nav key={section.heading} aria-label={section.heading}>
+            <h2 className="text-xs font-bold uppercase tracking-wider text-foreground mb-3">
+              {section.heading}
+            </h2>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {section.links.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="hover:text-foreground transition-colors"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ))}
       </div>
 
-      <div className="max-w-7xl mx-auto px-6 pb-6">
-        <p className="text-xs text-muted-foreground">
-          © {year} Offroad Parks. All rights reserved.
-        </p>
+      <div className="border-t border-border">
+        <div className="max-w-7xl mx-auto px-6 py-6">
+          <p className="text-xs text-muted-foreground">
+            © {year} Offroad Parks. All rights reserved.
+          </p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## What & why
Adds three public trust/funnel pages to support go-live and the operator GTM funnel, and expands the global site footer into grouped navigation.

- **/about** — mission + what-it-is: discovery (parks, trails, terrain, amenities, conditions, weather), how it works (free for riders; operators claim & manage), and values.
- **/contact** — honest contact page with a `mailto:` link (uses `contactEmail` from `src/lib/legal.ts`, no submit backend) plus guidance for claiming a park, reporting data problems, and operator inquiries.
- **/for-operators** — marketing landing selling the operator value prop (real-time trail status, accurate listings, free discovery; digital waivers & day-pass ticketing noted as coming soon). Primary CTA 'Claim your park' → `/` with claim instructions.
- **SiteFooter.tsx** — expanded into Explore / Company / Legal columns (real routes only), responsive stack→columns.

All pages use `AppHeader`, export `metadata`, and are themed/responsive following the legal-page pattern.

## Files
- create `src/app/about/page.tsx`
- create `src/app/contact/page.tsx`
- create `src/app/for-operators/page.tsx`
- edit `src/components/layout/SiteFooter.tsx`

## Verification
- `npm run lint` — 0 errors (only pre-existing warnings, none in new files)
- `npx tsc --noEmit` — clean
- `npm test` — 2172 passed, 2 skipped; no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)