### PR TITLE
feat(admin): rebuild dashboard around queues, AI health, and trend charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-leaflet": "^5.0.0",
+        "recharts": "^3.10.0",
         "resend": "^6.17.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
@@ -3486,6 +3487,32 @@
         "react-dom": "^19.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.43",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.43.tgz",
@@ -4518,6 +4545,12 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -4974,6 +5007,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5070,6 +5166,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -7263,6 +7365,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7370,6 +7593,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -7844,6 +8073,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -8360,7 +8599,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -9163,6 +9401,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9233,6 +9481,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -11978,7 +12235,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-leaflet": {
@@ -11993,6 +12249,29 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -12087,6 +12366,36 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.0.tgz",
+      "integrity": "sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12099,6 +12408,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12176,6 +12500,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resend": {
       "version": "6.17.2",
@@ -13235,6 +13565,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -13758,6 +14094,37 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-leaflet": "^5.0.0",
+    "recharts": "^3.10.0",
     "resend": "^6.17.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,127 +1,196 @@
 import { prisma } from "@/lib/prisma";
-import { Activity, Camera, CheckCircle, Clock, MapPin, MessageSquare } from "lucide-react";
+import {
+  Activity,
+  BrainCircuit,
+  Camera,
+  ClipboardCheck,
+  ClipboardList,
+  Clock,
+  FlaskConical,
+  Layers,
+  MessageSquare,
+} from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import {
+  DashboardCharts,
+  type SeriesPoint,
+} from "@/components/admin/DashboardCharts";
+
+export const dynamic = "force-dynamic";
+
+const MS_WEEK = 7 * 24 * 60 * 60 * 1000;
+const WEEKS = 12;
+
+// Bucket timestamps into the last `WEEKS` weekly buckets (oldest → newest).
+function weeklyBuckets(dates: Date[], now: Date): SeriesPoint[] {
+  const buckets: SeriesPoint[] = Array.from({ length: WEEKS }, (_, i) => {
+    const end = new Date(now.getTime() - (WEEKS - 1 - i) * MS_WEEK);
+    return { label: `${end.getMonth() + 1}/${end.getDate()}`, count: 0 };
+  });
+  for (const d of dates) {
+    const weeksAgo = Math.floor((now.getTime() - d.getTime()) / MS_WEEK);
+    const idx = WEEKS - 1 - weeksAgo;
+    if (idx >= 0 && idx < WEEKS) buckets[idx].count++;
+  }
+  return buckets;
+}
 
 export default async function AdminDashboard() {
-  // Fetch statistics
-  const [totalParks, pendingParks, totalUsers, pendingPhotos, pendingReviews, pendingConditions] =
-    await Promise.all([
-      prisma.park.count(),
-      prisma.park.count({ where: { status: "PENDING" } }),
-      prisma.user.count(),
-      prisma.parkPhoto.count({ where: { status: "PENDING" } }),
-      prisma.parkReview.count({ where: { status: "PENDING" } }),
-      prisma.trailCondition.count({ where: { reportStatus: "PENDING_REVIEW" } }),
-    ]);
+  const now = new Date();
+  const since = new Date(now.getTime() - WEEKS * MS_WEEK);
 
-  // Get recent pending parks
-  const recentPendingParks = await prisma.park.findMany({
-    where: { status: "PENDING" },
-    orderBy: { createdAt: "desc" },
-    take: 5,
-    select: {
-      id: true,
-      name: true,
-      createdAt: true,
-      submitterName: true,
-      address: {
-        select: {
-          city: true,
-          state: true,
-        },
+  const [
+    pendingParks,
+    pendingPhotos,
+    pendingReviews,
+    pendingConditions,
+    pendingClaims,
+    pendingFieldReviews,
+    researchQueued,
+    needsResearch,
+    inProgress,
+    partial,
+    researched,
+    totalSessions,
+    costAgg,
+    parkDates,
+    sessionDates,
+    recentPendingParks,
+    recentPhotos,
+  ] = await Promise.all([
+    prisma.park.count({ where: { status: "PENDING" } }),
+    prisma.parkPhoto.count({ where: { status: "PENDING" } }),
+    prisma.parkReview.count({ where: { status: "PENDING" } }),
+    prisma.trailCondition.count({ where: { reportStatus: "PENDING_REVIEW" } }),
+    prisma.parkClaim.count({ where: { status: "PENDING" } }),
+    prisma.fieldExtraction.count({ where: { status: "PENDING_REVIEW" } }),
+    prisma.park.count({ where: { researchQueuedAt: { not: null } } }),
+    prisma.park.count({ where: { researchStatus: "NEEDS_RESEARCH" } }),
+    prisma.park.count({ where: { researchStatus: "IN_PROGRESS" } }),
+    prisma.park.count({ where: { researchStatus: "PARTIAL" } }),
+    prisma.park.count({ where: { researchStatus: "RESEARCHED" } }),
+    prisma.researchSession.count(),
+    prisma.researchSession.aggregate({ _sum: { estimatedCostUSD: true } }),
+    prisma.park.findMany({
+      where: { createdAt: { gte: since } },
+      select: { createdAt: true },
+    }),
+    prisma.researchSession.findMany({
+      where: { createdAt: { gte: since } },
+      select: { createdAt: true },
+    }),
+    prisma.park.findMany({
+      where: { status: "PENDING" },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        submitterName: true,
+        address: { select: { city: true, state: true } },
       },
-    },
-  });
+    }),
+    prisma.parkPhoto.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 8,
+      include: {
+        park: { select: { name: true, slug: true } },
+        user: { select: { name: true } },
+      },
+    }),
+  ]);
 
