### PR TITLE
feat(ux): branded 404 + error/loading pages

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Home, RotateCw } from "lucide-react";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { BrokenTruck } from "@/components/BrokenTruck";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Sentry auto-captures via the app's instrumentation; log for local dev too.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <AppHeader />
+      <main className="flex-1 flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md text-center flex flex-col items-center">
+          <BrokenTruck className="w-64 sm:w-80 mb-8" />
+
+          <p className="text-sm font-bold uppercase tracking-widest text-primary">
+            Something broke down
+          </p>
+          <h1 className="mt-3 text-3xl sm:text-4xl font-extrabold tracking-tight text-foreground">
+            Something went sideways.
+          </h1>
+          <p className="mt-4 text-base text-muted-foreground leading-7">
+            We hit a rough patch loading this page. Give it another crank, or
+            head back to base camp.
+          </p>
+
+          {error.digest && (
+            <p className="mt-3 text-xs text-muted-foreground/70 font-mono">
+              Ref: {error.digest}
+            </p>
+          )}
+
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3 w-full sm:w-auto">
+            <Button
+              size="lg"
+              onClick={() => reset()}
+              className="w-full sm:w-auto"
+            >
+              <RotateCw className="w-4 h-4" />
+              Try again
+            </Button>
+            <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+              <Link href="/">
+                <Home className="w-4 h-4" />
+                Go home
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Last-resort fallback that replaces the root layout when it throws, so it
+ * must render its own <html>/<body>. Global CSS may not be applied here, so
+ * styling is kept inline and theme-neutral.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "1.5rem",
+          backgroundColor: "#161311",
+          color: "#f0ebe6",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+          textAlign: "center",
+        }}
+      >
+        <div style={{ maxWidth: "28rem" }}>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "0.75rem",
+              fontWeight: 700,
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "#e8763a",
+            }}
+          >
+            Offroad Parks
+          </p>
+          <h1
+            style={{
+              margin: "0.75rem 0 0",
+              fontSize: "1.75rem",
+              fontWeight: 800,
+              lineHeight: 1.2,
+            }}
+          >
+            The whole rig broke down.
+          </h1>
+          <p
+            style={{
+              margin: "1rem 0 0",
+              fontSize: "1rem",
+              lineHeight: 1.6,
+              color: "#b3aaa2",
+            }}
+          >
+            Something went badly wrong on our end. Try reloading — we&apos;ll get
+            back on the trail.
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              marginTop: "1.75rem",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "2.5rem",
+              padding: "0 1.5rem",
+              borderRadius: "0.375rem",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              backgroundColor: "#e8763a",
+              color: "#161311",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,17 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <div
+      className="min-h-screen bg-background flex flex-col items-center justify-center gap-4 px-6"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 className="w-10 h-10 text-primary animate-spin" />
+      <p className="text-sm font-medium text-muted-foreground">
+        Firing up the engine…
+      </p>
+      <span className="sr-only">Loading</span>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { Compass, MapPinned } from "lucide-react";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { BrokenTruck } from "@/components/BrokenTruck";
+import { Button } from "@/components/ui/button";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page not found · Offroad Parks",
+  description: "This trail's a dead end — the page you're looking for took a wrong turn off the map.",
+};
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <AppHeader />
+      <main className="flex-1 flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md text-center flex flex-col items-center">
+          <BrokenTruck className="w-64 sm:w-80 mb-8" />
+
+          <p className="text-sm font-bold uppercase tracking-widest text-primary">
+            404 — Off the map
+          </p>
+          <h1 className="mt-3 text-3xl sm:text-4xl font-extrabold tracking-tight text-foreground">
+            Well, this trail&apos;s a dead end.
+          </h1>
+          <p className="mt-4 text-base text-muted-foreground leading-7">
+            The page you&apos;re looking for took a wrong turn off the map. Let&apos;s
+            get you back on solid ground.
+          </p>
+
+          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3 w-full sm:w-auto">
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <Link href="/">
+                <Compass className="w-4 h-4" />
+                Back to base camp
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+              <Link href="/">
+                <MapPinned className="w-4 h-4" />
+                Browse parks
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/BrokenTruck.tsx
+++ b/src/components/BrokenTruck.tsx
@@ -1,0 +1,156 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Hand-authored cartoon "broken-down offroad truck" illustration.
+ *
+ * The whole scene is drawn with `currentColor` and Tailwind text-color
+ * utilities so it adapts to light and dark themes: the body reads in the
+ * brand `text-primary` orange, while tires, roll cage, dust and popped bolts
+ * pick up `text-foreground` / `text-muted-foreground`. No hard-coded hex, so
+ * it stays legible on either background.
+ */
+export function BrokenTruck({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 260 190"
+      role="img"
+      aria-label="A broken-down offroad truck tilted on a bare hub with a flat tire lying beside it and a puff of smoke rising from the hood"
+      className={cn("h-auto w-full", className)}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Ground / dust shadow */}
+      <g className="text-muted-foreground">
+        <ellipse cx="132" cy="172" rx="116" ry="9" fill="currentColor" opacity="0.14" />
+      </g>
+
+      {/* Puffs of smoke drifting up from the hood */}
+      <g className="text-muted-foreground" fill="currentColor">
+        <circle cx="66" cy="70" r="9" opacity="0.30" />
+        <circle cx="55" cy="55" r="7" opacity="0.24" />
+        <circle cx="70" cy="48" r="6" opacity="0.18" />
+        <circle cx="58" cy="40" r="4.5" opacity="0.12" />
+      </g>
+
+      {/* The truck, tilted forward onto its bare front hub */}
+      <g transform="rotate(5 130 118)">
+        {/* Body + nose (brand orange) */}
+        <g className="text-primary" fill="currentColor">
+          <path
+            d="M78 132
+               L74 112
+               Q74 106 80 105
+               L96 104
+               L112 82
+               Q115 78 121 78
+               L166 78
+               Q172 78 174 84
+               L186 108
+               L202 114
+               Q210 116 210 124
+               L210 132
+               Q210 138 204 138
+               L84 138
+               Q78 138 78 132 Z"
+          />
+          {/* Front skid / bumper lip */}
+          <path
+            d="M72 130 L74 118 Q74 122 80 123 L94 123 L92 132 Z"
+            opacity="0.85"
+          />
+        </g>
+
+        {/* Cockpit window glass */}
+        <path
+          className="text-foreground"
+          d="M118 84 L162 84 Q166 84 167 90 L173 104 L118 104 Z"
+          fill="currentColor"
+          opacity="0.16"
+        />
+
+        {/* Roll cage + seat detail */}
+        <g
+          className="text-foreground"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M114 106 L120 80 L166 80 L176 106" />
+          <path d="M140 80 L146 106" opacity="0.6" />
+          <path d="M132 106 L134 118" opacity="0.5" />
+        </g>
+
+        {/* Rear wheel — intact knobby tire */}
+        <g>
+          <circle className="text-foreground" cx="178" cy="140" r="23" fill="currentColor" />
+          <circle
+            className="text-muted-foreground"
+            cx="178"
+            cy="140"
+            r="23"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeDasharray="4 5"
+          />
+          <circle className="text-primary" cx="178" cy="140" r="9" fill="currentColor" />
+          <circle className="text-foreground" cx="178" cy="140" r="3" fill="currentColor" />
+        </g>
+
+        {/* Bare front hub — the wheel that fell off */}
+        <g className="text-muted-foreground">
+          <circle cx="98" cy="141" r="10" fill="currentColor" />
+          <circle
+            className="text-foreground"
+            cx="98"
+            cy="141"
+            r="4"
+            fill="currentColor"
+          />
+        </g>
+
+        {/* Headlight */}
+        <circle className="text-foreground" cx="79" cy="116" r="4" fill="currentColor" opacity="0.85" />
+      </g>
+
+      {/* Detached, flat tire lying in the foreground */}
+      <g>
+        <ellipse
+          className="text-foreground"
+          cx="60"
+          cy="156"
+          rx="30"
+          ry="14"
+          fill="currentColor"
+        />
+        <ellipse
+          className="text-muted-foreground"
+          cx="60"
+          cy="156"
+          rx="30"
+          ry="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeDasharray="4 5"
+        />
+        <ellipse
+          className="text-primary"
+          cx="60"
+          cy="156"
+          rx="12"
+          ry="5.5"
+          fill="currentColor"
+        />
+      </g>
+
+      {/* Popped-out bolts scattered by the hub */}
+      <g className="text-muted-foreground" fill="currentColor">
+        <circle cx="120" cy="164" r="3" />
+        <circle cx="134" cy="169" r="2.5" opacity="0.8" />
+        <circle cx="108" cy="171" r="2" opacity="0.7" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## What & why

Adds branded, theme-aware error, 404, and loading states so users hitting a bad URL or a runtime error land on something on-brand instead of Next's default gray screens.

The headliner is a hand-authored cartoon **broken-down offroad truck** SVG (`BrokenTruck.tsx`): a roll-caged buggy tipped onto a bare front hub, a flat tire lying beside it, a puff of smoke from the hood, and a couple of popped bolts. It's built entirely from `currentColor` + theme text-color classes (`text-primary`, `text-muted-foreground`, `text-foreground`) so it reads cleanly in both light and dark mode — no hard-coded hex.

## Files

- `src/components/BrokenTruck.tsx` — reusable inline-SVG illustration
- `src/app/not-found.tsx` — themed 404 with `AppHeader`, headline + CTAs ("Back to base camp", "Browse parks")
- `src/app/error.tsx` — client error boundary ("Something went sideways."), Try again / Go home, logs to console for Sentry
- `src/app/global-error.tsx` — self-contained `<html>/<body>` fallback with inline styles
- `src/app/loading.tsx` — centered `Loader2` spinner

## Verification

- `npm run lint` — pass (only pre-existing warnings, none in new files)
- `npx tsc --noEmit` — pass
- `npm test` — 2172 passed, 2 skipped (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)