### PR TITLE
feat(admin): responsive nav drawer + active states, AI Research to top

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,26 +2,8 @@ import { auth } from "@/lib/auth";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import {
-  Activity,
-  BrainCircuit,
-  Building2,
-  Camera,
-  ClipboardCheck,
-  ClipboardList,
-  FlaskConical,
-  Home,
-  Image as ImageIcon,
-  KeyRound,
-  LayoutDashboard,
-  LogOut,
-  MapPin,
-  MessageSquare,
-  PlusCircle,
-  Search,
-  Upload,
-  Users,
-} from "lucide-react";
+import { AdminNav } from "@/components/admin/AdminNav";
+import { LogOut } from "lucide-react";
 
 export default async function AdminLayout({
   children,
@@ -51,8 +33,8 @@ export default async function AdminLayout({
                 Admin Dashboard
               </h1>
             </div>
-            <div className="flex items-center gap-4">
-              <span className="text-sm text-muted-foreground">
+            <div className="flex items-center gap-3 sm:gap-4">
+              <span className="hidden sm:inline text-sm text-muted-foreground truncate max-w-[40vw]">
                 {session.user.email}
               </span>
               <ThemeToggle />
@@ -61,153 +43,16 @@ export default async function AdminLayout({
                 className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
               >
                 <LogOut className="w-4 h-4" />
-                Sign Out
+                <span className="hidden sm:inline">Sign Out</span>
               </Link>
             </div>
           </div>
         </div>
       </header>
 
-      <div className="flex max-w-7xl mx-auto">
-        {/* Sidebar */}
-        <aside className="w-64 bg-card border-r border-border min-h-[calc(100vh-4rem)]">
-          <nav className="p-4 space-y-2">
-            <Link
-              href="/"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Home className="w-5 h-5" />
-              <span className="font-medium">Return to Homepage</span>
-            </Link>
-            <div className="border-t border-border my-2"></div>
-            <Link
-              href="/admin/dashboard"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <LayoutDashboard className="w-5 h-5" />
-              <span className="font-medium">Dashboard</span>
-            </Link>
-            <Link
-              href="/admin/parks"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <MapPin className="w-5 h-5" />
-              <span className="font-medium">Parks</span>
-            </Link>
-            <Link
-              href="/admin/parks/new"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <PlusCircle className="w-5 h-5" />
-              <span className="font-medium">Add Park</span>
-            </Link>
-            <Link
-              href="/admin/parks/bulk-upload"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Upload className="w-5 h-5" />
-              <span className="font-medium">Bulk Upload</span>
-            </Link>
-            <Link
-              href="/admin/photos"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Camera className="w-5 h-5" />
-              <span className="font-medium">Photos</span>
-            </Link>
-            <Link
-              href="/admin/photos/bulk-upload"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <Upload className="w-4 h-4" />
-              <span className="font-medium text-sm">Bulk Photo Upload</span>
-            </Link>
-
-            <Link
-              href="/admin/conditions"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Activity className="w-5 h-5" />
-              <span className="font-medium">Trail Conditions</span>
-            </Link>
-            <Link
-              href="/admin/reviews"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <MessageSquare className="w-5 h-5" />
-              <span className="font-medium">Reviews</span>
-            </Link>
-            <Link
-              href="/admin/claims"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <ClipboardList className="w-5 h-5" />
-              <span className="font-medium">Park Claims</span>
-            </Link>
-            <Link
-              href="/admin/operators"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Building2 className="w-5 h-5" />
-              <span className="font-medium">Park Operators</span>
-            </Link>
-            <Link
-              href="/admin/map-heroes"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <ImageIcon className="w-5 h-5" />
-              <span className="font-medium">Map Heroes</span>
-            </Link>
-            <div className="border-t border-border my-2"></div>
-            <Link
-              href="/admin/ai-research"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <BrainCircuit className="w-5 h-5" />
-              <span className="font-medium">AI Research</span>
-            </Link>
-            <Link
-              href="/admin/ai-research/discovery"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <Search className="w-4 h-4" />
-              <span className="font-medium text-sm">Discover</span>
-            </Link>
-            <Link
-              href="/admin/ai-research/research"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <FlaskConical className="w-4 h-4" />
-              <span className="font-medium text-sm">Research</span>
-            </Link>
-            <Link
-              href="/admin/ai-research/review"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors pl-8"
-            >
-              <ClipboardCheck className="w-4 h-4" />
-              <span className="font-medium text-sm">Review</span>
-            </Link>
-            <Link
-              href="/admin/users"
-              className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-            >
-              <Users className="w-5 h-5" />
-              <span className="font-medium">Users</span>
-            </Link>
-            {isSuperAdmin && (
-              <Link
-                href="/admin/pre-grants"
-                className="flex items-center gap-3 px-4 py-3 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
-                <KeyRound className="w-5 h-5" />
-                <span className="font-medium">Pre-grants</span>
-              </Link>
-            )}
-          </nav>
-        </aside>
-
-        {/* Main Content */}
-        <main className="flex-1 p-8">{children}</main>
+      <div className="md:flex max-w-7xl mx-auto">
+        <AdminNav isSuperAdmin={isSuperAdmin} />
+        <main className="flex-1 min-w-0 p-4 sm:p-6 lg:p-8">{children}</main>
       </div>
     </div>
   );

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Activity,
+  BrainCircuit,
+  Building2,
+  Camera,
+  ClipboardList,
+  Home,
+  Image as ImageIcon,
+  KeyRound,
+  LayoutDashboard,
+  MapPin,
+  Menu,
+  MessageSquare,
+  PlusCircle,
+  Upload,
+  Users,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  superAdminOnly?: boolean;
+};
+
+// AI Research is near the top — it's the backbone of the app. Its sub-pages
+// (Discover/Research/Review) are reached via the in-page tab bar, so they're no
+// longer duplicated here.
+const NAV_ITEMS: NavItem[] = [
+  { href: "/admin/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/admin/ai-research", label: "AI Research", icon: BrainCircuit },
+  { href: "/admin/parks", label: "Parks", icon: MapPin },
+  { href: "/admin/parks/new", label: "Add Park", icon: PlusCircle },
+  { href: "/admin/parks/bulk-upload", label: "Bulk Upload", icon: Upload },
+  { href: "/admin/photos", label: "Photos", icon: Camera },
+  { href: "/admin/photos/bulk-upload", label: "Bulk Photo Upload", icon: Upload },
+  { href: "/admin/conditions", label: "Trail Conditions", icon: Activity },
+  { href: "/admin/reviews", label: "Reviews", icon: MessageSquare },
+  { href: "/admin/claims", label: "Park Claims", icon: ClipboardList },
+  { href: "/admin/operators", label: "Park Operators", icon: Building2 },
+  { href: "/admin/map-heroes", label: "Map Heroes", icon: ImageIcon },
+  { href: "/admin/users", label: "Users", icon: Users },
+  { href: "/admin/pre-grants", label: "Pre-grants", icon: KeyRound, superAdminOnly: true },
+];
+
+function NavList({
+  items,
+  activeHref,
+  onNavigate,
+}: {
+  items: NavItem[];
+  activeHref: string | undefined;
+  onNavigate: () => void;
+}) {
+  return (
+    <nav className="p-4 space-y-1">
+      <Link
+        href="/"
+        onClick={onNavigate}
+        className="flex items-center gap-3 px-4 py-2.5 text-foreground rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors"
+      >
+        <Home className="w-5 h-5" />
+        <span className="font-medium">Return to Homepage</span>
+      </Link>
+      <div className="border-t border-border my-2" />
+      {items.map(({ href, label, icon: Icon }) => {
+        const active = href === activeHref;
+        return (
+          <Link
+            key={href}
+            href={href}
+            onClick={onNavigate}
+            aria-current={active ? "page" : undefined}
+            className={`flex items-center gap-3 px-4 py-2.5 rounded-lg transition-colors ${
+              active
+                ? "bg-primary/10 text-primary font-semibold"
+                : "text-foreground hover:bg-accent hover:text-accent-foreground font-medium"
+            }`}
+          >
+            <Icon className="w-5 h-5 flex-shrink-0" />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function AdminNav({ isSuperAdmin }: { isSuperAdmin: boolean }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const items = NAV_ITEMS.filter((i) => !i.superAdminOnly || isSuperAdmin);
+
+  // Most-specific match wins, so "/admin/parks/new" highlights Add Park (not Parks).
+  const activeHref = items
+    .map((i) => i.href)
+    .filter((h) => pathname === h || pathname.startsWith(`${h}/`))
+    .sort((a, b) => b.length - a.length)[0];
+
+  return (
+    <>
+      {/* Mobile top bar with hamburger (hidden on desktop) */}
+      <div className="md:hidden flex items-center gap-3 border-b border-border bg-card px-4 py-2">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Open navigation menu"
+          className="inline-flex items-center justify-center rounded-lg p-2 text-foreground hover:bg-accent transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <span className="text-sm font-medium text-foreground">Admin menu</span>
+      </div>
+
+      {/* Persistent desktop sidebar */}
+      <aside className="hidden md:block w-64 flex-shrink-0 bg-card border-r border-border min-h-[calc(100vh-4rem)]">
+        <NavList items={items} activeHref={activeHref} onNavigate={() => setOpen(false)} />
+      </aside>
+
+      {/* Mobile drawer + backdrop */}
+      {open && (
+        <div className="md:hidden fixed inset-0 z-50" role="dialog" aria-modal="true">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <aside className="absolute inset-y-0 left-0 w-72 max-w-[80%] bg-card border-r border-border overflow-y-auto shadow-xl">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <span className="font-semibold text-foreground">Admin menu</span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close navigation menu"
+                className="inline-flex items-center justify-center rounded-lg p-2 text-foreground hover:bg-accent transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <NavList items={items} activeHref={activeHref} onNavigate={() => setOpen(false)} />
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}

--- a/test/components/admin/AdminNav.test.tsx
+++ b/test/components/admin/AdminNav.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { vi } from "vitest";
+import { AdminNav } from "@/components/admin/AdminNav";
+
+let mockPathname = "/admin/dashboard";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+describe("AdminNav", () => {
+  beforeEach(() => {
+    mockPathname = "/admin/dashboard";
+  });
+
+  it("renders the core nav items", () => {
+    render(<AdminNav isSuperAdmin={false} />);
+    expect(screen.getByRole("link", { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /ai research/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^parks$/i })).toBeInTheDocument();
+  });
+
+  it("hides Pre-grants from non-super-admins", () => {
+    render(<AdminNav isSuperAdmin={false} />);
+    expect(
+      screen.queryByRole("link", { name: /pre-grants/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Pre-grants to super admins", () => {
+    render(<AdminNav isSuperAdmin={true} />);
+    expect(
+      screen.getByRole("link", { name: /pre-grants/i })
+    ).toBeInTheDocument();
+  });
+
+  it("marks AI Research active on its sub-routes (most-specific match)", () => {
+    mockPathname = "/admin/ai-research/discovery";
+    render(<AdminNav isSuperAdmin={false} />);
+    expect(screen.getByRole("link", { name: /ai research/i })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    // Parks is not active while under the AI Research section.
+    expect(
+      screen.getByRole("link", { name: /^parks$/i })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("marks Add Park (not Parks) active on /admin/parks/new", () => {
+    mockPathname = "/admin/parks/new";
+    render(<AdminNav isSuperAdmin={false} />);
+    expect(screen.getByRole("link", { name: /add park/i })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(
+      screen.getByRole("link", { name: /^parks$/i })
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("opens and closes the mobile drawer", () => {
+    render(<AdminNav isSuperAdmin={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /open navigation menu/i })
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    // Drawer contains its own nav links.
+    expect(
+      within(dialog).getByRole("link", { name: /dashboard/i })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(dialog).getByRole("button", { name: /close navigation menu/i })
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the drawer when a nav link is clicked", () => {
+    render(<AdminNav isSuperAdmin={false} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /open navigation menu/i })
+    );
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("link", { name: /photos/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
First step of the admin-panel restructure — the navigation shell.

## Changes
- **Mobile-friendly nav (a):** the fixed `w-64` sidebar (which ate half a phone screen) becomes a **hamburger + slide-in drawer** with a backdrop that closes on link click; the persistent sidebar stays on `md+`. Header hides the email / "Sign Out" text on the smallest screens; `main` gets responsive padding + `min-w-0` so wide tables scroll instead of blowing out the layout.
- **Active-state highlighting** via `usePathname` — previously there was none. Uses most-specific match, so `/admin/parks/new` highlights **Add Park**, not Parks.
- **AI Research moved to the top (h)** — it's the backbone — and its `Discover / Research / Review` sidebar sub-items are **dropped**, since every AI page already renders the in-page tab bar (removes duplicated navigation).

Nav is extracted into a client component ([`AdminNav.tsx`](src/components/admin/AdminNav.tsx)); [`layout.tsx`](src/app/admin/layout.tsx) stays a server component for the auth gate.

## Testing
Component tests: active state on sub-routes, most-specific match (Add Park vs Parks), super-admin gating of Pre-grants, drawer open/close + close-on-navigate. `npm test` green (2266); `tsc` + ESLint clean.

> Consolidation of the now-redundant tabs (Add Park, Bulk Upload, Bulk Photo Upload, Map Heroes → buttons/sections; Users/Operators/Pre-grants → People & Access) lands in follow-up PRs. Browser verification n/a in-env (auth-gated admin, no local DB) — verified via component tests.

Part of the admin restructure (a, h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)