### PR TITLE
feat(ai-research): assisted-auto domain reliability from feedback

### DIFF
--- a/.github/workflows/domain-reliability.yml
+++ b/.github/workflows/domain-reliability.yml
@@ -1,0 +1,31 @@
+name: Domain Reliability Tuning
+
+# Nightly assisted-auto tuning of domain reliability scores from admin
+# approve/reject feedback. GitHub Actions cron avoids the Vercel plan's cron
+# limits; it just pings the CRON_SECRET-guarded endpoint. Scheduled runs only
+# fire from the default branch once merged.
+on:
+  schedule:
+    - cron: "30 8 * * *" # 08:30 UTC daily
+  workflow_dispatch: {}
+
+jobs:
+  tune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check config is present
+        id: cfg
+        run: |
+          if [ -n "${{ secrets.DOMAIN_RELIABILITY_URL }}" ] && [ -n "${{ secrets.CRON_SECRET }}" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Domain-reliability tuning skipped — set DOMAIN_RELIABILITY_URL (e.g. https://your-domain/api/cron/domain-reliability) and CRON_SECRET in repo Secrets (Settings → Secrets and variables → Actions)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run domain-reliability tuning
+        if: steps.cfg.outputs.ok == 'true'
+        run: |
+          curl --fail --silent --show-error --max-time 70 \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            "${{ secrets.DOMAIN_RELIABILITY_URL }}"

--- a/prisma/migrations/20260723120000_domain_reliability_locked/migration.sql
+++ b/prisma/migrations/20260723120000_domain_reliability_locked/migration.sql
@@ -1,0 +1,3 @@
+-- Lets an admin pin a domain's reliability score so the nightly feedback-driven
+-- auto-tuner leaves it alone. Existing rows default to unlocked.
+ALTER TABLE "DomainReliability" ADD COLUMN "locked" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -811,6 +811,7 @@ model DomainReliability {
   domainPattern      String   @unique  // e.g. "riderplanet-usa.com", ".gov"
   defaultReliability Int      @default(50)
   isBlocked          Boolean  @default(false)
+  locked             Boolean  @default(false) // pin the score against nightly auto-tuning
   notes              String?
 
   createdAt DateTime @default(now())

--- a/src/app/admin/ai-research/page.tsx
+++ b/src/app/admin/ai-research/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { getDomainAccuracyStats } from "@/lib/ai/feedback-loop";
+import { computeDomainAdjustments } from "@/lib/ai/domain-tuning";
+import { DomainSuggestions } from "@/components/admin/DomainSuggestions";
 import Link from "next/link";
 import {
   DollarSign,
@@ -46,6 +48,24 @@ export default async function AIResearchPage() {
   ]);
 
   const totalCost = costResult._sum.estimatedCostUSD ?? 0;
+
+  // Surface one-click block suggestions from the same logic the nightly tuner
+  // uses, annotated with the existing DomainReliability row id (if any).
+  const domainRows = await prisma.domainReliability.findMany({
+    select: {
+      id: true,
+      domainPattern: true,
+      defaultReliability: true,
+      isBlocked: true,
+      locked: true,
+    },
+  });
+  const { blockSuggestions } = computeDomainAdjustments(domainAccuracy, domainRows);
+  const domainSuggestions = blockSuggestions.map((s) => ({
+    ...s,
+    existingId:
+      domainRows.find((r) => r.domainPattern === s.domainPattern)?.id ?? null,
+  }));
 
   return (
     <div className="space-y-6">
@@ -119,6 +139,7 @@ export default async function AIResearchPage() {
           <BarChart3 className="w-5 h-5 text-muted-foreground" />
           <h2 className="text-lg font-semibold text-foreground">Domain Accuracy</h2>
         </div>
+        <DomainSuggestions suggestions={domainSuggestions} />
         {domainAccuracy.length === 0 ? (
           <p className="text-muted-foreground text-sm">No extraction reviews yet. Approve or reject extractions to see accuracy data.</p>
         ) : (

--- a/src/app/admin/ai-research/research/[parkId]/page.tsx
+++ b/src/app/admin/ai-research/research/[parkId]/page.tsx
@@ -88,6 +88,7 @@ export default async function ParkResearchWorkspacePage({
     domainPattern: d.domainPattern,
     defaultReliability: d.defaultReliability,
     isBlocked: d.isBlocked,
+    locked: d.locked,
     notes: d.notes,
     createdAt: d.createdAt.toISOString(),
   }));

--- a/src/app/api/admin/ai-research/domains/auto-tune/route.ts
+++ b/src/app/api/admin/ai-research/domains/auto-tune/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-helpers";
+import { applyDomainAutoTune } from "@/lib/ai/domain-tuning";
+
+// POST — run a domain-reliability tuning pass on demand (the same work the
+// nightly cron does), so an admin can apply the latest feedback immediately.
+export async function POST() {
+  const adminResult = await requireAdmin();
+  if (adminResult instanceof NextResponse) return adminResult;
+
+  try {
+    const { updates, blockSuggestions } = await applyDomainAutoTune();
+    return NextResponse.json({
+      success: true,
+      adjusted: updates.length,
+      updates,
+      blockSuggestions,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Tuning failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/ai-research/domains/route.ts
+++ b/src/app/api/admin/ai-research/domains/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
     domainPattern: d.domainPattern,
     defaultReliability: d.defaultReliability,
     isBlocked: d.isBlocked,
+    locked: d.locked,
     notes: d.notes,
     createdAt: d.createdAt.toISOString(),
   }));
@@ -28,7 +29,7 @@ export async function POST(request: Request) {
   if (adminResult instanceof NextResponse) return adminResult;
 
   const body = await request.json();
-  const { domainPattern, defaultReliability, isBlocked, notes } = body;
+  const { domainPattern, defaultReliability, isBlocked, locked, notes } = body;
 
   if (!domainPattern || typeof domainPattern !== "string" || !domainPattern.trim()) {
     return NextResponse.json(
@@ -65,6 +66,7 @@ export async function POST(request: Request) {
       domainPattern: domainPattern.trim(),
       defaultReliability,
       isBlocked: isBlocked ?? false,
+      locked: locked ?? false,
       notes: notes || null,
     },
   });
@@ -76,6 +78,7 @@ export async function POST(request: Request) {
       domainPattern: domain.domainPattern,
       defaultReliability: domain.defaultReliability,
       isBlocked: domain.isBlocked,
+      locked: domain.locked,
       notes: domain.notes,
       createdAt: domain.createdAt.toISOString(),
     } satisfies DomainReliabilitySummary,
@@ -87,7 +90,7 @@ export async function PATCH(request: Request) {
   if (adminResult instanceof NextResponse) return adminResult;
 
   const body = await request.json();
-  const { id, defaultReliability, isBlocked, notes } = body;
+  const { id, defaultReliability, isBlocked, locked, notes } = body;
 
   if (!id) {
     return NextResponse.json({ error: "id is required" }, { status: 400 });
@@ -123,6 +126,10 @@ export async function PATCH(request: Request) {
     updateData.isBlocked = Boolean(isBlocked);
   }
 
+  if (locked !== undefined) {
+    updateData.locked = Boolean(locked);
+  }
+
   if (notes !== undefined) {
     updateData.notes = notes || null;
   }
@@ -139,6 +146,7 @@ export async function PATCH(request: Request) {
       domainPattern: updated.domainPattern,
       defaultReliability: updated.defaultReliability,
       isBlocked: updated.isBlocked,
+      locked: updated.locked,
       notes: updated.notes,
       createdAt: updated.createdAt.toISOString(),
     } satisfies DomainReliabilitySummary,

--- a/src/app/api/cron/domain-reliability/route.ts
+++ b/src/app/api/cron/domain-reliability/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { applyDomainAutoTune } from "@/lib/ai/domain-tuning";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * Nightly assisted-auto tuning: nudge domain reliability scores toward observed
+ * approve/reject accuracy (bounded) and compute block suggestions. Triggered on
+ * a schedule by .github/workflows/domain-reliability.yml (GitHub Actions cron).
+ * Guarded by CRON_SECRET: `Authorization: Bearer $CRON_SECRET`.
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const secret = process.env.CRON_SECRET;
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const { updates, blockSuggestions } = await applyDomainAutoTune();
+    return NextResponse.json({
+      ok: true,
+      adjusted: updates.length,
+      updates,
+      blockSuggestions,
+    });
+  } catch (error) {
+    console.error("[cron/domain-reliability] tune failed", error);
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "tune failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/DomainReliabilityTable.tsx
+++ b/src/components/admin/DomainReliabilityTable.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Pencil, Trash2, Check, X } from "lucide-react";
+import { Plus, Pencil, Trash2, Check, X, Lock, LockOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { DomainReliabilitySummary } from "@/lib/types";
 
@@ -89,6 +89,20 @@ export function DomainReliabilityTable({ domains }: Props) {
       }
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleToggleLock = async (id: string, locked: boolean) => {
+    const response = await fetch("/api/admin/ai-research/domains", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, locked: !locked }),
+    });
+    if (response.ok) {
+      router.refresh();
+    } else {
+      const data = await response.json();
+      alert(data.error || "Failed to update lock");
     }
   };
 
@@ -276,13 +290,26 @@ export function DomainReliabilityTable({ domains }: Props) {
                         />
                         Blocked
                       </label>
-                    ) : domain.isBlocked ? (
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50">
-                        Blocked
-                      </span>
                     ) : (
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50">
-                        Active
+                      <span className="inline-flex items-center gap-1.5">
+                        {domain.isBlocked ? (
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border-red-200 dark:border-red-900/50">
+                            Blocked
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border-green-200 dark:border-green-900/50">
+                            Active
+                          </span>
+                        )}
+                        {domain.locked && (
+                          <span
+                            title="Score pinned — skipped by nightly auto-tuning"
+                            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium border bg-muted text-muted-foreground border-border"
+                          >
+                            <Lock className="w-2.5 h-2.5" />
+                            Pinned
+                          </span>
+                        )}
                       </span>
                     )}
                   </td>
@@ -326,6 +353,25 @@ export function DomainReliabilityTable({ domains }: Props) {
                         </>
                       ) : (
                         <>
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={() =>
+                              handleToggleLock(domain.id, domain.locked)
+                            }
+                            title={
+                              domain.locked
+                                ? "Unpin — allow auto-tuning"
+                                : "Pin score — skip auto-tuning"
+                            }
+                            className="text-muted-foreground hover:text-primary hover:bg-primary/10"
+                          >
+                            {domain.locked ? (
+                              <Lock className="w-4 h-4" />
+                            ) : (
+                              <LockOpen className="w-4 h-4" />
+                            )}
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon-sm"

--- a/src/components/admin/DomainSuggestions.tsx
+++ b/src/components/admin/DomainSuggestions.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, ShieldAlert, Sparkles, Ban } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type DomainBlockSuggestion = {
+  domainPattern: string;
+  reviewCount: number;
+  accuracy: number;
+  /** Existing DomainReliability row id, if the domain is already tracked (unblocked). */
+  existingId: string | null;
+};
+
+type Props = {
+  suggestions: DomainBlockSuggestion[];
+};
+
+export function DomainSuggestions({ suggestions }: Props) {
+  const router = useRouter();
+  const [tuning, setTuning] = useState(false);
+  const [tuneResult, setTuneResult] = useState<string | null>(null);
+  const [blockingPattern, setBlockingPattern] = useState<string | null>(null);
+
+  const handleAutoTune = async () => {
+    setTuning(true);
+    setTuneResult(null);
+    try {
+      const res = await fetch("/api/admin/ai-research/domains/auto-tune", {
+        method: "POST",
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setTuneResult(
+          `Adjusted ${data.adjusted} domain score${data.adjusted === 1 ? "" : "s"} from feedback.`
+        );
+        router.refresh();
+      } else {
+        setTuneResult(`Error: ${data.error || "Tuning failed"}`);
+      }
+    } catch (err) {
+      setTuneResult(
+        `Error: ${err instanceof Error ? err.message : "Network error"}`
+      );
+    } finally {
+      setTuning(false);
+    }
+  };
+
+  const handleBlock = async (s: DomainBlockSuggestion) => {
+    setBlockingPattern(s.domainPattern);
+    try {
+      const res = s.existingId
+        ? await fetch("/api/admin/ai-research/domains", {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: s.existingId, isBlocked: true }),
+          })
+        : await fetch("/api/admin/ai-research/domains", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              domainPattern: s.domainPattern,
+              defaultReliability: 0,
+              isBlocked: true,
+              notes: "Blocked from feedback suggestion",
+            }),
+          });
+      if (res.ok) {
+        router.refresh();
+      } else {
+        const data = await res.json();
+        alert(data.error || "Failed to block domain");
+      }
+    } finally {
+      setBlockingPattern(null);
+    }
+  };
+
+  return (
+    <div className="mb-4 space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          Reliability scores auto-tune nightly from your approve/reject feedback.
+        </p>
+        <Button
+          onClick={handleAutoTune}
+          disabled={tuning}
+          size="sm"
+          variant="outline"
+        >
+          {tuning ? (
+            <>
+              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              Tuning...
+            </>
+          ) : (
+            <>
+              <Sparkles className="w-4 h-4 mr-1" />
+              Auto-tune now
+            </>
+          )}
+        </Button>
+      </div>
+
+      {tuneResult && (
+        <div
+          className={`rounded-lg border px-4 py-2 text-sm ${
+            tuneResult.startsWith("Error")
+              ? "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-900/40 text-red-800 dark:text-red-300"
+              : "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-900/40 text-green-800 dark:text-green-300"
+          }`}
+        >
+          {tuneResult}
+        </div>
+      )}
+
+      {suggestions.length > 0 && (
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50 dark:bg-amber-900/20 p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <ShieldAlert className="w-4 h-4 text-amber-700 dark:text-amber-400" />
+            <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+              {suggestions.length} domain{suggestions.length === 1 ? "" : "s"} suggested for blocking
+            </p>
+          </div>
+          <p className="text-xs text-amber-700/80 dark:text-amber-400/80 mb-3">
+            High review volume with mostly-rejected extractions. Blocking stops
+            these sources from being crawled in future research.
+          </p>
+          <ul className="space-y-2">
+            {suggestions.map((s) => (
+              <li
+                key={s.domainPattern}
+                className="flex items-center justify-between gap-3 rounded-md bg-card border border-border px-3 py-2"
+              >
+                <span className="text-sm text-foreground">
+                  <span className="font-medium">{s.domainPattern}</span>
+                  <span className="text-muted-foreground ml-2">
+                    {Math.round(s.accuracy * 100)}% accurate over {s.reviewCount} reviews
+                  </span>
+                </span>
+                <Button
+                  onClick={() => handleBlock(s)}
+                  disabled={blockingPattern !== null}
+                  size="sm"
+                  variant="outline"
+                  className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
+                >
+                  {blockingPattern === s.domainPattern ? (
+                    <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  ) : (
+                    <Ban className="w-4 h-4 mr-1" />
+                  )}
+                  Block
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai/domain-tuning.ts
+++ b/src/lib/ai/domain-tuning.ts
@@ -1,0 +1,164 @@
+import { prisma } from "@/lib/prisma";
+import { getDomainAccuracyStats } from "./feedback-loop";
+
+/**
+ * Assisted-auto domain reliability tuning.
+ *
+ * Nightly, we nudge each domain's `defaultReliability` a little way toward the
+ * accuracy observed from admin approve/reject feedback — bounded so it drifts
+ * gently rather than snapping, and only for domains with enough reviews to
+ * trust. Blocking is never automated: low-accuracy domains are surfaced as
+ * one-click *suggestions* for an admin to act on. Locked or blocked domains are
+ * left untouched.
+ */
+
+export type DomainAccuracyStat = {
+  domain: string;
+  totalApproves: number;
+  totalRejects: number;
+  accuracy: number;
+  sourceCount: number;
+};
+
+export type DomainRow = {
+  domainPattern: string;
+  defaultReliability: number;
+  isBlocked: boolean;
+  locked: boolean;
+};
+
+export type ReliabilityUpdate = {
+  domainPattern: string;
+  from: number;
+  to: number;
+  reviewCount: number;
+  accuracy: number;
+  isNew: boolean;
+};
+
+export type BlockSuggestion = {
+  domainPattern: string;
+  reviewCount: number;
+  accuracy: number;
+};
+
+export type TuningOptions = {
+  /** Minimum reviews before we adjust a domain's score. */
+  minSample?: number;
+  /** Max points a score can move in a single run. */
+  maxStep?: number;
+  /** Minimum reviews before suggesting a block. */
+  blockMinSample?: number;
+  /** Accuracy at or below which we suggest blocking. */
+  blockAccuracyThreshold?: number;
+};
+
+const DEFAULTS: Required<TuningOptions> = {
+  minSample: 10,
+  maxStep: 10,
+  blockMinSample: 8,
+  blockAccuracyThreshold: 0.25,
+};
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+/**
+ * Pure planner: given accuracy stats and the existing domain rows, decide which
+ * reliability scores to nudge and which domains to suggest blocking. No I/O, so
+ * it's fully unit-testable.
+ */
+export function computeDomainAdjustments(
+  stats: DomainAccuracyStat[],
+  existing: DomainRow[],
+  options: TuningOptions = {}
+): { updates: ReliabilityUpdate[]; blockSuggestions: BlockSuggestion[] } {
+  const opts = { ...DEFAULTS, ...options };
+  const byPattern = new Map(existing.map((d) => [d.domainPattern, d]));
+
+  const updates: ReliabilityUpdate[] = [];
+  const blockSuggestions: BlockSuggestion[] = [];
+
+  for (const stat of stats) {
+    const reviewCount = stat.totalApproves + stat.totalRejects;
+    const row = byPattern.get(stat.domain);
+
+    // Block suggestion: high volume, poor accuracy, not already blocked.
+    if (
+      reviewCount >= opts.blockMinSample &&
+      stat.accuracy <= opts.blockAccuracyThreshold &&
+      !row?.isBlocked
+    ) {
+      blockSuggestions.push({
+        domainPattern: stat.domain,
+        reviewCount,
+        accuracy: stat.accuracy,
+      });
+    }
+
+    // Score nudge: enough reviews, and the domain isn't locked or blocked.
+    if (reviewCount < opts.minSample) continue;
+    if (row?.locked || row?.isBlocked) continue;
+
+    const current = row?.defaultReliability ?? 50;
+    const target = Math.round(stat.accuracy * 100);
+    if (target === current) continue;
+
+    const delta = clamp(target - current, -opts.maxStep, opts.maxStep);
+    const next = clamp(current + delta, 0, 100);
+    if (next === current) continue;
+
+    updates.push({
+      domainPattern: stat.domain,
+      from: current,
+      to: next,
+      reviewCount,
+      accuracy: stat.accuracy,
+      isNew: row === undefined,
+    });
+  }
+
+  return { updates, blockSuggestions };
+}
+
+/**
+ * Run one tuning pass: read stats + domain rows, compute bounded adjustments,
+ * and persist them (creating a tracked row for a high-signal domain we didn't
+ * have yet). Returns the audit of what changed and what to consider blocking.
+ */
+export async function applyDomainAutoTune(
+  options: TuningOptions = {}
+): Promise<{ updates: ReliabilityUpdate[]; blockSuggestions: BlockSuggestion[] }> {
+  const [stats, rows] = await Promise.all([
+    getDomainAccuracyStats(),
+    prisma.domainReliability.findMany({
+      select: {
+        domainPattern: true,
+        defaultReliability: true,
+        isBlocked: true,
+        locked: true,
+      },
+    }),
+  ]);
+
+  const { updates, blockSuggestions } = computeDomainAdjustments(
+    stats,
+    rows,
+    options
+  );
+
+  for (const u of updates) {
+    await prisma.domainReliability.upsert({
+      where: { domainPattern: u.domainPattern },
+      update: { defaultReliability: u.to },
+      create: {
+        domainPattern: u.domainPattern,
+        defaultReliability: u.to,
+        notes: "Auto-created by feedback tuning",
+      },
+    });
+  }
+
+  return { updates, blockSuggestions };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -523,6 +523,7 @@ export type DomainReliabilitySummary = {
   domainPattern: string;
   defaultReliability: number;
   isBlocked: boolean;
+  locked: boolean;
   notes: string | null;
   createdAt: string;
 };

--- a/test/components/admin/DomainReliabilityTable.test.tsx
+++ b/test/components/admin/DomainReliabilityTable.test.tsx
@@ -16,6 +16,7 @@ const makeDomain = (
   domainPattern: ".gov",
   defaultReliability: 80,
   isBlocked: false,
+  locked: false,
   notes: "Government sites",
   createdAt: "2026-04-01T00:00:00Z",
   ...overrides,

--- a/test/lib/ai/domain-tuning.test.ts
+++ b/test/lib/ai/domain-tuning.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeDomainAdjustments,
+  type DomainAccuracyStat,
+  type DomainRow,
+} from "@/lib/ai/domain-tuning";
+
+const stat = (
+  domain: string,
+  approves: number,
+  rejects: number
+): DomainAccuracyStat => {
+  const total = approves + rejects;
+  return {
+    domain,
+    totalApproves: approves,
+    totalRejects: rejects,
+    accuracy: total > 0 ? approves / total : 0,
+    sourceCount: 1,
+  };
+};
+
+const row = (over: Partial<DomainRow> & { domainPattern: string }): DomainRow => ({
+  defaultReliability: 50,
+  isBlocked: false,
+  locked: false,
+  ...over,
+});
+
+describe("computeDomainAdjustments — score nudging", () => {
+  it("nudges toward observed accuracy, capped at maxStep", () => {
+    // 90% accurate over 20 reviews → target 90, but current 50, step capped at 10.
+    const { updates } = computeDomainAdjustments(
+      [stat("good.com", 18, 2)],
+      [row({ domainPattern: "good.com", defaultReliability: 50 })],
+      { minSample: 10, maxStep: 10 }
+    );
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ from: 50, to: 60, domainPattern: "good.com" });
+  });
+
+  it("moves down toward a low accuracy target", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("meh.com", 6, 14)], // 30%
+      [row({ domainPattern: "meh.com", defaultReliability: 50 })],
+      { minSample: 10, maxStep: 10 }
+    );
+    expect(updates[0]).toMatchObject({ from: 50, to: 40 });
+  });
+
+  it("skips domains below the sample threshold", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("new.com", 3, 0)],
+      [],
+      { minSample: 10 }
+    );
+    expect(updates).toHaveLength(0);
+  });
+
+  it("does not touch locked domains", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("pinned.com", 20, 0)],
+      [row({ domainPattern: "pinned.com", defaultReliability: 50, locked: true })],
+      { minSample: 10 }
+    );
+    expect(updates).toHaveLength(0);
+  });
+
+  it("does not touch blocked domains", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("bad.com", 20, 0)],
+      [row({ domainPattern: "bad.com", defaultReliability: 0, isBlocked: true })],
+      { minSample: 10 }
+    );
+    expect(updates).toHaveLength(0);
+  });
+
+  it("flags new high-signal domains for creation (isNew)", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("fresh.com", 20, 0)],
+      [],
+      { minSample: 10, maxStep: 10 }
+    );
+    expect(updates[0]).toMatchObject({ isNew: true, from: 50, to: 60 });
+  });
+
+  it("no-ops when the score already matches the target", () => {
+    const { updates } = computeDomainAdjustments(
+      [stat("steady.com", 10, 10)], // 50%
+      [row({ domainPattern: "steady.com", defaultReliability: 50 })],
+      { minSample: 10 }
+    );
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe("computeDomainAdjustments — block suggestions", () => {
+  it("suggests blocking high-volume, low-accuracy, unblocked domains", () => {
+    const { blockSuggestions } = computeDomainAdjustments(
+      [stat("spam.com", 1, 19)], // 5% over 20
+      [],
+      { blockMinSample: 8, blockAccuracyThreshold: 0.25 }
+    );
+    expect(blockSuggestions).toHaveLength(1);
+    expect(blockSuggestions[0].domainPattern).toBe("spam.com");
+  });
+
+  it("does not suggest blocking domains already blocked", () => {
+    const { blockSuggestions } = computeDomainAdjustments(
+      [stat("spam.com", 1, 19)],
+      [row({ domainPattern: "spam.com", isBlocked: true })],
+      { blockMinSample: 8, blockAccuracyThreshold: 0.25 }
+    );
+    expect(blockSuggestions).toHaveLength(0);
+  });
+
+  it("does not suggest blocking low-volume domains", () => {
+    const { blockSuggestions } = computeDomainAdjustments(
+      [stat("rare.com", 0, 3)],
+      [],
+      { blockMinSample: 8 }
+    );
+    expect(blockSuggestions).toHaveLength(0);
+  });
+
+  it("does not suggest blocking accurate domains", () => {
+    const { blockSuggestions } = computeDomainAdjustments(
+      [stat("good.com", 18, 2)],
+      [],
+      { blockMinSample: 8, blockAccuracyThreshold: 0.25 }
+    );
+    expect(blockSuggestions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Workstream E — the final piece of the AI research engine refactor. Closes the feedback loop: approve/reject signal now **tunes** domain reliability instead of only being displayed.

## Behavior (assisted-auto, your chosen model)
- **Bounded nightly nudges**: each domain's `defaultReliability` moves a little way toward the accuracy observed from admin approve/reject feedback — only for domains with enough reviews (min sample), capped per run (max step), so it drifts gently rather than snapping.
- **Blocking stays human**: high-volume, low-accuracy domains are surfaced as **one-click block suggestions**; nothing is auto-blocked.
- **Admin keeps control**: a new `locked` flag pins a domain's score so the tuner leaves it alone.

## Changes
- **[`domain-tuning.ts`](src/lib/ai/domain-tuning.ts)** — `computeDomainAdjustments()` (pure, fully unit-tested) plans nudges + block suggestions; `applyDomainAutoTune()` persists them (creating a tracked row for a high-signal domain we didn't have yet).
- **`DomainReliability.locked`** (migration) — threaded through the summary type + domains API (POST/PATCH/GET); lock toggle + "Pinned" badge in the domains manager.
- **Nightly** `GET /api/cron/domain-reliability` (`CRON_SECRET`) + `.github/workflows/domain-reliability.yml` (GitHub Actions, daily — same plan-independent approach as the research queue). Plus `POST .../domains/auto-tune` for an on-demand **"Auto-tune now"**.
- **Overview → Domain Accuracy**: one-click block suggestions + an "Auto-tune now" button + a "scores auto-tune nightly" note.

## Setup
The nightly workflow skips cleanly until you set repo secrets `DOMAIN_RELIABILITY_URL` (e.g. `https://your-domain/api/cron/domain-reliability`) and `CRON_SECRET` — same pattern as the research-queue workflow. You can also trigger tuning any time with **Auto-tune now**.

## Testing
- `computeDomainAdjustments`: nudge direction/cap, sample threshold, lock/block skips, new-domain creation, block-suggestion rules.
- `npm test` full suite green (2249); `tsc` + ESLint clean; client regenerates.

> Migration is one additive `NOT NULL DEFAULT false` boolean. No `vercel.json` change (GitHub Actions drives the schedule). Browser verification n/a in-env (auth-gated, no local DB).

**This completes the six-workstream refactor** (search fix → extraction quality → source-quote → typed selectors → status lifecycle → bulk research → feedback automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)