-  // Get recent photos (all statuses)
-  const recentPhotos = await prisma.parkPhoto.findMany({
-    orderBy: { createdAt: "desc" },
-    take: 8,
-    include: {
-      park: {
-        select: {
-          name: true,
-          slug: true,
-        },
-      },
-      user: {
-        select: {
-          name: true,
-        },
-      },
-    },
-  });
+  const totalCost = costAgg._sum.estimatedCostUSD ?? 0;
+  const parksPerWeek = weeklyBuckets(
+    parkDates.map((p) => p.createdAt),
+    now
+  );
+  const sessionsPerWeek = weeklyBuckets(
+    sessionDates.map((s) => s.createdAt),
+    now
+  );
 
-  const stats = [
-    {
-      name: "Total Parks",
-      value: totalParks,
-      icon: MapPin,
-      color: "bg-blue-500",
-    },
-    {
-      name: "Pending Parks",
-      value: pendingParks,
-      icon: Clock,
-      color: "bg-yellow-500",
-    },
-    {
-      name: "Pending Photos",
-      value: pendingPhotos,
-      icon: Camera,
-      color: "bg-purple-500",
-    },
-    {
-      name: "Pending Reviews",
-      value: pendingReviews,
-      icon: MessageSquare,
-      color: "bg-orange-500",
-    },
-    {
-      name: "Pending Conditions",
-      value: pendingConditions,
-      icon: Activity,
-      color: "bg-teal-500",
-    },
-    {
-      name: "Total Users",
-      value: totalUsers,
-      icon: CheckCircle,
-      color: "bg-green-500",
-    },
+  const queues = [
+    { label: "Pending parks", value: pendingParks, href: "/admin/parks?status=pending", icon: Clock },
+    { label: "Field reviews", value: pendingFieldReviews, href: "/admin/ai-research/review", icon: ClipboardCheck },
+    { label: "Pending photos", value: pendingPhotos, href: "/admin/photos", icon: Camera },
+    { label: "Pending reviews", value: pendingReviews, href: "/admin/reviews", icon: MessageSquare },
+    { label: "Trail conditions", value: pendingConditions, href: "/admin/conditions", icon: Activity },
+    { label: "Park claims", value: pendingClaims, href: "/admin/claims", icon: ClipboardList },
+    { label: "Research queue", value: researchQueued, href: "/admin/ai-research/research", icon: Layers },
+    { label: "Needs research", value: needsResearch, href: "/admin/ai-research/research?status=NEEDS_RESEARCH", icon: FlaskConical },
   ];
 
   return (
-    <div>
-      <h1 className="text-3xl font-bold text-foreground mb-8">Dashboard</h1>
+    <div className="space-y-8">
+      <h1 className="text-2xl sm:text-3xl font-bold text-foreground">Dashboard</h1>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        {stats.map((stat) => {
-          const Icon = stat.icon;
-          return (
-            <div
-              key={stat.name}
-              className="bg-card rounded-lg shadow p-6 border border-border"
+      {/* Needs attention */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+          Needs attention
+        </h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {queues.map(({ label, value, href, icon: Icon }) => (
+            <Link
+              key={label}
+              href={href}
+              className={`rounded-lg border bg-card p-4 transition-colors hover:bg-accent ${
+                value > 0 ? "border-primary/40" : "border-border"
+              }`}
             >
               <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-muted-foreground">
-                    {stat.name}
-                  </p>
-                  <p className="text-3xl font-bold text-foreground mt-2">
-                    {stat.value}
-                  </p>
-                </div>
-                <div className={`${stat.color} rounded-full p-3`}>
-                  <Icon className="w-6 h-6 text-white" />
-                </div>
+                <span className="text-sm text-muted-foreground">{label}</span>
+                <Icon className="w-4 h-4 text-muted-foreground" />
               </div>
-            </div>
-          );
-        })}
-      </div>
+              <p
+                className={`mt-2 text-2xl font-bold ${
+                  value > 0 ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                {value}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* AI pipeline health */}
+      <section className="rounded-lg border border-border bg-card p-4 sm:p-6">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <BrainCircuit className="w-5 h-5 text-primary" />
+            AI data pipeline
+          </h2>
+          <Link
+            href="/admin/ai-research"
+            className="text-sm text-primary hover:text-primary/80 font-medium"
+          >
+            Open AI Research →
+          </Link>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          <PipelineStat label="Needs research" value={needsResearch} tone="warn" />
+          <PipelineStat label="In progress" value={inProgress} tone="neutral" />
+          <PipelineStat label="Partial" value={partial} tone="warn" />
+          <PipelineStat label="Researched" value={researched} tone="success" />
+          <PipelineStat label="Sessions" value={totalSessions} tone="muted" />
+          <PipelineStat label="Total cost" value={`$${totalCost.toFixed(2)}`} tone="muted" />
+        </div>
+      </section>
+
+      {/* Trends */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+          Trends
+        </h2>
+        <DashboardCharts
+          parksPerWeek={parksPerWeek}
+          sessionsPerWeek={sessionsPerWeek}
+        />
+      </section>
 
       {/* Recent Pending Parks */}
       <div className="bg-card rounded-lg shadow border border-border">
@@ -137,13 +206,10 @@ export default async function AdminDashboard() {
             </div>
           ) : (
             recentPendingParks.map((park) => (
-              <div
-                key={park.id}
-                className="p-6 hover:bg-accent/50 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="text-lg font-medium text-foreground">
+              <div key={park.id} className="p-6 hover:bg-accent/50 transition-colors">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="text-lg font-medium text-foreground truncate">
                       {park.name}
                     </h3>
                     <p className="text-sm text-muted-foreground">
@@ -157,7 +223,7 @@ export default async function AdminDashboard() {
                   </div>
                   <a
                     href={`/admin/parks?highlight=${park.id}`}
-                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+                    className="flex-shrink-0 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
                   >
                     Review
                   </a>
@@ -169,7 +235,7 @@ export default async function AdminDashboard() {
       </div>
 
       {/* Recent Photos */}
-      <div className="mt-8 bg-card rounded-lg shadow border border-border">
+      <div className="bg-card rounded-lg shadow border border-border">
         <div className="p-6 border-b border-border flex items-center justify-between">
           <h2 className="text-xl font-semibold text-foreground">Recent Photos</h2>
           <Link
@@ -208,18 +274,13 @@ export default async function AdminDashboard() {
                         {photo.park.name}
                       </p>
                       <p className="text-xs opacity-90">
-                        {
-                          /* v8 ignore next - Display text only, all statuses tested via E2E */
-                          photo.status === "PENDING"
-                            ? "⏳ Pending"
-                            : /* v8 ignore next */
-                              photo.status === "APPROVED"
-                              ? "✓ Approved"
-                              : /* v8 ignore next */
-                                photo.status === "REJECTED"
-                                ? "✗ Rejected"
-                                : null
-                        }
+                        {photo.status === "PENDING"
+                          ? "⏳ Pending"
+                          : photo.status === "APPROVED"
+                            ? "✓ Approved"
+                            : photo.status === "REJECTED"
+                              ? "✗ Rejected"
+                              : null}
                       </p>
                     </div>
                   </div>
@@ -229,6 +290,29 @@ export default async function AdminDashboard() {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function PipelineStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number | string;
+  tone: "neutral" | "success" | "warn" | "muted";
+}) {
+  const toneClass = {
+    neutral: "text-foreground",
+    success: "text-green-700 dark:text-green-400",
+    warn: "text-orange-700 dark:text-orange-400",
+    muted: "text-muted-foreground",
+  }[tone];
+  return (
+    <div className="rounded-lg border border-border bg-background p-3">
+      <div className={`text-xl font-bold ${toneClass}`}>{value}</div>
+      <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
     </div>
   );
 }

--- a/src/components/admin/DashboardCharts.tsx
+++ b/src/components/admin/DashboardCharts.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export type SeriesPoint = { label: string; count: number };
+
+const axisTick = { fontSize: 12, fill: "var(--muted-foreground)" };
+const tooltipStyle = {
+  background: "var(--card)",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  color: "var(--foreground)",
+  fontSize: 12,
+};
+
+export function DashboardCharts({
+  parksPerWeek,
+  sessionsPerWeek,
+}: {
+  parksPerWeek: SeriesPoint[];
+  sessionsPerWeek: SeriesPoint[];
+}) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <ChartCard title="Parks added" subtitle="per week · last 12 weeks">
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart
+            data={parksPerWeek}
+            margin={{ top: 8, right: 8, left: -16, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={axisTick}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={axisTick}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+              width={32}
+            />
+            <Tooltip
+              contentStyle={tooltipStyle}
+              cursor={{ fill: "var(--accent)" }}
+            />
+            <Bar
+              dataKey="count"
+              name="Parks"
+              fill="var(--chart-1)"
+              radius={[4, 4, 0, 0]}
+              maxBarSize={28}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <ChartCard title="Research sessions" subtitle="per week · last 12 weeks">
+        <ResponsiveContainer width="100%" height={220}>
+          <AreaChart
+            data={sessionsPerWeek}
+            margin={{ top: 8, right: 8, left: -16, bottom: 0 }}
+          >
+            <defs>
+              <linearGradient id="sessionFill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--chart-2)" stopOpacity={0.35} />
+                <stop offset="100%" stopColor="var(--chart-2)" stopOpacity={0.03} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--border)"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={axisTick}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={axisTick}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+              width={32}
+            />
+            <Tooltip
+              contentStyle={tooltipStyle}
+              cursor={{ stroke: "var(--border)" }}
+            />
+            <Area
+              type="monotone"
+              dataKey="count"
+              name="Sessions"
+              stroke="var(--chart-2)"
+              strokeWidth={2}
+              fill="url(#sessionFill)"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-card rounded-lg border border-border p-4">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/test/app/admin/dashboard/page.test.tsx
+++ b/test/app/admin/dashboard/page.test.tsx
@@ -3,27 +3,21 @@ import AdminDashboard from "@/app/admin/dashboard/page";
 import { prisma } from "@/lib/prisma";
 import { vi } from "vitest";
 
-// Mock dependencies
 vi.mock("@/lib/prisma", () => ({
   prisma: {
-    park: {
-      count: vi.fn(),
-      findMany: vi.fn(),
-    },
-    user: {
-      count: vi.fn(),
-    },
-    parkPhoto: {
-      count: vi.fn(),
-      findMany: vi.fn(),
-    },
-    parkReview: {
-      count: vi.fn(),
-    },
-    trailCondition: {
-      count: vi.fn(),
-    },
+    park: { count: vi.fn(), findMany: vi.fn() },
+    parkPhoto: { count: vi.fn(), findMany: vi.fn() },
+    parkReview: { count: vi.fn() },
+    trailCondition: { count: vi.fn() },
+    parkClaim: { count: vi.fn() },
+    fieldExtraction: { count: vi.fn() },
+    researchSession: { count: vi.fn(), aggregate: vi.fn(), findMany: vi.fn() },
   },
+}));
+
+// Recharts client component — stubbed so the test doesn't depend on SVG rendering.
+vi.mock("@/components/admin/DashboardCharts", () => ({
+  DashboardCharts: () => <div data-testid="dashboard-charts" />,
 }));
 
 vi.mock("next/image", () => ({
@@ -43,381 +37,173 @@ vi.mock("next/link", () => ({
 describe("AdminDashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default zero for trailCondition.count — overridden in specific tests
-    vi.mocked(prisma.trailCondition.count).mockResolvedValue(0);
-  });
-
-  it("should render dashboard title", async () => {
     vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
     vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
     vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.trailCondition.count).mockResolvedValue(0);
+    vi.mocked(prisma.parkClaim.count).mockResolvedValue(0);
+    vi.mocked(prisma.fieldExtraction.count).mockResolvedValue(0);
+    vi.mocked(prisma.researchSession.count).mockResolvedValue(0);
+    vi.mocked(prisma.researchSession.aggregate).mockResolvedValue({
+      _sum: { estimatedCostUSD: 0 },
+    } as any);
+    vi.mocked(prisma.researchSession.findMany).mockResolvedValue([] as any);
+    vi.mocked(prisma.park.findMany).mockResolvedValue([] as any);
+    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([] as any);
+  });
 
-    const component = await AdminDashboard();
-    render(component);
+  it("renders the dashboard title and sections", async () => {
+    render(await AdminDashboard());
 
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+    expect(screen.getByText("AI data pipeline")).toBeInTheDocument();
+    expect(screen.getByText("Trends")).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-charts")).toBeInTheDocument();
   });
 
-  it("should display total parks stat", async () => {
-    vi.mocked(prisma.park.count).mockImplementation((args?: any) => {
-      if (!args?.where) return Promise.resolve(42) as any;
-      if (args.where.status === "PENDING") return Promise.resolve(5) as any;
-      if (args.where.status === "APPROVED") return Promise.resolve(35) as any;
-      if (args.where.status === "REJECTED") return Promise.resolve(2) as any;
-      return Promise.resolve(0) as any;
-    });
-    vi.mocked(prisma.user.count).mockResolvedValue(100);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(10);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+  it("renders the attention queues with deep links", async () => {
+    render(await AdminDashboard());
 
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Total Parks")).toBeInTheDocument();
-    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /field reviews/i }),
+    ).toHaveAttribute("href", "/admin/ai-research/review");
+    expect(
+      screen.getByRole("link", { name: /research queue/i }),
+    ).toHaveAttribute("href", "/admin/ai-research/research");
+    expect(screen.getByRole("link", { name: /park claims/i })).toHaveAttribute(
+      "href",
+      "/admin/claims",
+    );
   });
 
-  it("should display pending parks stat", async () => {
-    vi.mocked(prisma.park.count).mockImplementation((args?: any) => {
-      if (!args?.where) return Promise.resolve(50) as any;
-      if (args.where.status === "PENDING") return Promise.resolve(12) as any;
-      return Promise.resolve(0) as any;
-    });
-    vi.mocked(prisma.user.count).mockResolvedValue(100);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(5);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+  it("shows the field-review queue count", async () => {
+    vi.mocked(prisma.fieldExtraction.count).mockResolvedValue(9);
+    render(await AdminDashboard());
 
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Pending Parks")).toBeInTheDocument();
-    expect(screen.getByText("12")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /field reviews/i });
+    expect(link).toHaveTextContent("9");
   });
 
-  it("should display pending photos stat", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(8);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+  it("renders the AI pipeline stats including total cost", async () => {
+    vi.mocked(prisma.researchSession.aggregate).mockResolvedValue({
+      _sum: { estimatedCostUSD: 12.5 },
+    } as any);
+    render(await AdminDashboard());
 
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Pending Photos")).toBeInTheDocument();
-    expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("Total cost")).toBeInTheDocument();
+    expect(screen.getByText("$12.50")).toBeInTheDocument();
+    expect(screen.getByText("Researched")).toBeInTheDocument();
   });
 
-  it("should display total users stat", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(250);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Total Users")).toBeInTheDocument();
-    expect(screen.getByText("250")).toBeInTheDocument();
-  });
-
-  it("should display recent pending parks section", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Recent Pending Parks")).toBeInTheDocument();
-  });
-
-  it("should show empty state when no pending parks", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("No pending parks to review")).toBeInTheDocument();
-  });
-
-  it("should display recent pending parks", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-
+  it("renders recent pending parks", async () => {
     const mockPendingParks = [
       {
         id: "park-1",
         name: "Test Park One",
         createdAt: new Date("2024-01-15"),
         submitterName: "John Doe",
-        address: {
-          city: "Los Angeles",
-          state: "California",
-        },
+        address: { city: "Los Angeles", state: "California" },
       },
       {
         id: "park-2",
         name: "Test Park Two",
         createdAt: new Date("2024-01-20"),
         submitterName: null,
-        address: {
-          city: null,
-          state: "Nevada",
-        },
+        address: { city: null, state: "Nevada" },
       },
     ];
+    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) =>
+      args?.where?.status === "PENDING"
+        ? (Promise.resolve(mockPendingParks) as any)
+        : (Promise.resolve([]) as any),
+    );
 
-    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) => {
-      if (args?.where?.status === "PENDING") {
-        return Promise.resolve(mockPendingParks as any) as any;
-      }
-      return Promise.resolve([]) as any;
-    });
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
+    render(await AdminDashboard());
 
     expect(screen.getByText("Test Park One")).toBeInTheDocument();
-    expect(screen.getByText("Test Park Two")).toBeInTheDocument();
     expect(screen.getByText("Los Angeles, California")).toBeInTheDocument();
     expect(screen.getByText("Nevada")).toBeInTheDocument();
   });
 
-  it("should show Anonymous for parks without submitter name", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
+  it("shows Anonymous for parks without a submitter name", async () => {
+    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) =>
+      args?.where?.status === "PENDING"
+        ? (Promise.resolve([
+            {
+              id: "park-1",
+              name: "Test Park",
+              createdAt: new Date("2024-01-15"),
+              submitterName: null,
+              address: { city: "Test City", state: "Test State" },
+            },
+          ]) as any)
+        : (Promise.resolve([]) as any),
+    );
 
-    const mockPendingParks = [
-      {
-        id: "park-1",
-        name: "Test Park",
-        createdAt: new Date("2024-01-15"),
-        submitterName: null,
-        address: {
-          city: "Test City",
-          state: "Test State",
-        },
-      },
-    ];
-
-    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) => {
-      if (args?.where?.status === "PENDING") {
-        return Promise.resolve(mockPendingParks as any) as any;
-      }
-      return Promise.resolve([]) as any;
-    });
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
+    render(await AdminDashboard());
     expect(screen.getByText(/submitted by: anonymous/i)).toBeInTheDocument();
   });
 
-  it("should render review links for pending parks", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
+  it("links a pending park to its review", async () => {
+    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) =>
+      args?.where?.status === "PENDING"
+        ? (Promise.resolve([
+            {
+              id: "park-123",
+              name: "Test Park",
+              createdAt: new Date(),
+              submitterName: "Test User",
+              address: { city: "Test City", state: "Test State" },
+            },
+          ]) as any)
+        : (Promise.resolve([]) as any),
+    );
 
-    const mockPendingParks = [
-      {
-        id: "park-123",
-        name: "Test Park",
-        createdAt: new Date(),
-        submitterName: "Test User",
-        address: {
-          city: "Test City",
-          state: "Test State",
-        },
-      },
-    ];
-
-    vi.mocked(prisma.park.findMany).mockImplementation((args?: any) => {
-      if (args?.where?.status === "PENDING") {
-        return Promise.resolve(mockPendingParks as any) as any;
-      }
-      return Promise.resolve([]) as any;
-    });
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    const reviewLink = screen.getByRole("link", { name: /review/i });
-    expect(reviewLink).toHaveAttribute(
+    render(await AdminDashboard());
+    expect(screen.getByRole("link", { name: /^review$/i })).toHaveAttribute(
       "href",
       "/admin/parks?highlight=park-123",
     );
   });
 
-  it("should display recent photos section", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Recent Photos")).toBeInTheDocument();
-  });
-
-  it("should show View All link for photos", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    const viewAllLink = screen.getByRole("link", { name: /view all/i });
-    expect(viewAllLink).toHaveAttribute("href", "/admin/photos");
-  });
-
-  it("should show empty state when no photos", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
+  it("shows empty states for pending parks and photos", async () => {
+    render(await AdminDashboard());
+    expect(screen.getByText("No pending parks to review")).toBeInTheDocument();
     expect(screen.getByText("No photos uploaded yet")).toBeInTheDocument();
   });
 
-  it("should display recent photos", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-
-    const mockPhotos = [
+  it("renders recent photos with a View All link", async () => {
+    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([
       {
         id: "photo-1",
         url: "https://example.com/photo1.jpg",
         caption: "Test Photo",
         status: "PENDING",
-        park: {
-          name: "Test Park",
-          slug: "test-park",
-        },
-        user: {
-          name: "John Doe",
-        },
+        park: { name: "Test Park", slug: "test-park" },
+        user: { name: "John Doe" },
       },
-    ];
+    ] as any);
 
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue(mockPhotos as any);
+    const { container } = render(await AdminDashboard());
 
-    const component = await AdminDashboard();
-    const { container } = render(component);
-
+    expect(screen.getByText("Recent Photos")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute(
+      "href",
+      "/admin/photos",
+    );
     const images = container.querySelectorAll("img");
-    expect(images.length).toBeGreaterThan(0);
     expect(images[0]).toHaveAttribute("src", "https://example.com/photo1.jpg");
   });
 
-  it("should render all six stat cards", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(10);
-    vi.mocked(prisma.user.count).mockResolvedValue(50);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(5);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(3);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Total Parks")).toBeInTheDocument();
-    expect(screen.getByText("Pending Parks")).toBeInTheDocument();
-    expect(screen.getByText("Pending Photos")).toBeInTheDocument();
-    expect(screen.getByText("Pending Reviews")).toBeInTheDocument();
-    expect(screen.getByText("Pending Conditions")).toBeInTheDocument();
-    expect(screen.getByText("Total Users")).toBeInTheDocument();
-  });
-
-  it("should display pending conditions stat", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.trailCondition.count).mockResolvedValue(7);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    const component = await AdminDashboard();
-    render(component);
-
-    expect(screen.getByText("Pending Conditions")).toBeInTheDocument();
-    expect(screen.getByText("7")).toBeInTheDocument();
-  });
-
-  it("should fetch limited number of pending parks", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
+  it("fetches limited pending parks and recent photos", async () => {
     await AdminDashboard();
 
     expect(prisma.park.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { status: "PENDING" },
-        take: 5,
-      }),
+      expect.objectContaining({ where: { status: "PENDING" }, take: 5 }),
     );
-  });
-
-  it("should fetch limited number of recent photos", async () => {
-    vi.mocked(prisma.park.count).mockResolvedValue(0);
-    vi.mocked(prisma.user.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkPhoto.count).mockResolvedValue(0);
-    vi.mocked(prisma.parkReview.count).mockResolvedValue(0);
-    vi.mocked(prisma.park.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
-
-    await AdminDashboard();
-
     expect(prisma.parkPhoto.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        take: 8,
-      }),
+      expect.objectContaining({ take: 8 }),
     );
   });
 });


### PR DESCRIPTION
Admin restructure, final step — the expanded dashboard (b), with charts.

## Changes
- **Needs attention** — actionable queue cards (pending parks, field reviews, photos, reviews, trail conditions, park claims, research queue, needs-research) that **deep-link** and highlight when non-zero. One glance shows everything waiting on an admin.
- **AI data pipeline** — a strip with the research-status breakdown (needs/in-progress/partial/researched) + total sessions + total cost, linking to AI Research (reinforces it as the backbone, per h).
- **Trends** — two **Recharts** time-series over the last 12 weeks: *parks added / week* (bar) and *research sessions / week* (area). Rendered in a client [`DashboardCharts`](src/components/admin/DashboardCharts.tsx) component using the theme's `--chart-1/2` tokens, recessive axes, and theme-styled tooltips. Single series each, so no legend — the card title names it (per the dataviz guidance).
- Keeps the recent-pending-parks and recent-photos lists.

## Dependency
Adds **recharts** (`^3.10.0`). It's client-only (`"use client"`), tree-shakeable, and works with React 19. The real proof is the Vercel build on this PR.

## Testing
- Dashboard test rewritten for the new structure (charts stubbed; all new prisma calls mocked).
- `npm test` green (2258); `tsc` + ESLint clean.

> Browser verification n/a in-env (auth-gated admin, no local DB). **This completes the admin restructure (a–h):** responsive drawer nav, Parks/Photos consolidations, People & Access, mobile card tables, and this dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)