### PR TITLE
feat(ai-research): sharpen extraction quality before review

### DIFF
--- a/src/lib/ai/extraction-validator.ts
+++ b/src/lib/ai/extraction-validator.ts
@@ -5,16 +5,26 @@ export type ValidationResult = {
   reason?: string;
 };
 
-const PRICE_FIELDS = new Set([
+export const PRICE_FIELDS = new Set([
   "dayPassUSD",
   "vehicleEntryFeeUSD",
   "riderFeeUSD",
   "membershipFeeUSD",
 ]);
 
-const PHONE_FIELDS = new Set(["phone", "campingPhone"]);
+export const PHONE_FIELDS = new Set(["phone", "campingPhone"]);
 
-const URL_FIELDS = new Set(["website", "campingWebsite"]);
+export const URL_FIELDS = new Set(["website", "campingWebsite"]);
+
+// Quantity fields where a value of 0 (or negative) is meaningless — a park with
+// "0 miles of trails" or "0 acres" is a bad extraction, not a real data point.
+// These get dropped rather than queued for review.
+export const POSITIVE_QUANTITY_FIELDS = new Set([
+  "milesOfTrails",
+  "acres",
+  "maxVehicleWidthInches",
+  "noiseLimitDBA",
+]);
 
 /**
  * Validate a single extracted field value.
@@ -105,6 +115,20 @@ export function validateExtraction(
     return { valid: true };
   }
 
+  // --- Positive-quantity fields (trail miles, acres, width, noise limit) ---
+  if (POSITIVE_QUANTITY_FIELDS.has(fieldName)) {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      return { valid: false, reason: `${fieldName} must be a number` };
+    }
+    if (value <= 0) {
+      return {
+        valid: false,
+        reason: `${fieldName} ${value} must be greater than 0`,
+      };
+    }
+    return { valid: true };
+  }
+
   // --- Email ---
   if (fieldName === "contactEmail") {
     if (typeof value !== "string") {
@@ -120,4 +144,33 @@ export function validateExtraction(
 
   // --- All other fields: no additional validation ---
   return { valid: true };
+}
+
+/**
+ * Strip an accidental city/state/zip tail from a street address so the stored
+ * `streetAddress` is just the street line. The LLM sometimes returns a full
+ * one-line address (e.g. "123 Main St, Boise, ID 83702") into `streetAddress`,
+ * duplicating the separately-extracted city/zip fields.
+ *
+ * Only strips when the trailing comma-segment clearly looks like city/state/zip,
+ * so legitimate street commas ("123 Main St, Suite 4") are left intact.
+ */
+export function cleanStreetAddress(raw: string): string {
+  const trimmed = raw.trim();
+  const parts = trimmed
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length < 2) return trimmed;
+
+  const last = parts[parts.length - 1];
+  // Trailing segment ending in a ZIP ("Boise, ID 83702", "Moab 84532", "83702")
+  // or a bare 2-letter state abbreviation ("…, Boise, ID") is a location tail.
+  const endsWithZip = /\b\d{5}(-\d{4})?$/.test(last);
+  const isTrailingState = parts.length >= 3 && /^[A-Za-z]{2}\.?$/.test(last);
+
+  if (endsWithZip || isTrailingState) {
+    return parts[0];
+  }
+  return trimmed;
 }

--- a/src/lib/ai/park-data-extractor.ts
+++ b/src/lib/ai/park-data-extractor.ts
@@ -37,6 +37,8 @@ Rules:
 - For pricing, extract the most common/standard adult rate. If seasonal pricing exists, use the peak season price.
 - For terrain, map descriptions: "sandy" = "sand", "rocky" = "rocks", "wooded trails" or "forest trails" = "trails", "hilly" or "mountain" = "hills", "muddy" or "clay" = "mud"
 - For amenities, only include amenities explicitly mentioned. "Full facilities" is too vague to map.
+- For the address, keep the fields separate: streetAddress is the street line ONLY (number + street, e.g. "123 Main St"). Do NOT include the city, state, or ZIP in streetAddress — put those in the city and zipCode fields.
+- Omit numeric quantities (milesOfTrails, acres, maxVehicleWidthInches, noiseLimitDBA) when the source says none or zero — only include a positive number actually stated in the source.
 - Confidence scoring:
   - 0.9-1.0: Explicitly and unambiguously stated (e.g., "Day pass: $25")
   - 0.7-0.89: Clearly implied with minor interpretation (e.g., "Fees: Adults $25" → dayPassUSD=25)

--- a/src/lib/ai/research-pipeline.ts
+++ b/src/lib/ai/research-pipeline.ts
@@ -16,7 +16,12 @@ import {
 } from "./research-lifecycle";
 import { isAllowedByRobots, clearRobotsCache } from "./robots";
 import { getDefaultReliabilityForSource } from "./domain-reliability";
-import { discoverSources } from "./source-discovery";
+import { discoverSources, normalizeUrl } from "./source-discovery";
+import {
+  PHONE_FIELDS,
+  URL_FIELDS,
+  cleanStreetAddress,
+} from "./extraction-validator";
 
 /**
  * Run the full AI research pipeline for a single park.
@@ -283,11 +288,19 @@ export async function researchPark(
               valuesMatch = false;
             }
           } else {
-            extractedValueJson = JSON.stringify(fieldData.value);
+            // Strip an accidental city/state/zip tail from the street line so
+            // the stored value is just the street address (item b).
+            const scalarValue =
+              fieldName === "address.streetAddress" &&
+              typeof fieldData.value === "string"
+                ? cleanStreetAddress(fieldData.value)
+                : fieldData.value;
+
+            extractedValueJson = JSON.stringify(scalarValue);
             valuesMatch =
               currentValueJson !== null &&
-              normalizeForComparison(extractedValueJson) ===
-                normalizeForComparison(currentValueJson);
+              normalizeForComparison(extractedValueJson, fieldName) ===
+                normalizeForComparison(currentValueJson, fieldName);
           }
 
           // For pending array extractions, deduplicate: skip if an identical
@@ -302,8 +315,8 @@ export async function researchPark(
             });
             if (
               existing?.extractedValue &&
-              normalizeForComparison(existing.extractedValue) ===
-                normalizeForComparison(extractedValueJson)
+              normalizeForComparison(existing.extractedValue, fieldName) ===
+                normalizeForComparison(extractedValueJson, fieldName)
             ) {
               // Duplicate suggestion — skip
               fieldsFoundInSources.set(
@@ -445,22 +458,62 @@ export async function researchPark(
 }
 
 /**
- * Normalize a JSON-encoded value for comparison.
- * Sorts arrays so ["rocks","sand"] matches ["sand","rocks"].
- * Trims and lowercases strings so "5551234567" matches "5551234567".
+ * Normalize a JSON-encoded value for comparison so that a value which merely
+ * *looks* different from the current one isn't queued for review. Comparison is
+ * field-type-aware when `fieldName` is supplied:
+ *  - arrays: order-insensitive (["rocks","sand"] === ["sand","rocks"])
+ *  - phone: digits only ("(555) 123-4567" === "5551234567")
+ *  - url: scheme/www/trailing-slash/tracking-param insensitive
+ *  - numeric fields: 25 === 25.0, and "$25" === 25
+ *  - other strings: trimmed, lowercased, whitespace-collapsed
  */
-function normalizeForComparison(jsonStr: string): string {
+export function normalizeForComparison(
+  jsonStr: string,
+  fieldName?: string
+): string {
   try {
     const val = JSON.parse(jsonStr);
+
     if (Array.isArray(val)) {
       return JSON.stringify([...val].sort());
     }
-    if (typeof val === "string") {
-      return JSON.stringify(val.trim().toLowerCase());
+
+    // JSON.parse already collapses numeric formatting (25 vs 25.0 → 25).
+    if (typeof val === "number") {
+      return JSON.stringify(val);
     }
+
+    if (typeof val === "string") {
+      if (fieldName && PHONE_FIELDS.has(fieldName)) {
+        return JSON.stringify(val.replace(/\D/g, ""));
+      }
+      if (fieldName && URL_FIELDS.has(fieldName)) {
+        return JSON.stringify(normalizeUrlForComparison(val));
+      }
+      // A numeric-typed field that arrived as a string ("$25", "25 mi").
+      if (fieldName && EXTRACTABLE_FIELDS[fieldName] === "number") {
+        const numeric = Number(val.replace(/[^0-9.-]/g, ""));
+        if (val.trim() !== "" && !Number.isNaN(numeric)) {
+          return JSON.stringify(numeric);
+        }
+      }
+      return JSON.stringify(val.trim().toLowerCase().replace(/\s+/g, " "));
+    }
+
     return JSON.stringify(val);
   } catch {
     return jsonStr;
+  }
+}
+
+/** URL comparison key: ignore scheme, www, trailing slash, tracking params, case. */
+function normalizeUrlForComparison(url: string): string {
+  try {
+    return normalizeUrl(url)
+      .replace(/^https?:\/\//i, "")
+      .toLowerCase();
+  } catch {
+    return url.trim().toLowerCase();
   }
 }
 

--- a/test/lib/ai/extraction-validator.test.ts
+++ b/test/lib/ai/extraction-validator.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { validateExtraction } from "@/lib/ai/extraction-validator";
+import {
+  validateExtraction,
+  cleanStreetAddress,
+} from "@/lib/ai/extraction-validator";
 
 describe("validateExtraction", () => {
   // ---- Latitude ----
@@ -317,5 +320,70 @@ describe("validateExtraction", () => {
       const result = validateExtraction("dayPassUSD", 500.01, null);
       expect(result.valid).toBe(false);
     });
+  });
+
+  // ---- Positive-quantity fields (item c) ----
+  describe("positive-quantity fields", () => {
+    const fields = [
+      "milesOfTrails",
+      "acres",
+      "maxVehicleWidthInches",
+      "noiseLimitDBA",
+    ];
+
+    for (const field of fields) {
+      it(`accepts a positive ${field}`, () => {
+        expect(validateExtraction(field, 42, null)).toEqual({ valid: true });
+      });
+
+      it(`rejects ${field} of 0`, () => {
+        const result = validateExtraction(field, 0, null);
+        expect(result.valid).toBe(false);
+        expect(result.reason).toContain("greater than 0");
+      });
+
+      it(`rejects negative ${field}`, () => {
+        expect(validateExtraction(field, -5, null).valid).toBe(false);
+      });
+
+      it(`rejects non-numeric ${field}`, () => {
+        expect(validateExtraction(field, "lots", null).valid).toBe(false);
+      });
+    }
+  });
+});
+
+// ---- Street address cleaning (item b) ----
+describe("cleanStreetAddress", () => {
+  it("strips a trailing city, state, and zip", () => {
+    expect(cleanStreetAddress("123 Main St, Boise, ID 83702")).toBe(
+      "123 Main St"
+    );
+  });
+
+  it("strips a trailing city + zip without state", () => {
+    expect(cleanStreetAddress("456 Elk Rd, Moab 84532")).toBe("456 Elk Rd");
+  });
+
+  it("strips a trailing state abbreviation", () => {
+    expect(cleanStreetAddress("789 Dune Way, Glamis, CA")).toBe("789 Dune Way");
+  });
+
+  it("strips a bare trailing zip segment", () => {
+    expect(cleanStreetAddress("12 Trailhead Ln, 55901")).toBe("12 Trailhead Ln");
+  });
+
+  it("leaves a legitimate street comma intact", () => {
+    expect(cleanStreetAddress("123 Main St, Suite 4")).toBe(
+      "123 Main St, Suite 4"
+    );
+  });
+
+  it("leaves a plain street line untouched", () => {
+    expect(cleanStreetAddress("100 Ridge Road")).toBe("100 Ridge Road");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(cleanStreetAddress("  100 Ridge Road  ")).toBe("100 Ridge Road");
   });
 });

--- a/test/lib/ai/normalize-comparison.test.ts
+++ b/test/lib/ai/normalize-comparison.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { normalizeForComparison } from "@/lib/ai/research-pipeline";
+
+// A pair "matches" (extraction is treated as a duplicate of the current value)
+// when their normalized forms are equal.
+const matches = (a: string, b: string, field?: string) =>
+  normalizeForComparison(a, field) === normalizeForComparison(b, field);
+
+describe("normalizeForComparison", () => {
+  describe("numbers", () => {
+    it("treats 25 and 25.0 as equal", () => {
+      expect(matches("25", "25.0")).toBe(true);
+    });
+
+    it("treats a numeric-typed string like \"$25\" as equal to 25", () => {
+      expect(matches('"$25"', "25", "dayPassUSD")).toBe(true);
+    });
+
+    it("does not equate different numbers", () => {
+      expect(matches("25", "30")).toBe(false);
+    });
+  });
+
+  describe("phone fields", () => {
+    it("ignores formatting differences", () => {
+      expect(matches('"(555) 123-4567"', '"5551234567"', "phone")).toBe(true);
+    });
+
+    it("respects digit differences", () => {
+      expect(matches('"5551234567"', '"5559999999"', "phone")).toBe(false);
+    });
+
+    it("does not digit-normalize a non-phone string field", () => {
+      // Without the phone field hint, punctuation is preserved.
+      expect(matches('"(555) 123-4567"', '"5551234567"')).toBe(false);
+    });
+  });
+
+  describe("url fields", () => {
+    it("ignores scheme, www, and trailing slash", () => {
+      expect(
+        matches('"http://www.example.com/"', '"https://example.com"', "website")
+      ).toBe(true);
+    });
+
+    it("ignores tracking params", () => {
+      expect(
+        matches(
+          '"https://example.com/park?utm_source=x"',
+          '"https://example.com/park"',
+          "website"
+        )
+      ).toBe(true);
+    });
+
+    it("respects genuinely different URLs", () => {
+      expect(
+        matches('"https://example.com/a"', '"https://example.com/b"', "website")
+      ).toBe(false);
+    });
+  });
+
+  describe("strings", () => {
+    it("is case- and whitespace-insensitive", () => {
+      expect(matches('"Open  Year-Round"', '"open year-round"')).toBe(true);
+    });
+  });
+
+  describe("arrays", () => {
+    it("is order-insensitive", () => {
+      expect(matches('["rocks","sand"]', '["sand","rocks"]', "terrain")).toBe(
+        true
+      );
+    });
+  });
+});


### PR DESCRIPTION
Workstream A of the AI research engine refactor — cut three recurring sources of review-queue noise so the admin approves less junk. No schema changes.

## (a) Same value, different format no longer queues for review
[`normalizeForComparison`](src/lib/ai/research-pipeline.ts) is now **field-type-aware** (via the `EXTRACTABLE_FIELDS` type map). When an extracted value only *looks* different from the current one, it auto-confirms instead of asking you:
- **phone** → digits only (`(555) 123-4567` == `5551234567`)
- **url** → ignores scheme, `www`, trailing slash, tracking params
- **numeric** → `25` == `25.0`, and `"$25"` == `25`
- **strings** → trimmed, lowercased, whitespace-collapsed

## (b) Street addresses that bundle city/state/zip are split
`cleanStreetAddress` strips a trailing `", City, ST 12345"` / `", City 12345"` / `", ST"` tail so the stored `streetAddress` is just the street line, while leaving legitimate street commas (`"123 Main St, Suite 4"`) intact. The [extractor prompt](src/lib/ai/park-data-extractor.ts) now also tells the model to keep the address fields separate.

## (c) Zero/negative quantities are dropped
`milesOfTrails`, `acres`, `maxVehicleWidthInches`, `noiseLimitDBA` of `0` (or less) now **fail validation** in [`extraction-validator.ts`](src/lib/ai/extraction-validator.ts) instead of becoming bogus pending reviews. Prompt reinforces omitting them.

## Testing
- New `test/lib/ai/normalize-comparison.test.ts` for the field-aware comparison.
- Extended validator tests: positive-quantity rejection + street-address cleaning.
- Full AI suite green (287); `npm test` green; `tsc` + ESLint clean.

> Browser verification n/a (server-side extraction logic; no local DB). Verified via unit tests + typecheck.

Part of the [AI research engine refactor](https://github.com/mikesassatelli/offroad-parks/pull/169). Next up: Workstream B (source-quote context + typed review selectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)