### PR TITLE
feat(loading): in-content spinner + rotating offroad phrases

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,17 +1,13 @@
-import { Loader2 } from "lucide-react";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { LoadingMessage } from "@/components/LoadingMessage";
 
 export default function Loading() {
   return (
-    <div
-      className="min-h-screen bg-background flex flex-col items-center justify-center gap-4 px-6"
-      role="status"
-      aria-live="polite"
-    >
-      <Loader2 className="w-10 h-10 text-primary animate-spin" />
-      <p className="text-sm font-medium text-muted-foreground">
-        Firing up the engine…
-      </p>
-      <span className="sr-only">Loading</span>
+    <div className="min-h-screen bg-background flex flex-col">
+      <AppHeader />
+      <main className="flex-1 flex items-center justify-center px-6 py-16">
+        <LoadingMessage />
+      </main>
     </div>
   );
 }

--- a/src/components/LoadingMessage.tsx
+++ b/src/components/LoadingMessage.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+
+/**
+ * Fun, offroad-flavored loading phrases. One is picked at random each time the
+ * indicator mounts (fresh on every client navigation).
+ */
+const MESSAGES = [
+  "Firing up the engine…",
+  "Airing down the tires…",
+  "Warming up the winch…",
+  "Scouting the trailhead…",
+  "Kicking up some dust…",
+  "Locking the diffs…",
+  "Checking the trail map…",
+  "Fueling up for the ride…",
+  "Reading the mud…",
+  "Chasing the ridgeline…",
+  "Loading up the gear…",
+  "Picking a line through the rocks…",
+];
+
+export function LoadingMessage() {
+  // Lazy initializer runs once per mount — a new phrase each time the loading
+  // state appears, without a setState-in-effect. The server and first client
+  // paint may differ, so the text node opts out of hydration warnings.
+  const [message] = useState(
+    () => MESSAGES[Math.floor(Math.random() * MESSAGES.length)],
+  );
+
+  return (
+    <div
+      className="flex flex-col items-center gap-4 text-center"
+      role="status"
+      aria-live="polite"
+    >
+      <Loader2 className="w-10 h-10 text-primary animate-spin" />
+      <p
+        className="text-sm font-medium text-muted-foreground"
+        suppressHydrationWarning
+      >
+        {message}
+      </p>
+      <span className="sr-only">Loading</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Two tweaks to the route loading state:

1. **Less jumpy** — render `AppHeader` (and keep the layout footer) with the spinner in the content area, matching the 404/error shells, instead of a full-screen centered takeover.
2. **Fun phrases** — new `LoadingMessage` client component randomly picks from a dozen offroad-themed messages (kept "Firing up the engine…" and added 11 more) on each mount, so it varies every time.

Verified: `eslint` clean, `tsc --noEmit` clean, pre-commit hook ran the full test suite. Live browser render not run (no DB/.env in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)