### PR TITLE
feat(ai-discovery): manually seed park names as candidates

### DIFF
--- a/src/app/api/admin/ai-research/discovery/seed/route.ts
+++ b/src/app/api/admin/ai-research/discovery/seed/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-helpers";
+import { seedParkCandidatesByName } from "@/lib/ai/park-discovery";
+import { normalizeStateName } from "@/lib/us-states";
+
+// POST — manually seed one or more park names as PENDING candidates, skipping
+// the SerpApi + LLM discovery step. Body: { state, names: string[] }.
+export async function POST(request: Request) {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  let body: { state?: string; names?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const canonicalState = normalizeStateName(body.state);
+  if (!canonicalState) {
+    return NextResponse.json(
+      {
+        error:
+          "state must be a US state full name (e.g. 'Arkansas') or 2-letter code (e.g. 'AR')",
+      },
+      { status: 400 }
+    );
+  }
+
+  const names = Array.isArray(body.names)
+    ? body.names.filter((n): n is string => typeof n === "string")
+    : [];
+  if (names.length === 0) {
+    return NextResponse.json(
+      { error: "Provide at least one park name to seed" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { candidates, skipped } = await seedParkCandidatesByName(
+      canonicalState,
+      names
+    );
+
+    return NextResponse.json({
+      success: true,
+      candidatesFound: candidates.length,
+      skipped: skipped.length,
+      skippedDetails: skipped,
+    });
+  } catch (error) {
+    console.error("[discovery/seed] Error seeding candidates:", error);
+    return NextResponse.json({ error: "Seeding failed" }, { status: 500 });
+  }
+}

--- a/src/components/admin/ParkDiscoveryTable.tsx
+++ b/src/components/admin/ParkDiscoveryTable.tsx
@@ -10,6 +10,7 @@ import {
   Search,
   CheckCheck,
   XOctagon,
+  ListPlus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { ParkCandidateSummary } from "@/lib/types";
@@ -85,6 +86,12 @@ export function ParkDiscoveryTable({ candidates }: Props) {
   const [discoverState, setDiscoverState] = useState("");
   const [discovering, setDiscovering] = useState(false);
   const [discoverResult, setDiscoverResult] = useState<string | null>(null);
+
+  // Seed park names state
+  const [seedState, setSeedState] = useState("");
+  const [seedNames, setSeedNames] = useState("");
+  const [seeding, setSeeding] = useState(false);
+  const [seedResult, setSeedResult] = useState<string | null>(null);
 
   const pendingCandidates = candidates.filter((c) => c.status === "PENDING");
 
@@ -214,6 +221,51 @@ export function ParkDiscoveryTable({ candidates }: Props) {
     }
   };
 
+  const handleSeed = async () => {
+    const names = seedNames
+      .split("\n")
+      .map((n) => n.trim())
+      .filter(Boolean);
+    if (!seedState || names.length === 0) return;
+    setSeeding(true);
+    setSeedResult(null);
+    try {
+      const response = await fetch(
+        "/api/admin/ai-research/discovery/seed",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ state: seedState, names }),
+        }
+      );
+      const data = await response.json();
+      if (response.ok) {
+        const parts = [
+          `Seeded ${data.candidatesFound} candidate(s) in ${seedState}`,
+        ];
+        if (data.skipped > 0) {
+          parts.push(`${data.skipped} skipped (duplicate or invalid)`);
+        }
+        setSeedResult(`${parts.join(", ")}.`);
+        setSeedNames("");
+        router.refresh();
+      } else {
+        setSeedResult(`Error: ${data.error || "Seeding failed"}`);
+      }
+    } catch (err) {
+      setSeedResult(
+        `Error: ${err instanceof Error ? err.message : "Network error"}`
+      );
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  const seedNameCount = seedNames
+    .split("\n")
+    .map((n) => n.trim())
+    .filter(Boolean).length;
+
   const isProcessing = processingId !== null || processingBulk !== null;
 
   return (
@@ -266,6 +318,80 @@ export function ParkDiscoveryTable({ candidates }: Props) {
             }`}
           >
             {discoverResult}
+          </div>
+        )}
+      </div>
+
+      {/* Seed Park Names Manually */}
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm font-medium text-foreground mb-1">
+          Seed park names manually
+        </p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Know the parks already (e.g. from Google Maps)? Add them straight to
+          the candidate queue — one name per line. No AI search runs; details
+          are filled in by research once you accept a candidate.
+        </p>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="w-full sm:max-w-xs">
+            <label className="block text-xs text-muted-foreground mb-1">
+              State
+            </label>
+            <select
+              value={seedState}
+              onChange={(e) => setSeedState(e.target.value)}
+              className="w-full rounded-md border border-input bg-background text-foreground px-3 py-2 text-sm focus:border-ring focus:ring-1 focus:ring-ring"
+            >
+              <option value="">Select a state...</option>
+              {US_STATES.map((s) => (
+                <option key={s.value} value={s.value}>
+                  {s.label} ({s.value})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-muted-foreground mb-1">
+              Park names (one per line)
+            </label>
+            <textarea
+              value={seedNames}
+              onChange={(e) => setSeedNames(e.target.value)}
+              rows={4}
+              placeholder={"Windrock Park\nBrimstone Recreation\nRoyal Blue OHV Area"}
+              className="w-full rounded-md border border-input bg-background text-foreground px-3 py-2 text-sm focus:border-ring focus:ring-1 focus:ring-ring resize-y"
+            />
+          </div>
+        </div>
+        <div className="mt-3">
+          <Button
+            onClick={handleSeed}
+            disabled={seeding || !seedState || seedNameCount === 0}
+            size="sm"
+          >
+            {seeding ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                Seeding...
+              </>
+            ) : (
+              <>
+                <ListPlus className="w-4 h-4 mr-1" />
+                Seed {seedNameCount > 0 ? `${seedNameCount} ` : ""}Name
+                {seedNameCount === 1 ? "" : "s"}
+              </>
+            )}
+          </Button>
+        </div>
+        {seedResult && (
+          <div
+            className={`mt-3 rounded-lg border px-4 py-3 text-sm ${
+              seedResult.startsWith("Error")
+                ? "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-900/40 text-red-800 dark:text-red-300"
+                : "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-900/40 text-green-800 dark:text-green-300"
+            }`}
+          >
+            {seedResult}
           </div>
         )}
       </div>

--- a/src/lib/ai/park-discovery.ts
+++ b/src/lib/ai/park-discovery.ts
@@ -54,7 +54,7 @@ export function normalizeParkName(name: string): string {
 
 // ── Fuzzy dedup check ────────────────────────────────────────────────────────
 
-function isFuzzyDuplicate(
+export function isFuzzyDuplicate(
   candidateName: string,
   existingName: string
 ): boolean {
@@ -248,4 +248,109 @@ export async function discoverParksInState(state: string): Promise<{
     inputTokens,
     outputTokens,
   };
+}
+
+// ── Manual name seeding ──────────────────────────────────────────────────────
+// Admins gather park names by hand (e.g. browsing Google Maps) and seed them
+// directly as PENDING candidates — skipping the SerpApi + LLM discovery step.
+// No location/source is captured here; the research pipeline fills that in once
+// a candidate is accepted into a Park.
+
+export type SeedSkip = {
+  name: string;
+  reason: "duplicate" | "invalid";
+};
+
+// Clean and de-duplicate a raw list of typed names before hitting the DB.
+// Trims whitespace, drops blank lines, and removes intra-batch duplicates using
+// the same normalization as fuzzy dedup. Pure/synchronous so it can be unit
+// tested without a database.
+export function dedupeSeedNames(names: string[]): {
+  cleaned: string[];
+  skipped: SeedSkip[];
+} {
+  const cleaned: string[] = [];
+  const seenKeys = new Set<string>();
+  const skipped: SeedSkip[] = [];
+
+  for (const raw of names) {
+    const name = raw.trim().replace(/\s+/g, " ");
+    if (!name) continue; // blank line — silently ignore
+
+    const key = normalizeParkName(name);
+    if (!key) {
+      // Name is nothing but generic suffix words ("OHV Park") — can't dedup or
+      // research it meaningfully.
+      skipped.push({ name, reason: "invalid" });
+      continue;
+    }
+    if (seenKeys.has(key)) {
+      skipped.push({ name, reason: "duplicate" });
+      continue;
+    }
+
+    seenKeys.add(key);
+    cleaned.push(name);
+  }
+
+  return { cleaned, skipped };
+}
+
+export async function seedParkCandidatesByName(
+  state: string,
+  names: string[]
+): Promise<{
+  candidates: Array<{ name: string; state: string }>;
+  skipped: SeedSkip[];
+}> {
+  const canonicalState = normalizeStateName(state);
+  if (!canonicalState) {
+    throw new Error(`Unknown US state: "${state}"`);
+  }
+
+  const { cleaned, skipped } = dedupeSeedNames(names);
+
+  if (cleaned.length === 0) {
+    return { candidates: [], skipped };
+  }
+
+  // Fuzzy dedup against existing parks and pending candidates in this state.
+  const [existingParks, existingCandidates] = await Promise.all([
+    prisma.park.findMany({
+      where: { address: { state: canonicalState } },
+      select: { name: true },
+    }),
+    prisma.parkCandidate.findMany({
+      where: { state: canonicalState },
+      select: { name: true },
+    }),
+  ]);
+
+  const existingNames = [
+    ...existingParks.map((p) => p.name),
+    ...existingCandidates.map((c) => c.name),
+  ];
+
+  const fresh: Array<{ name: string; state: string }> = [];
+  for (const name of cleaned) {
+    const isDuplicate = existingNames.some((existing) =>
+      isFuzzyDuplicate(name, existing)
+    );
+    if (isDuplicate) {
+      skipped.push({ name, reason: "duplicate" });
+      continue;
+    }
+    fresh.push({ name, state: canonicalState });
+  }
+
+  // Persist — city/coords/sourceUrl stay null (unknown at seed time). The
+  // @@unique([name, state]) constraint + skipDuplicates guards against races.
+  if (fresh.length > 0) {
+    await prisma.parkCandidate.createMany({
+      data: fresh,
+      skipDuplicates: true,
+    });
+  }
+
+  return { candidates: fresh, skipped };
 }

--- a/test/components/admin/ParkDiscoveryTable.test.tsx
+++ b/test/components/admin/ParkDiscoveryTable.test.tsx
@@ -67,7 +67,8 @@ describe("ParkDiscoveryTable", () => {
       json: async () => ({ candidatesFound: 3 }),
     });
     render(<ParkDiscoveryTable candidates={[]} />);
-    const select = screen.getByRole("combobox");
+    // First combobox is the discovery state select (second is the seed panel).
+    const select = screen.getAllByRole("combobox")[0];
     fireEvent.change(select, { target: { value: "UT" } });
 
     fireEvent.click(screen.getByRole("button", { name: /search/i }));
@@ -92,7 +93,9 @@ describe("ParkDiscoveryTable", () => {
       json: async () => ({ error: "quota exceeded" }),
     });
     render(<ParkDiscoveryTable candidates={[]} />);
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "CA" } });
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "CA" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /search/i }));
 
     await waitFor(() => {
@@ -103,11 +106,77 @@ describe("ParkDiscoveryTable", () => {
   it("shows generic error when discovery fetch throws", async () => {
     mockFetch.mockRejectedValueOnce(new Error("offline"));
     render(<ParkDiscoveryTable candidates={[]} />);
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "AZ" } });
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "AZ" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /search/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/error: offline/i)).toBeInTheDocument();
+    });
+  });
+
+  it("Seed button is disabled until a state and a name are provided", () => {
+    render(<ParkDiscoveryTable candidates={[]} />);
+    const seedBtn = screen.getByRole("button", { name: /seed/i });
+    expect(seedBtn).toBeDisabled();
+
+    // Second combobox is the seed panel's state select.
+    fireEvent.change(screen.getAllByRole("combobox")[1], {
+      target: { value: "TN" },
+    });
+    expect(seedBtn).toBeDisabled(); // no names yet
+
+    fireEvent.change(screen.getByPlaceholderText(/windrock/i), {
+      target: { value: "Windrock Park" },
+    });
+    expect(seedBtn).not.toBeDisabled();
+  });
+
+  it("seeds manually entered park names via POST", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ candidatesFound: 2, skipped: 0 }),
+    });
+    render(<ParkDiscoveryTable candidates={[]} />);
+    fireEvent.change(screen.getAllByRole("combobox")[1], {
+      target: { value: "TN" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/windrock/i), {
+      target: { value: "Windrock Park\nBrimstone Recreation" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /seed/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/admin/ai-research/discovery/seed",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("Windrock Park"),
+        })
+      );
+      expect(
+        screen.getByText(/seeded 2 candidate\(s\) in TN/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("reports skipped names in the seed result", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ candidatesFound: 1, skipped: 1 }),
+    });
+    render(<ParkDiscoveryTable candidates={[]} />);
+    fireEvent.change(screen.getAllByRole("combobox")[1], {
+      target: { value: "TN" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/windrock/i), {
+      target: { value: "Windrock Park\nWindrock OHV Park" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /seed/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 skipped/i)).toBeInTheDocument();
     });
   });
 

--- a/test/lib/ai/park-discovery.test.ts
+++ b/test/lib/ai/park-discovery.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   levenshteinDistance,
   normalizeParkName,
+  dedupeSeedNames,
 } from "@/lib/ai/park-discovery";
 
 describe("levenshteinDistance", () => {
@@ -146,5 +147,44 @@ describe("fuzzy dedup logic", () => {
     const b = normalizeParkName("Carnegie SVRA");
     // Both normalize — "ohv" and "park" stripped
     expect(levenshteinDistance(a, b)).toBe(0);
+  });
+});
+
+describe("dedupeSeedNames", () => {
+  it("trims whitespace and keeps distinct names", () => {
+    const { cleaned, skipped } = dedupeSeedNames([
+      "  Windrock Park  ",
+      "Brimstone Recreation",
+    ]);
+    expect(cleaned).toEqual(["Windrock Park", "Brimstone Recreation"]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("ignores blank lines entirely (not counted as skipped)", () => {
+    const { cleaned, skipped } = dedupeSeedNames(["Windrock", "", "   "]);
+    expect(cleaned).toEqual(["Windrock"]);
+    expect(skipped).toEqual([]);
+  });
+
+  it("collapses internal whitespace", () => {
+    const { cleaned } = dedupeSeedNames(["Royal   Blue   OHV   Area"]);
+    expect(cleaned).toEqual(["Royal Blue OHV Area"]);
+  });
+
+  it("removes intra-batch duplicates using park-name normalization", () => {
+    const { cleaned, skipped } = dedupeSeedNames([
+      "Windrock Park",
+      "Windrock OHV Park", // normalizes to same key as the first
+    ]);
+    expect(cleaned).toEqual(["Windrock Park"]);
+    expect(skipped).toEqual([
+      { name: "Windrock OHV Park", reason: "duplicate" },
+    ]);
+  });
+
+  it("flags names that are only generic suffix words as invalid", () => {
+    const { cleaned, skipped } = dedupeSeedNames(["OHV Park"]);
+    expect(cleaned).toEqual([]);
+    expect(skipped).toEqual([{ name: "OHV Park", reason: "invalid" }]);
   });
 });


### PR DESCRIPTION
## What

Adds a **"Seed park names manually"** panel to the AI park discovery tab. An admin who already knows a state's parks (e.g. from browsing Google Maps) can paste names — one per line — straight into the candidate queue, instead of relying on the AI/SerpApi search to find them.

Seeded names become `PENDING` `ParkCandidate` rows with no location/source. Those details get filled in by the existing research pipeline once a candidate is **accepted** into a Park — same downstream flow as AI-discovered candidates.

## How

- `dedupeSeedNames()` — pure, unit-tested helper: trims, drops blank lines, collapses whitespace, removes intra-batch duplicates (via the existing `normalizeParkName` key), and flags suffix-only names ("OHV Park") as invalid.
- `seedParkCandidatesByName()` — reuses the existing fuzzy-dedup against parks + candidates already in the state, then `createMany({ skipDuplicates: true })`.
- New `POST /api/admin/ai-research/discovery/seed` route (`requireAdmin`-gated), body `{ state, names: string[] }`.
- UI: textarea + state selector in `ParkDiscoveryTable`, mirroring the existing "Discover Parks" panel. Result banner reports seeded + skipped counts.

## Testing

- `npm test` — full suite green (2179 tests).
- New unit tests for `dedupeSeedNames`; new component tests for the seed flow (enabled/disabled state, POST payload, skipped-count reporting); disambiguated the existing discovery tests now that the panel has two `<select>`s.
- `tsc --noEmit` and ESLint clean.

> Note: browser verification wasn't possible in the dev environment (no local DB/`.env`, and the admin page is auth-gated). Verified via the full test suite, typecheck, and lint. The new panel is a close mirror of the existing, working discovery panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)