### PR TITLE
feat(admin): unify Users, Operators, Pre-grants into People & Access

### DIFF
--- a/src/app/admin/operators/page.tsx
+++ b/src/app/admin/operators/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
+import { PeopleTabs } from "@/components/admin/PeopleTabs";
 import {
   OperatorManagementClient,
   type AdminOperatorRow,
@@ -12,6 +13,7 @@ export default async function AdminOperatorsPage() {
   if (role !== "ADMIN" && role !== "SUPER_ADMIN") {
     redirect("/");
   }
+  const isSuperAdmin = role === "SUPER_ADMIN";
 
   const operators = await prisma.operator.findMany({
     orderBy: { createdAt: "desc" },
@@ -59,8 +61,8 @@ export default async function AdminOperatorsPage() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-foreground mb-2">Park Operators</h1>
-      <p className="text-sm text-muted-foreground mb-8">
+      <PeopleTabs isSuperAdmin={isSuperAdmin} />
+      <p className="text-sm text-muted-foreground mb-6">
         Manage operator accounts: create operators, attach/detach parks, and
         add or remove users. Normally operators are created through the
         Park Claims flow — this surface is for direct maintenance.

--- a/src/app/admin/pre-grants/page.tsx
+++ b/src/app/admin/pre-grants/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
+import { PeopleTabs } from "@/components/admin/PeopleTabs";
 import { PreGrantManagementClient, type PreGrantRow } from "./PreGrantManagementClient";
 
 export default async function AdminPreGrantsPage() {
@@ -26,8 +27,8 @@ export default async function AdminPreGrantsPage() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-foreground mb-2">Pre-grants</h1>
-      <p className="text-sm text-muted-foreground mb-8">
+      <PeopleTabs isSuperAdmin={true} />
+      <p className="text-sm text-muted-foreground mb-6">
         Declare a role and/or operator membership for an email so it is applied
         automatically on their first sign-in. Useful for onboarding beta
         testers without making them go through the claim flow.

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { PeopleTabs } from "@/components/admin/PeopleTabs";
 import {
   UserManagementTable,
   type AssignableRole,
@@ -29,8 +30,8 @@ export default async function AdminUsersPage() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-foreground mb-2">User Management</h1>
-      <p className="text-sm text-muted-foreground mb-8">
+      <PeopleTabs isSuperAdmin={canEditRoles} />
+      <p className="text-sm text-muted-foreground mb-6">
         {canEditRoles
           ? "As a super admin, you can promote or demote users."
           : "Only the super admin can change user roles."}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -6,11 +6,9 @@ import { usePathname } from "next/navigation";
 import {
   Activity,
   BrainCircuit,
-  Building2,
   Camera,
   ClipboardList,
   Home,
-  KeyRound,
   LayoutDashboard,
   MapPin,
   Menu,
@@ -25,6 +23,8 @@ type NavItem = {
   label: string;
   icon: LucideIcon;
   superAdminOnly?: boolean;
+  /** Extra routes that should also mark this item active. */
+  match?: string[];
 };
 
 // AI Research is near the top — it's the backbone of the app. Its sub-pages
@@ -38,9 +38,12 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/admin/conditions", label: "Trail Conditions", icon: Activity },
   { href: "/admin/reviews", label: "Reviews", icon: MessageSquare },
   { href: "/admin/claims", label: "Park Claims", icon: ClipboardList },
-  { href: "/admin/operators", label: "Park Operators", icon: Building2 },
-  { href: "/admin/users", label: "Users", icon: Users },
-  { href: "/admin/pre-grants", label: "Pre-grants", icon: KeyRound, superAdminOnly: true },
+  {
+    href: "/admin/users",
+    label: "People & Access",
+    icon: Users,
+    match: ["/admin/operators", "/admin/pre-grants"],
+  },
 ];
 
 function NavList({
@@ -92,11 +95,17 @@ export function AdminNav({ isSuperAdmin }: { isSuperAdmin: boolean }) {
 
   const items = NAV_ITEMS.filter((i) => !i.superAdminOnly || isSuperAdmin);
 
-  // Most-specific match wins, so "/admin/parks/new" highlights Add Park (not Parks).
-  const activeHref = items
-    .map((i) => i.href)
-    .filter((h) => pathname === h || pathname.startsWith(`${h}/`))
-    .sort((a, b) => b.length - a.length)[0];
+  // Longest matching route (across each item's href + `match` list) wins, so
+  // "/admin/parks/new" highlights Parks and "/admin/operators" highlights People.
+  const matchLen = (item: NavItem): number => {
+    const lens = [item.href, ...(item.match ?? [])]
+      .filter((h) => pathname === h || pathname.startsWith(`${h}/`))
+      .map((h) => h.length);
+    return lens.length ? Math.max(...lens) : -1;
+  };
+  const activeHref = [...items]
+    .filter((i) => matchLen(i) >= 0)
+    .sort((a, b) => matchLen(b) - matchLen(a))[0]?.href;
 
   return (
     <>

--- a/src/components/admin/PeopleTabs.tsx
+++ b/src/components/admin/PeopleTabs.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Users, Building2, KeyRound, type LucideIcon } from "lucide-react";
+
+type Tab = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  superAdminOnly?: boolean;
+};
+
+const TABS: Tab[] = [
+  { href: "/admin/users", label: "Users", icon: Users },
+  { href: "/admin/operators", label: "Operators", icon: Building2 },
+  { href: "/admin/pre-grants", label: "Pre-grants", icon: KeyRound, superAdminOnly: true },
+];
+
+/**
+ * Shared header + tab bar for the People & Access section (Users, Operators,
+ * Pre-grants). Pre-grants is SUPER_ADMIN-only. Rendered at the top of each of
+ * the three pages so they read as one section.
+ */
+export function PeopleTabs({ isSuperAdmin }: { isSuperAdmin: boolean }) {
+  const pathname = usePathname();
+  const tabs = TABS.filter((t) => !t.superAdminOnly || isSuperAdmin);
+
+  return (
+    <div className="mb-6">
+      <h1 className="text-2xl font-bold text-foreground mb-1">People &amp; Access</h1>
+      <p className="text-sm text-muted-foreground mb-4">
+        Manage user roles, operator accounts, and pre-granted access.
+      </p>
+      <div className="border-b border-border">
+        <nav className="flex gap-1 -mb-px overflow-x-auto" aria-label="People sections">
+          {tabs.map((tab) => {
+            const active = pathname === tab.href;
+            const Icon = tab.icon;
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                aria-current={active ? "page" : undefined}
+                className={`inline-flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+                  active
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                {tab.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/UserManagementTable.tsx
+++ b/src/components/admin/UserManagementTable.tsx
@@ -76,6 +76,38 @@ export function UserManagementTable({
     }
   }
 
+  // Role select (editable) or badge (read-only) — shared by table + cards.
+  const renderRoleControl = (user: ManagedUser) => {
+    const isSelf = user.id === currentUserId;
+    const isSaving = savingId === user.id || pending;
+    if (!canEditRoles) {
+      return (
+        <span
+          className={`px-2 py-1 text-xs font-medium rounded-full ${roleBadgeClass(user.role)}`}
+        >
+          {user.role}
+        </span>
+      );
+    }
+    return (
+      <select
+        aria-label={`Role for ${user.email ?? user.id}`}
+        disabled={isSaving}
+        value={user.role}
+        onChange={(e) =>
+          handleRoleChange(user.id, e.target.value as AssignableRole)
+        }
+        className="text-xs font-medium rounded-md border border-border bg-background px-2 py-1 disabled:opacity-50"
+      >
+        {ASSIGNABLE_ROLES.map((r) => (
+          <option key={r} value={r} disabled={isSelf && r !== "SUPER_ADMIN"}>
+            {r}
+          </option>
+        ))}
+      </select>
+    );
+  };
+
   return (
     <div className="space-y-4">
       {error && (
@@ -88,7 +120,7 @@ export function UserManagementTable({
       )}
 
       <div className="bg-card rounded-lg shadow border border-border overflow-hidden">
-        <div className="overflow-x-auto">
+        <div className="hidden md:block overflow-x-auto">
           <table className="min-w-full divide-y divide-border">
             <thead className="bg-muted/50">
               <tr>
@@ -111,8 +143,6 @@ export function UserManagementTable({
             </thead>
             <tbody className="bg-card divide-y divide-border">
               {users.map((user) => {
-                const isSelf = user.id === currentUserId;
-                const isSaving = savingId === user.id || pending;
                 return (
                   <tr
                     key={user.id}
@@ -134,42 +164,7 @@ export function UserManagementTable({
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      {canEditRoles ? (
-                        <label className="sr-only" htmlFor={`role-${user.id}`}>
-                          Role for {user.email ?? user.id}
-                        </label>
-                      ) : null}
-                      {canEditRoles ? (
-                        <select
-                          id={`role-${user.id}`}
-                          aria-label={`Role for ${user.email ?? user.id}`}
-                          disabled={isSaving}
-                          value={user.role}
-                          onChange={(e) =>
-                            handleRoleChange(
-                              user.id,
-                              e.target.value as AssignableRole,
-                            )
-                          }
-                          className="text-xs font-medium rounded-md border border-border bg-background px-2 py-1 disabled:opacity-50"
-                        >
-                          {ASSIGNABLE_ROLES.map((r) => (
-                            <option
-                              key={r}
-                              value={r}
-                              disabled={isSelf && r !== "SUPER_ADMIN"}
-                            >
-                              {r}
-                            </option>
-                          ))}
-                        </select>
-                      ) : (
-                        <span
-                          className={`px-2 py-1 text-xs font-medium rounded-full ${roleBadgeClass(user.role)}`}
-                        >
-                          {user.role}
-                        </span>
-                      )}
+                      {renderRoleControl(user)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-muted-foreground">
                       {user.submittedParkCount}
@@ -182,6 +177,34 @@ export function UserManagementTable({
               })}
             </tbody>
           </table>
+        </div>
+
+        {/* Mobile card layout */}
+        <div className="md:hidden divide-y divide-border">
+          {users.map((user) => (
+            <div key={user.id} className="p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                    <UsersIcon className="w-4 h-4 text-muted-foreground" />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-foreground truncate">
+                      {user.name || "Anonymous"}
+                    </div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {user.email}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex-shrink-0">{renderRoleControl(user)}</div>
+              </div>
+              <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+                <span>{user.submittedParkCount} parks submitted</span>
+                <span>Joined {new Date(user.createdAt).toLocaleDateString()}</span>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/test/components/admin/AdminNav.test.tsx
+++ b/test/components/admin/AdminNav.test.tsx
@@ -19,18 +19,26 @@ describe("AdminNav", () => {
     expect(screen.getByRole("link", { name: /^parks$/i })).toBeInTheDocument();
   });
 
-  it("hides Pre-grants from non-super-admins", () => {
+  it("shows a single People & Access entry (Users/Operators/Pre-grants are tabs)", () => {
     render(<AdminNav isSuperAdmin={false} />);
+    expect(
+      screen.getByRole("link", { name: /people & access/i })
+    ).toBeInTheDocument();
+    // The individual pages are no longer separate top-level nav items.
     expect(
       screen.queryByRole("link", { name: /pre-grants/i })
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /park operators/i })
+    ).not.toBeInTheDocument();
   });
 
-  it("shows Pre-grants to super admins", () => {
+  it("marks People & Access active on Operators and Pre-grants routes", () => {
+    mockPathname = "/admin/operators";
     render(<AdminNav isSuperAdmin={true} />);
     expect(
-      screen.getByRole("link", { name: /pre-grants/i })
-    ).toBeInTheDocument();
+      screen.getByRole("link", { name: /people & access/i })
+    ).toHaveAttribute("aria-current", "page");
   });
 
   it("marks AI Research active on its sub-routes (most-specific match)", () => {

--- a/test/components/admin/UserManagementTable.test.tsx
+++ b/test/components/admin/UserManagementTable.test.tsx
@@ -1,10 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   UserManagementTable,
   type ManagedUser,
 } from "@/components/admin/UserManagementTable";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Renders as a desktop table + a mobile card list (jsdom applies no CSS, so both
+// are present). Scope role/badge assertions to the desktop table.
+const inTable = () => within(screen.getByRole("table"));
 
 const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
@@ -60,9 +64,9 @@ describe("UserManagementTable", () => {
       />,
     );
 
-    expect(screen.getByText("USER")).toBeInTheDocument();
-    expect(screen.getByText("ADMIN")).toBeInTheDocument();
-    expect(screen.getByText("SUPER_ADMIN")).toBeInTheDocument();
+    expect(inTable().getByText("USER")).toBeInTheDocument();
+    expect(inTable().getByText("ADMIN")).toBeInTheDocument();
+    expect(inTable().getByText("SUPER_ADMIN")).toBeInTheDocument();
     expect(screen.queryAllByRole("combobox")).toHaveLength(0);
   });
 
@@ -75,7 +79,7 @@ describe("UserManagementTable", () => {
       />,
     );
 
-    expect(screen.getAllByRole("combobox")).toHaveLength(3);
+    expect(inTable().getAllByRole("combobox")).toHaveLength(3);
   });
 
   it("disables non-SUPER_ADMIN options for the current viewer (no self-demote)", () => {
@@ -87,7 +91,7 @@ describe("UserManagementTable", () => {
       />,
     );
 
-    const ownSelect = screen.getByLabelText(
+    const ownSelect = inTable().getByLabelText(
       "Role for mike.sassatelli@gmail.com",
     ) as HTMLSelectElement;
     const options = Array.from(ownSelect.querySelectorAll("option"));
@@ -109,7 +113,7 @@ describe("UserManagementTable", () => {
       />,
     );
 
-    const aliceSelect = screen.getByLabelText("Role for alice@example.com");
+    const aliceSelect = inTable().getByLabelText("Role for alice@example.com");
     await user.selectOptions(aliceSelect, "ADMIN");
 
     expect(mockFetch).toHaveBeenCalledWith("/api/admin/users/u1/role", {
@@ -137,7 +141,7 @@ describe("UserManagementTable", () => {
       />,
     );
 
-    const bobSelect = screen.getByLabelText("Role for bob@example.com");
+    const bobSelect = inTable().getByLabelText("Role for bob@example.com");
     await user.selectOptions(bobSelect, "USER");
 
     await waitFor(() =>


### PR DESCRIPTION
Admin restructure, step 4 — People & Access (g).

## Changes
- **Combined section:** a shared [`PeopleTabs`](src/components/admin/PeopleTabs.tsx) bar (Users · Operators · Pre-grants) renders at the top of each of the three pages, so they read as one section. **Pre-grants is SUPER_ADMIN-only** (the page also still redirects non-super-admins). The three routes stay in place, so the large co-located Operator/Pre-grant client components don't have to move.
- **Nav:** the three separate sidebar entries (Park Operators, Users, Pre-grants) collapse into a single **"People & Access"** item. `AdminNav` active-state now supports a `match` list, so People highlights on `/admin/operators` and `/admin/pre-grants` too.
- **Mobile (a):** `UserManagementTable` gets a card layout below `md` (avatar + email + role control, with parks/joined below). The role select/badge is extracted to a shared renderer and the duplicate-id `<label>` dropped in favor of `aria-label`.

The sidebar is now ~8 top-level items (from 17 at the start).

## Testing
- `AdminNav` test: single People entry, individual pages no longer top-level, People active on Operators/Pre-grants routes.
- Users table assertions scoped to the desktop table (dual layout under jsdom).
- `npm test` green (2266); `tsc` + ESLint clean.

## Follow-up
Operators uses `OperatorManagementClient`, a management *panel* (create/attach/add flows) rather than a plain data table, and already uses `flex-wrap` toolbars — I left its mobile layout as-is here rather than force it into cards. Happy to give it a dedicated mobile pass if you want. Last step: the expanded dashboard with charts (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)