### PR TITLE
feat(ai-research): session-driven research status + stuck-run recovery

### DIFF
--- a/prisma/migrations/20260723100000_research_status_partial/migration.sql
+++ b/prisma/migrations/20260723100000_research_status_partial/migration.sql
@@ -1,0 +1,6 @@
+-- Add a resting "ran but incomplete" state, ordered right after IN_PROGRESS so
+-- `ORDER BY researchStatus` keeps a sensible progression. Existing rows are
+-- unaffected; parks stuck in IN_PROGRESS are reclassified at runtime by
+-- reconcileStuckResearch() (a value can't be safely used in the same migration
+-- transaction that adds it, so no backfill here).
+ALTER TYPE "ResearchStatus" ADD VALUE IF NOT EXISTS 'PARTIAL' AFTER 'IN_PROGRESS';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -307,7 +307,8 @@ enum Ownership {
 
 enum ResearchStatus {
   NEEDS_RESEARCH
-  IN_PROGRESS
+  IN_PROGRESS // a research session is actively running right now
+  PARTIAL // ran at least once but hasn't graduated (incomplete / awaiting review)
   RESEARCHED
   MAINTENANCE
 }

--- a/src/app/admin/ai-research/page.tsx
+++ b/src/app/admin/ai-research/page.tsx
@@ -17,6 +17,7 @@ export default async function AIResearchPage() {
     totalParks,
     needsResearch,
     inProgress,
+    partial,
     researched,
     maintenance,
     pendingReviewCount,
@@ -29,6 +30,7 @@ export default async function AIResearchPage() {
     prisma.park.count(),
     prisma.park.count({ where: { researchStatus: "NEEDS_RESEARCH" } }),
     prisma.park.count({ where: { researchStatus: "IN_PROGRESS" } }),
+    prisma.park.count({ where: { researchStatus: "PARTIAL" } }),
     prisma.park.count({ where: { researchStatus: "RESEARCHED" } }),
     prisma.park.count({ where: { researchStatus: "MAINTENANCE" } }),
     prisma.fieldExtraction.count({ where: { status: "PENDING_REVIEW" } }),
@@ -87,7 +89,7 @@ export default async function AIResearchPage() {
       {/* Research Status Breakdown */}
       <div className="rounded-lg border border-border bg-card p-6">
         <h2 className="text-lg font-semibold text-foreground mb-4">Research Status</h2>
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
           <div className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/40 p-4">
             <p className="text-sm text-red-600 dark:text-red-400 font-medium">Needs Research</p>
             <p className="mt-1 text-2xl font-bold text-red-900 dark:text-red-200">{needsResearch}</p>
@@ -95,6 +97,10 @@ export default async function AIResearchPage() {
           <div className="rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-900/40 p-4">
             <p className="text-sm text-yellow-600 dark:text-yellow-400 font-medium">In Progress</p>
             <p className="mt-1 text-2xl font-bold text-yellow-900 dark:text-yellow-200">{inProgress}</p>
+          </div>
+          <div className="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-900/40 p-4">
+            <p className="text-sm text-amber-600 dark:text-amber-400 font-medium">Partial</p>
+            <p className="mt-1 text-2xl font-bold text-amber-900 dark:text-amber-200">{partial}</p>
           </div>
           <div className="rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-900/40 p-4">
             <p className="text-sm text-green-600 dark:text-green-400 font-medium">Researched</p>

--- a/src/app/admin/ai-research/research/[parkId]/page.tsx
+++ b/src/app/admin/ai-research/research/[parkId]/page.tsx
@@ -180,6 +180,7 @@ function ResearchStatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     NEEDS_RESEARCH: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50",
     IN_PROGRESS: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border-yellow-200 dark:border-yellow-900/50",
+    PARTIAL: "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 border-amber-200 dark:border-amber-900/50",
     RESEARCHED: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50",
     MAINTENANCE: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-900/50",
   };

--- a/src/app/admin/ai-research/research/page.tsx
+++ b/src/app/admin/ai-research/research/page.tsx
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/prisma";
 import Link from "next/link";
 import { ArrowRight, FlaskConical } from "lucide-react";
+import { reconcileStuckResearch } from "@/lib/ai/research-lifecycle";
+import type { ResearchStatus } from "@/lib/types";
 
 export default async function ResearchListPage({
   searchParams,
@@ -11,9 +13,13 @@ export default async function ResearchListPage({
   const q = params.q?.trim() || "";
   const statusFilter = params.status || "ALL";
 
+  // Heal any parks stuck in IN_PROGRESS (orphaned fire-and-forget runs) before
+  // we read the list, so the statuses shown are accurate.
+  await reconcileStuckResearch();
+
   const where: {
     status: "APPROVED";
-    researchStatus?: "NEEDS_RESEARCH" | "IN_PROGRESS" | "RESEARCHED" | "MAINTENANCE";
+    researchStatus?: ResearchStatus;
     name?: { contains: string; mode: "insensitive" };
   } = { status: "APPROVED" };
   if (statusFilter !== "ALL") {
@@ -74,6 +80,7 @@ export default async function ResearchListPage({
         <StatusFilterLink label="All" value="ALL" active={statusFilter === "ALL"} q={q} />
         <StatusFilterLink label="Needs Research" value="NEEDS_RESEARCH" active={statusFilter === "NEEDS_RESEARCH"} q={q} />
         <StatusFilterLink label="In Progress" value="IN_PROGRESS" active={statusFilter === "IN_PROGRESS"} q={q} />
+        <StatusFilterLink label="Partial" value="PARTIAL" active={statusFilter === "PARTIAL"} q={q} />
         <StatusFilterLink label="Researched" value="RESEARCHED" active={statusFilter === "RESEARCHED"} q={q} />
         <StatusFilterLink label="Maintenance" value="MAINTENANCE" active={statusFilter === "MAINTENANCE"} q={q} />
       </div>
@@ -172,6 +179,7 @@ function ResearchStatusBadge({ status }: { status: string }) {
   const styles: Record<string, string> = {
     NEEDS_RESEARCH: "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50",
     IN_PROGRESS: "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border-yellow-200 dark:border-yellow-900/50",
+    PARTIAL: "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 border-amber-200 dark:border-amber-900/50",
     RESEARCHED: "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50",
     MAINTENANCE: "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 border-blue-200 dark:border-blue-900/50",
   };

--- a/src/app/api/admin/ai-research/dashboard/route.ts
+++ b/src/app/api/admin/ai-research/dashboard/route.ts
@@ -11,6 +11,7 @@ export async function GET() {
     totalParks,
     needsResearch,
     inProgress,
+    partial,
     researched,
     maintenance,
     pendingReviewCount,
@@ -21,6 +22,7 @@ export async function GET() {
     prisma.park.count(),
     prisma.park.count({ where: { researchStatus: "NEEDS_RESEARCH" } }),
     prisma.park.count({ where: { researchStatus: "IN_PROGRESS" } }),
+    prisma.park.count({ where: { researchStatus: "PARTIAL" } }),
     prisma.park.count({ where: { researchStatus: "RESEARCHED" } }),
     prisma.park.count({ where: { researchStatus: "MAINTENANCE" } }),
     prisma.fieldExtraction.count({ where: { status: "PENDING_REVIEW" } }),
@@ -36,6 +38,7 @@ export async function GET() {
   const parksByResearchStatus: Record<ResearchStatus, number> = {
     NEEDS_RESEARCH: needsResearch,
     IN_PROGRESS: inProgress,
+    PARTIAL: partial,
     RESEARCHED: researched,
     MAINTENANCE: maintenance,
   };

--- a/src/lib/ai/research-lifecycle.ts
+++ b/src/lib/ai/research-lifecycle.ts
@@ -1,6 +1,13 @@
 import { prisma } from "@/lib/prisma";
 import { EXTRACTABLE_FIELDS } from "./config";
-import type { DbPark } from "@/lib/types";
+import type { DbPark, ResearchStatus } from "@/lib/types";
+
+/**
+ * A research session left IN_PROGRESS longer than this (with no active run) is
+ * considered orphaned — the serverless invocation almost certainly died. Used by
+ * reconcileStuckResearch() to un-stick parks.
+ */
+export const STUCK_SESSION_MINUTES = 15;
 
 /**
  * Get field names to exclude from extraction prompts.
@@ -59,6 +66,82 @@ export function shouldGraduate(
     hasTerrain &&
     hasVehicleTypes
   );
+}
+
+/**
+ * Decide a park's resting research status once a research run finishes. Pure so
+ * it can be unit tested. `IN_PROGRESS` is only ever a transient (actively-
+ * running) state now — a finished run always resolves to a terminal state:
+ *  - MAINTENANCE is preserved (an admin opted the park into periodic re-checks)
+ *  - graduated → RESEARCHED
+ *  - otherwise → PARTIAL (ran, but data is incomplete / awaiting review)
+ */
+export function resolveTerminalStatus(
+  priorStatus: ResearchStatus,
+  graduated: boolean
+): ResearchStatus {
+  if (priorStatus === "MAINTENANCE") return "MAINTENANCE";
+  return graduated ? "RESEARCHED" : "PARTIAL";
+}
+
+/**
+ * Heal parks stuck in IN_PROGRESS. A park is stuck if it's marked IN_PROGRESS
+ * but has no research session that is genuinely still running (started within
+ * the last STUCK_SESSION_MINUTES) — e.g. a fire-and-forget run whose serverless
+ * invocation died before writing a terminal status. Orphaned IN_PROGRESS
+ * sessions are marked FAILED and the park is reset to a runnable resting state
+ * (PARTIAL if it has been researched before, else NEEDS_RESEARCH).
+ *
+ * Returns the number of parks reconciled. Cheap when nothing is stuck.
+ */
+export async function reconcileStuckResearch(): Promise<number> {
+  const threshold = new Date(Date.now() - STUCK_SESSION_MINUTES * 60_000);
+
+  const stuck = await prisma.park.findMany({
+    where: {
+      researchStatus: "IN_PROGRESS",
+      NOT: {
+        researchSessions: {
+          some: { status: "IN_PROGRESS", startedAt: { gte: threshold } },
+        },
+      },
+    },
+    select: { id: true, lastResearchedAt: true },
+  });
+
+  if (stuck.length === 0) return 0;
+
+  const ids = stuck.map((p) => p.id);
+  const researchedBefore = stuck
+    .filter((p) => p.lastResearchedAt !== null)
+    .map((p) => p.id);
+  const neverResearched = stuck
+    .filter((p) => p.lastResearchedAt === null)
+    .map((p) => p.id);
+
+  await prisma.researchSession.updateMany({
+    where: { parkId: { in: ids }, status: "IN_PROGRESS" },
+    data: {
+      status: "FAILED",
+      completedAt: new Date(),
+      errorMessage: "Reconciled: session orphaned or exceeded time limit.",
+    },
+  });
+
+  if (researchedBefore.length > 0) {
+    await prisma.park.updateMany({
+      where: { id: { in: researchedBefore } },
+      data: { researchStatus: "PARTIAL" },
+    });
+  }
+  if (neverResearched.length > 0) {
+    await prisma.park.updateMany({
+      where: { id: { in: neverResearched } },
+      data: { researchStatus: "NEEDS_RESEARCH" },
+    });
+  }
+
+  return stuck.length;
 }
 
 /**

--- a/src/lib/ai/research-pipeline.ts
+++ b/src/lib/ai/research-pipeline.ts
@@ -13,7 +13,9 @@ import {
   calculateCompleteness,
   shouldGraduate,
   getCurrentFieldValue,
+  resolveTerminalStatus,
 } from "./research-lifecycle";
+import type { ResearchStatus } from "@/lib/types";
 import { isAllowedByRobots, clearRobotsCache } from "./robots";
 import { getDefaultReliabilityForSource } from "./domain-reliability";
 import { discoverSources, normalizeUrl } from "./source-discovery";
@@ -60,10 +62,23 @@ export async function researchPark(
     },
   });
 
+  // IN_PROGRESS is a transient "actively running" state. Set it up front and
+  // resolve to a terminal state in `finally` so a crashed run never leaves the
+  // park stuck. MAINTENANCE is left alone (admin-managed).
+  const priorStatus = park.researchStatus as ResearchStatus;
+  if (priorStatus !== "IN_PROGRESS" && priorStatus !== "MAINTENANCE") {
+    await prisma.park.update({
+      where: { id: parkId },
+      data: { researchStatus: "IN_PROGRESS" },
+    });
+  }
+
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
   let totalFieldsExtracted = 0;
   let totalSourcesFound = 0;
+  let sourcesProcessed = 0;
+  let graduated = false;
 
   try {
     // Get fields to exclude (already resolved)
@@ -74,6 +89,8 @@ export async function researchPark(
       (f) => !excludedFields.includes(f)
     );
     if (remainingFields.length === 0) {
+      // Nothing left to research — every field is approved or marked not-found.
+      graduated = true;
       await completeSession(session.id, {
         status: "COMPLETED",
         summary: "All fields already resolved. No extraction needed.",
@@ -87,8 +104,9 @@ export async function researchPark(
 
     // Stage 1: Source Discovery (for parks still being actively researched)
     if (
-      park.researchStatus === "NEEDS_RESEARCH" ||
-      park.researchStatus === "IN_PROGRESS"
+      priorStatus === "NEEDS_RESEARCH" ||
+      priorStatus === "IN_PROGRESS" ||
+      priorStatus === "PARTIAL"
     ) {
       // Exclude all existing URLs + URLs previously rejected as wrong park
       const existingUrls = park.dataSources.map((s) => s.url);
@@ -401,34 +419,13 @@ export async function researchPark(
       }
     }
 
-    // Update park metadata
-    const completenessScore = calculateCompleteness(park);
+    // Decide graduation. The park's terminal research status is applied in the
+    // `finally` block so it's set exactly once, on every exit path.
     const approvedCount = await prisma.fieldExtraction.count({
       where: { parkId, status: "APPROVED" },
     });
-
-    const updateData: Record<string, unknown> = {
-      lastResearchedAt: new Date(),
-      dataCompletenessScore: completenessScore,
-    };
-
-    // Advance research status
-    if (park.researchStatus === "NEEDS_RESEARCH") {
-      updateData.researchStatus = "IN_PROGRESS";
-    }
-
-    if (
-      shouldGraduate(park, approvedCount, sources.length) &&
-      park.researchStatus !== "RESEARCHED" &&
-      park.researchStatus !== "MAINTENANCE"
-    ) {
-      updateData.researchStatus = "RESEARCHED";
-    }
-
-    await prisma.park.update({
-      where: { id: parkId },
-      data: updateData,
-    });
+    sourcesProcessed = sources.length;
+    graduated = shouldGraduate(park, approvedCount, sourcesProcessed);
 
     // Complete session
     const summaryParts = [
@@ -446,7 +443,7 @@ export async function researchPark(
       outputTokens: totalOutputTokens,
     });
   } catch (error) {
-    // Mark session as failed
+    // Mark session as failed. `graduated` stays false → park resolves to PARTIAL.
     await completeSession(session.id, {
       status: "FAILED",
       errorMessage:
@@ -456,6 +453,21 @@ export async function researchPark(
       inputTokens: totalInputTokens,
       outputTokens: totalOutputTokens,
     });
+  } finally {
+    // Always leave a terminal resting state — never a dangling IN_PROGRESS.
+    const terminalStatus = resolveTerminalStatus(priorStatus, graduated);
+    await prisma.park
+      .update({
+        where: { id: parkId },
+        data: {
+          researchStatus: terminalStatus,
+          lastResearchedAt: new Date(),
+          dataCompletenessScore: calculateCompleteness(park),
+        },
+      })
+      .catch(() => {
+        // Best-effort — never mask the run's real outcome with a write error.
+      });
   }
 
   return { sessionId: session.id };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,7 +70,12 @@ export type VehicleType = "motorcycle" | "atv" | "sxs" | "fullSize";
 export type ParkStatus = "PENDING" | "APPROVED" | "REJECTED" | "DRAFT";
 
 // AI Data Context Engine types
-export type ResearchStatus = "NEEDS_RESEARCH" | "IN_PROGRESS" | "RESEARCHED" | "MAINTENANCE";
+export type ResearchStatus =
+  | "NEEDS_RESEARCH"
+  | "IN_PROGRESS"
+  | "PARTIAL"
+  | "RESEARCHED"
+  | "MAINTENANCE";
 export type DataSourceType = "website" | "pdf" | "facebook" | "governmentPage" | "reviewSite" | "campingDirectory" | "other";
 export type DataSourceOrigin = "OPERATOR_PROVIDED" | "AI_DISCOVERED" | "ADMIN_ADDED" | "USER_SUBMITTED";
 export type CrawlStatus = "PENDING" | "SUCCESS" | "FAILED" | "ROBOTS_BLOCKED" | "SKIPPED" | "WRONG_PARK";

--- a/test/lib/ai/research-lifecycle.test.ts
+++ b/test/lib/ai/research-lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   shouldGraduate,
   getCurrentFieldValue,
   getExcludedFields,
+  resolveTerminalStatus,
 } from "@/lib/ai/research-lifecycle";
 import { prisma } from "@/lib/prisma";
 import type { DbPark } from "@/lib/types";
@@ -459,5 +460,29 @@ describe("getExcludedFields", () => {
     expect(result).toHaveLength(2);
     expect(result).toContain("terrain");
     expect(result).toContain("amenities");
+  });
+});
+
+describe("resolveTerminalStatus", () => {
+  it("graduates to RESEARCHED when the run met the bar", () => {
+    expect(resolveTerminalStatus("IN_PROGRESS", true)).toBe("RESEARCHED");
+    expect(resolveTerminalStatus("NEEDS_RESEARCH", true)).toBe("RESEARCHED");
+    expect(resolveTerminalStatus("PARTIAL", true)).toBe("RESEARCHED");
+  });
+
+  it("falls back to PARTIAL when the run did not graduate", () => {
+    expect(resolveTerminalStatus("NEEDS_RESEARCH", false)).toBe("PARTIAL");
+    expect(resolveTerminalStatus("IN_PROGRESS", false)).toBe("PARTIAL");
+    expect(resolveTerminalStatus("RESEARCHED", false)).toBe("PARTIAL");
+  });
+
+  it("never leaves a park stuck in IN_PROGRESS", () => {
+    expect(resolveTerminalStatus("IN_PROGRESS", true)).not.toBe("IN_PROGRESS");
+    expect(resolveTerminalStatus("IN_PROGRESS", false)).not.toBe("IN_PROGRESS");
+  });
+
+  it("preserves an admin-set MAINTENANCE status regardless of graduation", () => {
+    expect(resolveTerminalStatus("MAINTENANCE", true)).toBe("MAINTENANCE");
+    expect(resolveTerminalStatus("MAINTENANCE", false)).toBe("MAINTENANCE");
   });
 });


### PR DESCRIPTION
Workstream C of the AI research engine refactor — fixes the confusing status lifecycle you flagged (all discovered parks stuck "In progress", nothing ever completing).

## Why it happened
`researchStatus` had only two write sites, and `IN_PROGRESS` was used as a *resting* state that only ever advanced to `RESEARCHED` if a run happened to clear the graduation bar. So one-pass discovered parks got stranded in `IN_PROGRESS` forever, and a crashed fire-and-forget run could orphan its session and leave the park stuck too.

## Changes
- **`IN_PROGRESS` is now transient** — set at run start, resolved at run end.
- **New `PARTIAL` state** = "ran at least once but hasn't graduated" (incomplete / awaiting review), ordered right after `IN_PROGRESS`. Enum + migration (`ADD VALUE IF NOT EXISTS`).
- **`resolveTerminalStatus()`** (pure, unit-tested) decides the resting state on **every** exit path via a `finally` block: `MAINTENANCE` preserved, graduated → `RESEARCHED`, otherwise `PARTIAL`. A run can no longer end in `IN_PROGRESS`.
- **`reconcileStuckResearch()`** heals parks stuck `IN_PROGRESS` with no live session (orphaned runs > 15 min): marks the dead session `FAILED` and resets the park to `PARTIAL` (if researched before) or `NEEDS_RESEARCH`. Runs when the Research list loads, so existing stuck parks self-heal on first view.
- Source discovery now also runs for `PARTIAL` parks on re-research.
- **UI**: `PARTIAL` status filter, badges (per-park + list), and overview/dashboard counts.

## Testing
- `resolveTerminalStatus` across all prior states × graduation, incl. the "never leaves IN_PROGRESS" invariant.
- `npm test` full suite green (2231); `tsc` + ESLint clean; client regenerates.

> Migration is an additive enum value (no backfill — the reconcile pass reclassifies existing stuck rows at runtime, since a new enum value can't be used in the same migration tx). Browser verification n/a in-env (auth-gated, no local DB).

Next: Workstream D (bulk research via cron-drained queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)