### PR TITLE
feat(ai-research): seed domains, verify source state, standardize county

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:studio": "prisma studio",
     "db:seed-reviews": "tsx prisma/seed-reviews.ts",
     "db:seed-reviews:wipe": "tsx prisma/seed-reviews.ts --wipe",
+    "db:seed-domains": "tsx prisma/seed-domain-reliability.ts",
     "db:normalize-states": "tsx prisma/normalize-state-values.ts",
     "db:normalize-states:dry": "tsx prisma/normalize-state-values.ts --dry",
     "prepare": "husky",

--- a/prisma/seed-domain-reliability.ts
+++ b/prisma/seed-domain-reliability.ts
@@ -1,0 +1,28 @@
+/**
+ * Seed script: populate the DomainReliability table with sensible starting
+ * defaults (.gov=85, riderplanet-usa.com=90, recreation.gov=85, alltrails=70,
+ * tripadvisor=65, facebook/fb/yelp=60).
+ *
+ * Usage:
+ *   npx tsx prisma/seed-domain-reliability.ts
+ *
+ * Idempotent: create-only (existing rows are left untouched), so it's safe to
+ * run repeatedly and it will never overwrite an admin-edited or auto-tuned
+ * score. Targets whatever DB the environment's DATABASE_URL points at.
+ */
+
+import { seedDomainReliability } from "../src/lib/ai/seed-domain-reliability";
+import { prisma } from "../src/lib/prisma";
+
+async function main() {
+  await seedDomainReliability();
+  const total = await prisma.domainReliability.count();
+  console.log(`✓ Domain reliability seeded. ${total} row(s) total.`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/lib/ai/extraction-validator.ts
+++ b/src/lib/ai/extraction-validator.ts
@@ -174,3 +174,15 @@ export function cleanStreetAddress(raw: string): string {
   }
   return trimmed;
 }
+
+/**
+ * Standardize a county name to just the name — strip a trailing "County",
+ * "Parish", "Borough", "Census Area", or "Municipality" so a source's
+ * "Polk County" matches a stored value of "Polk".
+ */
+export function cleanCounty(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\s+(County|Parish|Borough|Census Area|Municipality)\.?$/i, "")
+    .trim();
+}

--- a/src/lib/ai/park-data-extractor.ts
+++ b/src/lib/ai/park-data-extractor.ts
@@ -38,6 +38,8 @@ Rules:
 - For terrain, map descriptions: "sandy" = "sand", "rocky" = "rocks", "wooded trails" or "forest trails" = "trails", "hilly" or "mountain" = "hills", "muddy" or "clay" = "mud"
 - For amenities, only include amenities explicitly mentioned. "Full facilities" is too vague to map.
 - For the address, keep the fields separate: streetAddress is the street line ONLY (number + street, e.g. "123 Main St"). Do NOT include the city, state, or ZIP in streetAddress — put those in the city and zipCode fields.
+- For county, give the name only, WITHOUT the word "County"/"Parish"/"Borough" (e.g. "Polk", not "Polk County").
+- Extract the US state the park is located in (full name or 2-letter code) if the source states it — this is used to confirm the source is about the right park.
 - Omit numeric quantities (milesOfTrails, acres, maxVehicleWidthInches, noiseLimitDBA) when the source says none or zero — only include a positive number actually stated in the source.
 - Confidence scoring:
   - 0.9-1.0: Explicitly and unambiguously stated (e.g., "Day pass: $25")

--- a/src/lib/ai/research-pipeline.ts
+++ b/src/lib/ai/research-pipeline.ts
@@ -23,7 +23,9 @@ import {
   PHONE_FIELDS,
   URL_FIELDS,
   cleanStreetAddress,
+  cleanCounty,
 } from "./extraction-validator";
