### PR TITLE
feat(ai-research): typed selectors for editing extracted values

### DIFF
--- a/src/components/admin/FieldExtractionReview.tsx
+++ b/src/components/admin/FieldExtractionReview.tsx
@@ -6,6 +6,50 @@ import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon, Pencil, Check
 import { Button } from "@/components/ui/button";
 import type { FieldExtractionSummary } from "@/lib/types";
 import { FIELD_DISPLAY_NAMES } from "@/lib/ai/field-display-names";
+import {
+  ARRAY_FIELD_OPTIONS,
+  OWNERSHIP_OPTIONS,
+  EXTRACTABLE_FIELDS,
+  humanizeOption,
+} from "@/lib/ai/park-fields";
+
+type EditorKind = "array" | "ownership" | "boolean" | "number" | "string";
+
+function editorKind(fieldName: string): EditorKind {
+  if (fieldName in ARRAY_FIELD_OPTIONS) return "array";
+  const type = EXTRACTABLE_FIELDS[fieldName];
+  if (type === "Ownership") return "ownership";
+  if (type === "boolean") return "boolean";
+  if (type === "number") return "number";
+  return "string";
+}
+
+function parseArrayValue(json: string): string[] {
+  try {
+    const v = JSON.parse(json);
+    return Array.isArray(v) ? v.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseStringValue(json: string | null): string {
+  if (!json) return "";
+  try {
+    const v = JSON.parse(json);
+    return typeof v === "string" ? v : String(v);
+  } catch {
+    return json;
+  }
+}
+
+function safeParse(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return json;
+  }
+}
 
 type Props = {
   extractions: FieldExtractionSummary[];
@@ -16,7 +60,11 @@ export function FieldExtractionReview({ extractions }: Props) {
   const [processingId, setProcessingId] = useState<string | null>(null);
   const [processingBulk, setProcessingBulk] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
+  // `editValue` holds the JSON-encoded value for discrete controls
+  // (array/ownership/boolean); `editRaw` holds the raw text for free-typed
+  // scalars (number/string) so controlled inputs behave naturally.
   const [editValue, setEditValue] = useState<string>("");
+  const [editRaw, setEditRaw] = useState<string>("");
   const [editError, setEditError] = useState<string | null>(null);
 
   // Group extractions by park
@@ -82,20 +130,154 @@ export function FieldExtractionReview({ extractions }: Props) {
 
   const startEdit = (extraction: FieldExtractionSummary) => {
     setEditError(null);
-    // Prefill the editor with the human-readable form of the extracted value.
-    setEditValue(extraction.extractedValue ? formatValue(extraction.extractedValue) : "");
+    const kind = editorKind(extraction.fieldName);
+    const json = extraction.extractedValue;
+
+    if (kind === "number") {
+      const n = json ? Number(safeParse(json)) : NaN;
+      setEditRaw(Number.isNaN(n) ? "" : String(n));
+      setEditValue("");
+    } else if (kind === "string") {
+      setEditRaw(parseStringValue(json));
+      setEditValue("");
+    } else {
+      // Discrete controls read/write JSON directly.
+      const fallback =
+        kind === "array" ? "[]" : kind === "ownership" ? '"unknown"' : "false";
+      setEditValue(json ?? fallback);
+      setEditRaw("");
+    }
     setEditingId(extraction.id);
   };
 
   const saveEdit = (extraction: FieldExtractionSummary) => {
-    // Re-encode the edited text back into the JSON shape the API expects,
-    // preserving the field's underlying type (array / boolean / number / string).
-    const encoded = encodeValue(extraction.fieldName, editValue, extraction.extractedValue);
-    if (encoded === null) {
-      setEditError("Could not parse that value. For list fields use comma-separated values.");
-      return;
+    const kind = editorKind(extraction.fieldName);
+    let finalJson: string;
+
+    if (kind === "number") {
+      const n = Number(editRaw.trim());
+      if (editRaw.trim() === "" || Number.isNaN(n)) {
+        setEditError("Enter a valid number.");
+        return;
+      }
+      finalJson = JSON.stringify(n);
+    } else if (kind === "string") {
+      if (editRaw.trim() === "") {
+        setEditError("Value can't be empty.");
+        return;
+      }
+      finalJson = JSON.stringify(editRaw);
+    } else if (kind === "array") {
+      const arr = parseArrayValue(editValue);
+      if (arr.length === 0) {
+        setEditError("Select at least one option.");
+        return;
+      }
+      finalJson = JSON.stringify(arr);
+    } else {
+      // ownership / boolean — the control always yields a valid value.
+      finalJson = editValue;
     }
-    handleApprove(extraction.id, encoded);
+
+    handleApprove(extraction.id, finalJson);
+  };
+
+  const renderEditor = (extraction: FieldExtractionSummary) => {
+    const field = extraction.fieldName;
+    const kind = editorKind(field);
+
+    if (kind === "array") {
+      const options = ARRAY_FIELD_OPTIONS[field];
+      const selected = new Set(parseArrayValue(editValue));
+      return (
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((opt) => {
+            const checked = selected.has(opt);
+            return (
+              <label
+                key={opt}
+                className={`cursor-pointer select-none rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                  checked
+                    ? "border-green-300 dark:border-green-900/50 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300"
+                    : "border-input bg-background text-muted-foreground hover:bg-accent"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  className="sr-only"
+                  checked={checked}
+                  onChange={() => {
+                    const next = new Set(selected);
+                    if (next.has(opt)) next.delete(opt);
+                    else next.add(opt);
+                    setEditValue(JSON.stringify([...next]));
+                  }}
+                />
+                {humanizeOption(opt)}
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+
+    if (kind === "ownership") {
+      const current = parseStringValue(editValue);
+      return (
+        <select
+          value={current}
+          onChange={(e) => setEditValue(JSON.stringify(e.target.value))}
+          className="w-full max-w-xs rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm focus:border-ring focus:ring-1 focus:ring-ring"
+        >
+          {OWNERSHIP_OPTIONS.map((o) => (
+            <option key={o} value={o}>
+              {humanizeOption(o)}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    if (kind === "boolean") {
+      const current = (() => {
+        try {
+          return JSON.parse(editValue) === true;
+        } catch {
+          return false;
+        }
+      })();
+      return (
+        <select
+          value={current ? "true" : "false"}
+          onChange={(e) => setEditValue(JSON.stringify(e.target.value === "true"))}
+          className="w-full max-w-[8rem] rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm focus:border-ring focus:ring-1 focus:ring-ring"
+        >
+          <option value="true">Yes</option>
+          <option value="false">No</option>
+        </select>
+      );
+    }
+
+    if (kind === "number") {
+      return (
+        <input
+          type="number"
+          value={editRaw}
+          onChange={(e) => setEditRaw(e.target.value)}
+          className="w-full max-w-[12rem] rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm font-mono focus:border-ring focus:ring-1 focus:ring-ring"
+        />
+      );
+    }
+
+    // string / address
+    return (
+      <textarea
+        value={editRaw}
+        onChange={(e) => setEditRaw(e.target.value)}
+        rows={1}
+        className="w-full rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm font-mono focus:border-ring focus:ring-1 focus:ring-ring"
+      />
+    );
   };
 
   const handleReject = async (id: string) => {
@@ -176,17 +358,12 @@ export function FieldExtractionReview({ extractions }: Props) {
                     </div>
                     {editingId === extraction.id && (
                       <div className="mt-3 rounded-md border border-border bg-muted/40 p-3">
-                        <label className="block text-xs text-muted-foreground mb-1">
+                        <label className="block text-xs text-muted-foreground mb-1.5">
                           {isArrayField(extraction.fieldName)
-                            ? "Edit values (comma-separated), then approve"
+                            ? "Select values to add, then approve"
                             : "Edit value, then approve"}
                         </label>
-                        <textarea
-                          value={editValue}
-                          onChange={(e) => setEditValue(e.target.value)}
-                          rows={isArrayField(extraction.fieldName) ? 2 : 1}
-                          className="w-full rounded-md border border-input bg-background text-foreground px-2 py-1 text-sm font-mono focus:border-ring focus:ring-1 focus:ring-ring"
-                        />
+                        {renderEditor(extraction)}
                         {editError && (
                           <p className="mt-1 text-xs text-red-600 dark:text-red-400">{editError}</p>
                         )}
@@ -313,52 +490,4 @@ function formatValue(jsonStr: string): string {
   } catch {
     return jsonStr;
   }
-}
-
-/**
- * Re-encode admin-edited display text back into the JSON shape the approve API
- * expects, inferring the target type from the field and the original value.
- * Returns null if the input can't be coerced sensibly.
- */
-function encodeValue(
-  fieldName: string,
-  text: string,
-  originalJson: string | null
-): string | null {
-  const trimmed = text.trim();
-
-  if (isArrayField(fieldName)) {
-    const items = trimmed
-      .split(",")
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
-    return JSON.stringify(items);
-  }
-
-  // Infer scalar type from the original extracted value when available.
-  let originalType: "boolean" | "number" | "string" = "string";
-  if (originalJson) {
-    try {
-      const parsed = JSON.parse(originalJson);
-      if (typeof parsed === "boolean") originalType = "boolean";
-      else if (typeof parsed === "number") originalType = "number";
-    } catch {
-      // fall back to string
-    }
-  }
-
-  if (originalType === "boolean") {
-    const lower = trimmed.toLowerCase();
-    if (["yes", "true", "1"].includes(lower)) return JSON.stringify(true);
-    if (["no", "false", "0"].includes(lower)) return JSON.stringify(false);
-    return null;
-  }
-
-  if (originalType === "number") {
-    const num = Number(trimmed);
-    if (Number.isNaN(num)) return null;
-    return JSON.stringify(num);
-  }
-
-  return JSON.stringify(trimmed);
 }

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -26,45 +26,9 @@ export const MIN_SOURCES_FOR_NOT_FOUND = 3;
 /** Max sources to process per research session. */
 export const MAX_SOURCES_PER_SESSION = 5;
 
-/**
- * Park fields that the AI can extract. Maps field name to its value type
- * for display in the admin review UI.
- */
-export const EXTRACTABLE_FIELDS: Record<string, string> = {
-  latitude: "number",
-  longitude: "number",
-  website: "string",
-  phone: "string",
-  campingWebsite: "string",
-  campingPhone: "string",
-  isFree: "boolean",
-  dayPassUSD: "number",
-  vehicleEntryFeeUSD: "number",
-  riderFeeUSD: "number",
-  membershipFeeUSD: "number",
-  milesOfTrails: "number",
-  acres: "number",
-  notes: "string",
-  datesOpen: "string",
-  contactEmail: "string",
-  ownership: "Ownership",
-  permitRequired: "boolean",
-  permitType: "string",
-  membershipRequired: "boolean",
-  maxVehicleWidthInches: "number",
-  flagsRequired: "boolean",
-  sparkArrestorRequired: "boolean",
-  helmetsRequired: "boolean",
-  noiseLimitDBA: "number",
-  "address.streetAddress": "string",
-  "address.city": "string",
-  "address.zipCode": "string",
-  "address.county": "string",
-  terrain: "Terrain[]",
-  amenities: "Amenity[]",
-  camping: "Camping[]",
-  vehicleTypes: "VehicleType[]",
-};
+// EXTRACTABLE_FIELDS now lives in the side-effect-free park-fields module (so it
+// can be shared with client components). Re-exported here for existing importers.
+export { EXTRACTABLE_FIELDS } from "./park-fields";
 
 export function estimateCost(
   inputTokens: number,

--- a/src/lib/ai/park-fields.ts
+++ b/src/lib/ai/park-fields.ts
@@ -1,0 +1,140 @@
+/**
+ * Single source of truth (TypeScript side) for the park enum option lists and
+ * the extractable-field type map. These MUST stay in sync with the Prisma enums
+ * in prisma/schema.prisma (Terrain, Amenity, Camping, VehicleType, Ownership) —
+ * Prisma enums can't be imported into TS, so this file mirrors them and is the
+ * one place the Zod extraction schema, the admin review selectors, and field
+ * validation all read from.
+ *
+ * This module is intentionally side-effect free (no SDK/client imports) so it is
+ * safe to import into client components.
+ */
+
+export const TERRAIN_OPTIONS = [
+  "sand",
+  "rocks",
+  "mud",
+  "trails",
+  "hills",
+  "motocrossTrack",
+] as const;
+
+export const AMENITY_OPTIONS = [
+  "restrooms",
+  "showers",
+  "food",
+  "fuel",
+  "repair",
+  "boatRamp",
+  "loadingRamp",
+  "picnicTable",
+  "shelter",
+  "grill",
+  "playground",
+  "wifi",
+  "fishing",
+  "airStation",
+  "trailMaps",
+  "rentals",
+  "training",
+  "firstAid",
+  "store",
+] as const;
+
+export const CAMPING_OPTIONS = [
+  "tent",
+  "rv30A",
+  "rv50A",
+  "fullHookup",
+  "cabin",
+  "groupSite",
+  "backcountry",
+] as const;
+
+export const VEHICLE_TYPE_OPTIONS = [
+  "motorcycle",
+  "atv",
+  "sxs",
+  "fullSize",
+] as const;
+
+export const OWNERSHIP_OPTIONS = [
+  "private",
+  "public",
+  "mixed",
+  "unknown",
+] as const;
+
+/** Array (many-to-many) fields → their valid enum option list. */
+export const ARRAY_FIELD_OPTIONS: Record<string, readonly string[]> = {
+  terrain: TERRAIN_OPTIONS,
+  amenities: AMENITY_OPTIONS,
+  camping: CAMPING_OPTIONS,
+  vehicleTypes: VEHICLE_TYPE_OPTIONS,
+};
+
+/**
+ * Park fields the AI can extract, mapped to their value type. Used by the review
+ * UI (to pick the right editor), the research pipeline (comparison), and the
+ * lifecycle helpers (which fields still need research).
+ */
+export const EXTRACTABLE_FIELDS: Record<string, string> = {
+  latitude: "number",
+  longitude: "number",
+  website: "string",
+  phone: "string",
+  campingWebsite: "string",
+  campingPhone: "string",
+  isFree: "boolean",
+  dayPassUSD: "number",
+  vehicleEntryFeeUSD: "number",
+  riderFeeUSD: "number",
+  membershipFeeUSD: "number",
+  milesOfTrails: "number",
+  acres: "number",
+  notes: "string",
+  datesOpen: "string",
+  contactEmail: "string",
+  ownership: "Ownership",
+  permitRequired: "boolean",
+  permitType: "string",
+  membershipRequired: "boolean",
+  maxVehicleWidthInches: "number",
+  flagsRequired: "boolean",
+  sparkArrestorRequired: "boolean",
+  helmetsRequired: "boolean",
+  noiseLimitDBA: "number",
+  "address.streetAddress": "string",
+  "address.city": "string",
+  "address.zipCode": "string",
+  "address.county": "string",
+  terrain: "Terrain[]",
+  amenities: "Amenity[]",
+  camping: "Camping[]",
+  vehicleTypes: "VehicleType[]",
+};
+
+/** Human-readable label for an enum option value shown in the review selectors. */
+const OPTION_LABEL_OVERRIDES: Record<string, string> = {
+  atv: "ATV",
+  sxs: "Side-by-side (SxS)",
+  fullSize: "Full-size 4x4",
+  rv30A: "RV 30A",
+  rv50A: "RV 50A",
+  fullHookup: "Full hookup",
+  groupSite: "Group site",
+  motocrossTrack: "Motocross track",
+  boatRamp: "Boat ramp",
+  loadingRamp: "Loading ramp",
+  picnicTable: "Picnic table",
+  airStation: "Air station",
+  trailMaps: "Trail maps",
+  firstAid: "First aid",
+  wifi: "Wi-Fi",
+};
+
+export function humanizeOption(value: string): string {
+  if (OPTION_LABEL_OVERRIDES[value]) return OPTION_LABEL_OVERRIDES[value];
+  const spaced = value.replace(/([a-z])([A-Z])/g, "$1 $2");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import {
+  TERRAIN_OPTIONS,
+  AMENITY_OPTIONS,
+  CAMPING_OPTIONS,
+  VEHICLE_TYPE_OPTIONS,
+  OWNERSHIP_OPTIONS,
+} from "./park-fields";
 
 /** Schema for a single extracted field with confidence metadata. */
 function field<T extends z.ZodTypeAny>(valueSchema: T) {
@@ -42,9 +49,7 @@ export const parkExtractionSchema = z.object({
 
   // Operational
   datesOpen: field(z.string()),
-  ownership: field(
-    z.enum(["private", "public", "mixed", "unknown"])
-  ),
+  ownership: field(z.enum(OWNERSHIP_OPTIONS)),
   permitRequired: field(z.boolean()),
   permitType: field(z.string()),
   membershipRequired: field(z.boolean()),
@@ -61,52 +66,10 @@ export const parkExtractionSchema = z.object({
   county: field(z.string()),
 
   // Categorical (arrays)
-  terrain: field(
-    z.array(
-      z.enum(["sand", "rocks", "mud", "trails", "hills", "motocrossTrack"])
-    )
-  ),
-  amenities: field(
-    z.array(
-      z.enum([
-        "restrooms",
-        "showers",
-        "food",
-        "fuel",
-        "repair",
-        "boatRamp",
-        "loadingRamp",
-        "picnicTable",
-        "shelter",
-        "grill",
-        "playground",
-        "wifi",
-        "fishing",
-        "airStation",
-        "trailMaps",
-        "rentals",
-        "training",
-        "firstAid",
-        "store",
-      ])
-    )
-  ),
-  camping: field(
-    z.array(
-      z.enum([
-        "tent",
-        "rv30A",
-        "rv50A",
-        "fullHookup",
-        "cabin",
-        "groupSite",
-        "backcountry",
-      ])
-    )
-  ),
-  vehicleTypes: field(
-    z.array(z.enum(["motorcycle", "atv", "sxs", "fullSize"]))
-  ),
+  terrain: field(z.array(z.enum(TERRAIN_OPTIONS))),
+  amenities: field(z.array(z.enum(AMENITY_OPTIONS))),
+  camping: field(z.array(z.enum(CAMPING_OPTIONS))),
+  vehicleTypes: field(z.array(z.enum(VEHICLE_TYPE_OPTIONS))),
 });
 
 export type ParkExtraction = z.infer<typeof parkExtractionSchema>;

--- a/test/components/admin/FieldExtractionReview.test.tsx
+++ b/test/components/admin/FieldExtractionReview.test.tsx
@@ -417,4 +417,145 @@ describe("FieldExtractionReview", () => {
     const { container } = render(<FieldExtractionReview extractions={[]} />);
     expect(container.querySelector("h2")).toBeNull();
   });
+
+  describe("typed editors", () => {
+    const openEdit = () =>
+      fireEvent.click(screen.getByTitle(/edit value before approving/i));
+
+    const approveWithEdit = () =>
+      fireEvent.click(screen.getByRole("button", { name: /approve with edit/i }));
+
+    const lastEditedValue = () =>
+      JSON.parse(JSON.parse(mockFetch.mock.calls[0][1].body).editedValue);
+
+    it("edits an array field via option chips and approves selected values", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "amenities",
+              extractedValue: JSON.stringify(["restrooms"]),
+              currentValue: JSON.stringify([]),
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.click(screen.getByText("Showers")); // add another option
+      approveWithEdit();
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/admin/ai-research/extractions/ext-1/approve",
+          expect.objectContaining({ method: "POST" })
+        );
+      });
+      expect(lastEditedValue()).toEqual(["restrooms", "showers"]);
+    });
+
+    it("blocks approving an array field with nothing selected", () => {
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "terrain",
+              extractedValue: JSON.stringify(["sand"]),
+              currentValue: JSON.stringify([]),
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.click(screen.getByText("Sand")); // unselect the only value
+      approveWithEdit();
+      expect(screen.getByText(/select at least one option/i)).toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("edits ownership via a dropdown constrained to valid options", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "ownership",
+              extractedValue: JSON.stringify("private"),
+              currentValue: JSON.stringify("public"),
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.change(screen.getByRole("combobox"), {
+        target: { value: "mixed" },
+      });
+      approveWithEdit();
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(lastEditedValue()).toBe("mixed");
+    });
+
+    it("edits a boolean field via a Yes/No dropdown", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "permitRequired",
+              extractedValue: JSON.stringify(true),
+              currentValue: JSON.stringify(false),
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.change(screen.getByRole("combobox"), {
+        target: { value: "false" },
+      });
+      approveWithEdit();
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(lastEditedValue()).toBe(false);
+    });
+
+    it("approves a valid number edit as a number", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "acres",
+              extractedValue: JSON.stringify(100),
+              currentValue: null,
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.change(screen.getByRole("spinbutton"), {
+        target: { value: "250" },
+      });
+      approveWithEdit();
+      await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+      expect(lastEditedValue()).toBe(250);
+    });
+
+    it("blocks approving an empty number edit", () => {
+      render(
+        <FieldExtractionReview
+          extractions={[
+            makeExtraction({
+              fieldName: "acres",
+              extractedValue: JSON.stringify(100),
+              currentValue: null,
+            }),
+          ]}
+        />
+      );
+      openEdit();
+      fireEvent.change(screen.getByRole("spinbutton"), { target: { value: "" } });
+      approveWithEdit();
+      expect(screen.getByText(/valid number/i)).toBeInTheDocument();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Workstream B, part (d) of the AI research engine refactor — the last of the review-UX work.

## Problem
The review editor was a single free-text `textarea` for **every** field. For typed fields (`amenities`, `terrain`, `camping`, `vehicleTypes`, `ownership`, booleans) you could type anything, and an invalid enum value would only fail later at write time.

## Change
Each field now gets an editor matched to its type, so typed fields can only take valid values:
- **array enum fields** → option chips (multi-select), pre-checked with the extracted values
- **ownership** → dropdown of valid options
- **boolean fields** → Yes/No dropdown
- **numeric fields** → number input (empty/NaN blocked on save)
- **string/address fields** → text input

### Consolidation (worth it on its own)
The valid-option lists were **triplicated** — the Prisma enums, the `z.enum()`s in `schemas.ts`, and the field-type map in `config.ts`. This introduces one side-effect-free source of truth, [`src/lib/ai/park-fields.ts`](src/lib/ai/park-fields.ts), that the Zod extraction schema, the review selectors, and validation all read from. `config.ts` re-exports `EXTRACTABLE_FIELDS` so existing importers are untouched. (The module is deliberately free of SDK imports so it's safe in the client bundle.)

## Testing
- New editor tests: array add/clear-guard, ownership dropdown, boolean dropdown, number valid/invalid-guard.
- Existing display + approve/reject tests unchanged and green.
- `npm test` full suite green (2227); `tsc` + ESLint clean.

> No migration. Browser verification n/a in-env (auth-gated, no local DB) — verified via tests + typecheck.

Completes Workstream B. Next: Workstream C (research status lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)