### PR TITLE
feat(ai-research): show the source quote alongside each extracted value

### DIFF
--- a/prisma/migrations/20260723000000_field_extraction_source_quote/migration.sql
+++ b/prisma/migrations/20260723000000_field_extraction_source_quote/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: nullable source snippet showing where the AI found each value.
+-- Nullable with no default, so every existing FieldExtraction row stays valid
+-- (older extractions simply have no captured quote).
+ALTER TABLE "FieldExtraction" ADD COLUMN "sourceQuote" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -739,6 +739,7 @@ model FieldExtraction {
   parkId          String
   fieldName       String
   extractedValue  String?               @db.Text
+  sourceQuote     String?               @db.Text // short snippet from the source showing where the value was found
   confidence      FieldConfidence       @default(AI_EXTRACTED)
   confidenceScore Float?
   status          FieldExtractionStatus @default(PENDING_REVIEW)

--- a/src/app/admin/ai-research/research/[parkId]/page.tsx
+++ b/src/app/admin/ai-research/research/[parkId]/page.tsx
@@ -78,6 +78,7 @@ export default async function ParkResearchWorkspacePage({
     sourcesChecked: e.sourcesChecked,
     sourceUrl: e.dataSource?.url ?? null,
     sourceTitle: e.dataSource?.title ?? null,
+    sourceQuote: e.sourceQuote,
     sessionId: e.sessionId,
     createdAt: e.createdAt.toISOString(),
   }));

--- a/src/app/admin/ai-research/review/page.tsx
+++ b/src/app/admin/ai-research/review/page.tsx
@@ -36,6 +36,7 @@ export default async function ReviewPage() {
     sourcesChecked: e.sourcesChecked,
     sourceUrl: e.dataSource?.url ?? null,
     sourceTitle: e.dataSource?.title ?? null,
+    sourceQuote: e.sourceQuote,
     sessionId: e.sessionId,
     createdAt: e.createdAt.toISOString(),
   }));

--- a/src/app/api/admin/ai-research/pending-reviews/route.ts
+++ b/src/app/api/admin/ai-research/pending-reviews/route.ts
@@ -141,6 +141,7 @@ export async function GET(request: Request) {
     sourcesChecked: e.sourcesChecked,
     sourceUrl: e.dataSource?.url ?? null,
     sourceTitle: e.dataSource?.title ?? null,
+    sourceQuote: e.sourceQuote,
     sessionId: e.sessionId,
     createdAt: e.createdAt.toISOString(),
   }));

--- a/src/components/admin/FieldExtractionReview.tsx
+++ b/src/components/admin/FieldExtractionReview.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon, Pencil, Check, X } from "lucide-react";
+import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon, Pencil, Check, X, Quote } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { FieldExtractionSummary } from "@/lib/types";
 import { FIELD_DISPLAY_NAMES } from "@/lib/ai/field-display-names";
@@ -215,6 +215,14 @@ export function FieldExtractionReview({ extractions }: Props) {
                           </Button>
                         </div>
                       </div>
+                    )}
+                    {extraction.sourceQuote && (
+                      <blockquote className="mt-3 flex gap-2 rounded-md border-l-2 border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground italic">
+                        <Quote className="w-3 h-3 flex-shrink-0 mt-0.5 opacity-60" />
+                        <span className="break-words">
+                          &ldquo;{extraction.sourceQuote}&rdquo;
+                        </span>
+                      </blockquote>
                     )}
                     {extraction.sourceUrl && (
                       <div className="mt-2">

--- a/src/lib/ai/research-pipeline.ts
+++ b/src/lib/ai/research-pipeline.ts
@@ -332,6 +332,10 @@ export async function researchPark(
               parkId,
               fieldName,
               extractedValue: extractedValueJson,
+              // Snippet from the source showing where the value came from, so an
+              // admin can verify without opening the page. The LLM returns this
+              // per field (see park-data-extractor prompt).
+              sourceQuote: fieldData.source_quote?.trim() || null,
               confidence: "AI_EXTRACTED",
               confidenceScore: fieldData.confidence,
               status: valuesMatch ? "APPROVED" : "PENDING_REVIEW",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -473,6 +473,7 @@ export type FieldExtractionSummary = {
   sourcesChecked: number;
   sourceUrl: string | null;
   sourceTitle: string | null;
+  sourceQuote: string | null;
   sessionId: string | null;
   createdAt: string;
 };

--- a/test/components/admin/FieldExtractionReview.test.tsx
+++ b/test/components/admin/FieldExtractionReview.test.tsx
@@ -24,6 +24,7 @@ const makeExtraction = (
   sourcesChecked: 2,
   sourceUrl: "https://example.com/park",
   sourceTitle: "Example source",
+  sourceQuote: "Trails are rated moderate for intermediate riders.",
   sessionId: "sess-1",
   createdAt: "2026-04-01T00:00:00Z",
   ...overrides,
@@ -89,6 +90,24 @@ describe("FieldExtractionReview", () => {
       />
     );
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders the source quote so admins can verify without opening the page", () => {
+    render(<FieldExtractionReview extractions={[makeExtraction()]} />);
+    expect(
+      screen.getByText(/Trails are rated moderate for intermediate riders\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("omits the quote block when sourceQuote is null", () => {
+    render(
+      <FieldExtractionReview
+        extractions={[makeExtraction({ sourceQuote: null })]}
+      />
+    );
+    expect(
+      screen.queryByText(/intermediate riders/i)
+    ).not.toBeInTheDocument();
   });
 
   it("formats boolean extracted values as Yes/No", () => {


### PR DESCRIPTION
Workstream B, part (e) of the AI research engine refactor.

## The gist
The LLM **already returns a `source_quote`** for every field it extracts (the snippet of source text where it found the value) — the pipeline was throwing it away. This persists it and shows it in the review UI, so you can verify a pending value without clicking through to the source and hunting for the text.

## Changes
- **Schema + migration** — `FieldExtraction.sourceQuote` (nullable `TEXT`). Nullable/no-default, so existing rows stay valid (older extractions just have no quote). Migration: `20260723000000_field_extraction_source_quote`.
- **[research-pipeline.ts](src/lib/ai/research-pipeline.ts)** — store `fieldData.source_quote` when creating each `FieldExtraction`.
- **Type threading** — `sourceQuote` added to `FieldExtractionSummary` and populated in all three builders: the [review page](src/app/admin/ai-research/review/page.tsx), the [per-park research page](src/app/admin/ai-research/research/[parkId]/page.tsx), and the [pending-reviews API](src/app/api/admin/ai-research/pending-reviews/route.ts).
- **[FieldExtractionReview.tsx](src/components/admin/FieldExtractionReview.tsx)** — renders the quote as a blockquote above the source link; hidden when absent.

## Testing
- Component tests: quote renders when present, omitted when `null`.
- `npm test` full suite green (2221); `tsc` + ESLint clean; `prisma validate` passes.

> First migration-bearing PR of the refactor. The migration is a single additive nullable column; the build's `prisma migrate deploy` applies it. Browser verification n/a in-env (auth-gated, no local DB) — verified via tests + typecheck.

Next in Workstream B: **(d)** typed review selectors + option-list consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)