+import { normalizeStateName } from "@/lib/us-states";
 
 /**
  * Run the full AI research pipeline for a single park.
@@ -254,6 +256,20 @@ export async function researchPark(
         for (const [key, fieldData] of Object.entries(extraction)) {
           if (!fieldData) continue;
 
+          // `state` is extracted for verification only — never stored/applied
+          // (the park's state is set at creation). A mismatch is a wrong-park
+          // signal, surfaced as a session warning.
+          if (key === "state") {
+            const sourceState = normalizeStateName(String(fieldData.value));
+            const parkState = park.address?.state ?? null;
+            if (sourceState && parkState && sourceState !== parkState) {
+              validationWarnings.push(
+                `${source.url}: source names ${sourceState}, but park is in ${parkState} (possible wrong park)`
+              );
+            }
+            continue;
+          }
+
           // Map flat address keys to dot notation
           const addressFields = [
             "streetAddress",
@@ -306,13 +322,18 @@ export async function researchPark(
               valuesMatch = false;
             }
           } else {
-            // Strip an accidental city/state/zip tail from the street line so
-            // the stored value is just the street address (item b).
-            const scalarValue =
-              fieldName === "address.streetAddress" &&
-              typeof fieldData.value === "string"
-                ? cleanStreetAddress(fieldData.value)
-                : fieldData.value;
+            // Normalize address fields before storing:
+            //  - streetAddress: strip an accidental city/state/zip tail
+            //  - county: strip the "County"/"Parish"/… suffix so "Polk County"
+            //    is stored (and matched) as just "Polk"
+            let scalarValue: unknown = fieldData.value;
+            if (typeof fieldData.value === "string") {
+              if (fieldName === "address.streetAddress") {
+                scalarValue = cleanStreetAddress(fieldData.value);
+              } else if (fieldName === "address.county") {
+                scalarValue = cleanCounty(fieldData.value);
+              }
+            }
 
             extractedValueJson = JSON.stringify(scalarValue);
             valuesMatch =
@@ -481,6 +502,7 @@ export async function researchPark(
  *  - phone: digits only ("(555) 123-4567" === "5551234567")
  *  - url: scheme/www/trailing-slash/tracking-param insensitive
  *  - numeric fields: 25 === 25.0, and "$25" === 25
+ *  - county: "Polk County" === "Polk" (suffix ignored)
  *  - other strings: trimmed, lowercased, whitespace-collapsed
  */
 export function normalizeForComparison(
@@ -505,6 +527,10 @@ export function normalizeForComparison(
       }
       if (fieldName && URL_FIELDS.has(fieldName)) {
         return JSON.stringify(normalizeUrlForComparison(val));
+      }
+      // County: "Polk County" === "Polk" (suffix ignored).
+      if (fieldName === "address.county") {
+        return JSON.stringify(cleanCounty(val).toLowerCase());
       }
       // A numeric-typed field that arrived as a string ("$25", "25 mi").
       if (fieldName && EXTRACTABLE_FIELDS[fieldName] === "number") {

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -62,6 +62,7 @@ export const parkExtractionSchema = z.object({
   // Address
   streetAddress: field(z.string()),
   city: field(z.string()),
+  state: field(z.string()), // verification only — not stored; a mismatch flags a wrong park
   zipCode: field(z.string()),
   county: field(z.string()),
 

--- a/test/lib/ai/extraction-validator.test.ts
+++ b/test/lib/ai/extraction-validator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   validateExtraction,
   cleanStreetAddress,
+  cleanCounty,
 } from "@/lib/ai/extraction-validator";
 
 describe("validateExtraction", () => {
@@ -385,5 +386,36 @@ describe("cleanStreetAddress", () => {
 
   it("trims surrounding whitespace", () => {
     expect(cleanStreetAddress("  100 Ridge Road  ")).toBe("100 Ridge Road");
+  });
+});
+
+describe("cleanCounty", () => {
+  it("strips a trailing 'County'", () => {
+    expect(cleanCounty("Polk County")).toBe("Polk");
+  });
+
+  it("strips 'Parish' (Louisiana)", () => {
+    expect(cleanCounty("De Soto Parish")).toBe("De Soto");
+  });
+
+  it("strips 'Borough' and 'Census Area' (Alaska)", () => {
+    expect(cleanCounty("North Slope Borough")).toBe("North Slope");
+    expect(cleanCounty("Nome Census Area")).toBe("Nome");
+  });
+
+  it("is case-insensitive on the suffix", () => {
+    expect(cleanCounty("Polk COUNTY")).toBe("Polk");
+  });
+
+  it("leaves a bare county name unchanged", () => {
+    expect(cleanCounty("Polk")).toBe("Polk");
+  });
+
+  it("does not strip 'County' mid-name", () => {
+    expect(cleanCounty("County Line")).toBe("County Line");
+  });
+
+  it("trims whitespace", () => {
+    expect(cleanCounty("  Polk County  ")).toBe("Polk");
   });
 });

--- a/test/lib/ai/normalize-comparison.test.ts
+++ b/test/lib/ai/normalize-comparison.test.ts
@@ -66,6 +66,20 @@ describe("normalizeForComparison", () => {
     });
   });
 
+  describe("county", () => {
+    it("treats 'Polk County' the same as 'Polk'", () => {
+      expect(matches('"Polk County"', '"Polk"', "address.county")).toBe(true);
+    });
+
+    it("still distinguishes genuinely different counties", () => {
+      expect(matches('"Polk County"', '"Benton"', "address.county")).toBe(false);
+    });
+
+    it("does not strip the county suffix without the field hint", () => {
+      expect(matches('"Polk County"', '"Polk"')).toBe(false);
+    });
+  });
+
   describe("arrays", () => {
     it("is order-insensitive", () => {
       expect(matches('["rocks","sand"]', '["sand","rocks"]', "terrain")).toBe(


### PR DESCRIPTION
Three small extraction/ops improvements. No migration.

## 1. Seed script for domain reliability defaults
Wires up the existing but never-called `seedDomainReliability()` behind a script + npm command:
```bash
npm run db:seed-domains
```
Idempotent (create-only — never overwrites an admin-edited or auto-tuned score), so it's safe to run repeatedly. Seeds `riderplanet-usa.com`=90, `.gov`=85, `recreation.gov`=85, `alltrails`=70, `tripadvisor`=65, `facebook`/`fb`/`yelp`=60. **Run it once against prod** to give trusted sources their head start (right now the table is empty and everything falls back to 50).

## 2. Source-state verification (finishing item b)
The extractor now returns the state it reads from a source; the pipeline compares it to the park's known state (via `normalizeStateName`) and logs a **"possible wrong park"** session warning on mismatch. The state is used for **verification only** — never stored or applied (the park's state is set at creation).

## 3. County standardization
`cleanCounty()` strips a trailing `County` / `Parish` / `Borough` / `Census Area` / `Municipality`, so a source's **"Polk County" is stored — and compared — as just "Polk"**. That kills the redundant suggestions you were seeing when the park already has "Polk". Applied at extraction time, made comparison-aware for pre-existing data, and reinforced in the extractor prompt (name only).

## Testing
- `cleanCounty` (County/Parish/Borough/Census Area, case-insensitivity, mid-name safety) + county-aware comparison ("Polk County" == "Polk", but ≠ "Benton", and no-strip without the field hint).
- `npm test` full suite green (2259); `tsc` + ESLint clean.

> No schema change (`state` is added to the Zod extraction schema, not the Prisma model). Browser verification n/a in-env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)