### PR TITLE
fix(admin-parks): search across all parks, not just the current page

### DIFF
--- a/src/app/admin/parks/page.tsx
+++ b/src/app/admin/parks/page.tsx
@@ -6,6 +6,7 @@ interface SearchParams {
   status?: string;
   highlight?: string;
   page?: string;
+  search?: string;
 }
 
 const PAGE_SIZE = 25;
@@ -25,18 +26,50 @@ export default async function AdminParksPage({
 }) {
   const params = await searchParams;
   const statusFilter = params.status || "all";
+  const searchTerm = (params.search ?? "").trim();
 
-  // Build where clause based on status filter
+  // Search runs in the DB (name / city / state) so it spans ALL parks, not just
+  // the current page. Kept separate from the status filter so the tab badges
+  // below can reflect the active search too.
+  const searchWhere: Prisma.ParkWhereInput = searchTerm
+    ? {
+        OR: [
+          { name: { contains: searchTerm, mode: "insensitive" } },
+          {
+            address: {
+              is: { city: { contains: searchTerm, mode: "insensitive" } },
+            },
+          },
+          {
+            address: {
+              is: { state: { contains: searchTerm, mode: "insensitive" } },
+            },
+          },
+        ],
+      }
+    : {};
+
+  // Combine the status and search filters, keeping the clause minimal: `{}`
+  // when unfiltered, a bare status/search clause when only one is active, and
+  // an AND only when both apply.
+  const conditions: Prisma.ParkWhereInput[] = [];
+  if (statusFilter !== "all") {
+    conditions.push({
+      status: statusFilter.toUpperCase() as
+        | "PENDING"
+        | "APPROVED"
+        | "REJECTED"
+        | "DRAFT",
+    });
+  }
+  if (searchTerm) conditions.push(searchWhere);
+
   const whereClause: Prisma.ParkWhereInput =
-    statusFilter === "all"
+    conditions.length === 0
       ? {}
-      : {
-          status: statusFilter.toUpperCase() as
-            | "PENDING"
-            | "APPROVED"
-            | "REJECTED"
-            | "DRAFT",
-        };
+      : conditions.length === 1
+        ? conditions[0]
+        : { AND: conditions };
 
   // Total count for the current filter, used to compute pagination bounds.
   const totalCount = await prisma.park.count({ where: whereClause });
@@ -53,6 +86,7 @@ export default async function AdminParksPage({
   // on the current page.
   const statusCounts = await prisma.park.groupBy({
     by: ["status"],
+    where: searchWhere,
     _count: { _all: true },
   });
   const countsByStatus = new Map<ParkStatus, number>(
@@ -94,6 +128,7 @@ export default async function AdminParksPage({
   const buildHref = (overrides: Record<string, string | undefined>) => {
     const query = new URLSearchParams();
     if (statusFilter !== "all") query.set("status", statusFilter);
+    if (searchTerm) query.set("search", searchTerm);
     for (const [key, value] of Object.entries(overrides)) {
       if (value === undefined) {
         query.delete(key);
@@ -147,7 +182,12 @@ export default async function AdminParksPage({
       </div>
 
       {/* Parks Table */}
-      <ParkManagementTable parks={parks} highlightId={params.highlight} />
+      <ParkManagementTable
+        parks={parks}
+        highlightId={params.highlight}
+        statusFilter={statusFilter}
+        initialSearch={searchTerm}
+      />
 
       {/* Pagination Controls */}
       {totalCount > 0 && (

--- a/src/components/admin/ParkManagementTable.tsx
+++ b/src/components/admin/ParkManagementTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Camera, CheckCircle, Edit, MapPin, Trash2, XCircle } from "lucide-react";
 
 type ParkStatus = "PENDING" | "APPROVED" | "REJECTED" | "DRAFT";
@@ -29,18 +30,36 @@ interface Park {
 interface Props {
   parks: Park[];
   highlightId?: string;
+  statusFilter?: string;
+  initialSearch?: string;
 }
 
-export function ParkManagementTable({ parks, highlightId }: Props) {
+export function ParkManagementTable({
+  parks,
+  highlightId,
+  statusFilter = "all",
+  initialSearch = "",
+}: Props) {
+  const router = useRouter();
   const [processingId, setProcessingId] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState(initialSearch);
 
-  const filteredParks = parks.filter(
-    (p) =>
-      p.name.toLowerCase().includes(search.toLowerCase()) ||
-      (p.address?.city ?? "").toLowerCase().includes(search.toLowerCase()) ||
-      (p.address?.state ?? "").toLowerCase().includes(search.toLowerCase()),
-  );
+  // Search runs server-side so it spans every park, not just this page. Push the
+  // term into the URL (debounced) and let the server component re-query; reset
+  // to page 1 on every new search.
+  useEffect(() => {
+    if (search === initialSearch) return;
+    const handle = setTimeout(() => {
+      const query = new URLSearchParams();
+      if (statusFilter && statusFilter !== "all") {
+        query.set("status", statusFilter);
+      }
+      if (search.trim()) query.set("search", search.trim());
+      const qs = query.toString();
+      router.push(qs ? `/admin/parks?${qs}` : "/admin/parks");
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [search, initialSearch, statusFilter, router]);
 
   const handleApprove = async (parkId: string) => {
     setProcessingId(parkId);
@@ -140,14 +159,16 @@ export function ParkManagementTable({ parks, highlightId }: Props) {
           className="w-full max-w-sm px-4 py-2 border border-input bg-background text-foreground rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
         />
       </div>
-      {filteredParks.length === 0 ? (
+      {parks.length === 0 ? (
         <div className="p-12 text-center">
           <MapPin className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">
             No parks found
           </h3>
           <p className="text-muted-foreground">
-            No parks match the current filter criteria.
+            {search.trim()
+              ? `No parks match "${search.trim()}".`
+              : "No parks match the current filter criteria."}
           </p>
         </div>
       ) : (
@@ -176,7 +197,7 @@ export function ParkManagementTable({ parks, highlightId }: Props) {
             </tr>
           </thead>
           <tbody className="bg-card divide-y divide-border">
-            {filteredParks.map((park) => (
+            {parks.map((park) => (
               <tr
                 key={park.id}
                 className={`hover:bg-accent/50 transition-colors ${

--- a/test/app/admin/parks/page.test.tsx
+++ b/test/app/admin/parks/page.test.tsx
@@ -269,6 +269,76 @@ describe("AdminParksPage", () => {
     );
   });
 
+  describe("search", () => {
+    it("builds a DB-side OR clause across name/city/state", async () => {
+      vi.mocked(prisma.park.findMany).mockResolvedValue([]);
+
+      await AdminParksPage({
+        searchParams: Promise.resolve({ search: "dunes" }),
+      });
+
+      expect(prisma.park.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: [
+              { name: { contains: "dunes", mode: "insensitive" } },
+              {
+                address: {
+                  is: { city: { contains: "dunes", mode: "insensitive" } },
+                },
+              },
+              {
+                address: {
+                  is: { state: { contains: "dunes", mode: "insensitive" } },
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    it("ANDs the status filter with the search clause when both are present", async () => {
+      vi.mocked(prisma.park.findMany).mockResolvedValue([]);
+
+      await AdminParksPage({
+        searchParams: Promise.resolve({ status: "approved", search: "dunes" }),
+      });
+
+      const call = vi.mocked(prisma.park.findMany).mock.calls[0][0] as any;
+      expect(call.where.AND).toHaveLength(2);
+      expect(call.where.AND[0]).toEqual({ status: "APPROVED" });
+      expect(call.where.AND[1].OR).toHaveLength(3);
+    });
+
+    it("trims whitespace and treats a blank search as no filter", async () => {
+      vi.mocked(prisma.park.findMany).mockResolvedValue([]);
+
+      await AdminParksPage({
+        searchParams: Promise.resolve({ search: "   " }),
+      });
+
+      expect(prisma.park.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      );
+    });
+
+    it("preserves the search term in pagination links", async () => {
+      vi.mocked(prisma.park.count).mockResolvedValue(75);
+      vi.mocked(prisma.park.findMany).mockResolvedValue(mockParks as any);
+
+      const component = await AdminParksPage({
+        searchParams: Promise.resolve({ search: "dunes", page: "2" }),
+      });
+      render(component);
+
+      expect(screen.getByRole("link", { name: "Next" })).toHaveAttribute(
+        "href",
+        "/admin/parks?search=dunes&page=3",
+      );
+    });
+  });
+
   describe("pagination", () => {
     it("should request the correct skip/take for a given page", async () => {
       vi.mocked(prisma.park.count).mockResolvedValue(60);

--- a/test/components/admin/ParkManagementTable.test.tsx
+++ b/test/components/admin/ParkManagementTable.test.tsx
@@ -3,6 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { ParkManagementTable } from "@/components/admin/ParkManagementTable";
 import { vi } from "vitest";
 
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 describe("ParkManagementTable", () => {
   const mockParks = [
     {
@@ -102,7 +107,7 @@ describe("ParkManagementTable", () => {
     ).toBeInTheDocument();
   });
 
-  it("should still show search bar when no results match", async () => {
+  it("pushes a server-side search query to the URL when typing", async () => {
     const user = userEvent.setup();
 
     render(<ParkManagementTable parks={mockParks} />);
@@ -111,10 +116,32 @@ describe("ParkManagementTable", () => {
       "Search by name, city, or state...",
     );
     await user.type(searchInput, "zzznomatch");
-
-    expect(screen.getByText("No parks found")).toBeInTheDocument();
-    expect(searchInput).toBeInTheDocument();
     expect(searchInput).toHaveValue("zzznomatch");
+
+    // Search is server-driven now — typing debounces a navigation rather than
+    // filtering the current page's rows in place.
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/admin/parks?search=zzznomatch");
+    });
+  });
+
+  it("preserves the active status filter in the search URL", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ParkManagementTable parks={mockParks} statusFilter="pending" />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("Search by name, city, or state..."),
+      "dunes",
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        "/admin/parks?status=pending&search=dunes",
+      );
+    });
   });
 
   it("should render table headers", () => {


### PR DESCRIPTION
## Problem

Admin park search (Park Management tab) filtered **client-side over only the 25 rows on the current page**. Pagination is done server-side (`skip`/`take`), so a park on any other page was invisible while searching — the search box could only ever match the current page.

## Fix

Move search into the database query so it spans every park.

- **[page.tsx](src/app/admin/parks/page.tsx)** — reads a new `search` param, folds it into the `where` clause across `name` / `address.city` / `address.state` (`contains`, case-insensitive). Kept minimal: `{}` when unfiltered, a bare status/search clause when one filter is active, `AND` only when both apply. Applies the search to the tab badge counts too, and preserves the term across pagination/tab links.
- **[ParkManagementTable.tsx](src/components/admin/ParkManagementTable.tsx)** — the search input now debounces a push of the term into the URL (server re-queries); removed the client-side `filteredParks` filter; empty state names the search term.

Because filtering happens in the DB, `totalCount`, the page count, and the "Showing X–Y of Z" summary are all correct for the full result set.

## Testing

- `npm test` — full suite green (2187 tests).
- Component tests: mock `next/navigation`; assert the debounced search navigation and status-filter preservation.
- Page tests: OR clause across name/city/state, status+search AND composition, blank/whitespace search = no filter, and search-term preservation in pagination links.
- `tsc --noEmit` + ESLint clean.

> Browser verification wasn't possible in-env (auth-gated admin page, no local DB); verified via tests + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)