### PR TITLE
fix(welcome): dismiss dialog reliably on first visit

### DIFF
--- a/src/components/welcome/WelcomeProvider.tsx
+++ b/src/components/welcome/WelcomeProvider.tsx
@@ -61,11 +61,16 @@ const WelcomeContext = createContext<WelcomeContextValue | null>(null);
 export function WelcomeProvider({ children }: { children: React.ReactNode }) {
   const mounted = useIsMounted();
   const [manualOpen, setManualOpen] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
 
-  // Auto-open only on the client, only until the visitor has dismissed it once.
-  // `hasSeenWelcome()` is short-circuited behind `mounted`, so it never runs on
-  // the server. Once dismissed we write the flag, so this flips to false.
-  const autoOpen = mounted && !hasSeenWelcome();
+  // Auto-open only on the client, only until the visitor dismisses it. The
+  // `dismissed` React state is what makes a close re-render: on a first visit
+  // `open` is driven purely by `autoOpen`, so `manualOpen` never flipped and a
+  // bare `setManualOpen(false)` would be a no-op that React bails out of,
+  // leaving the dialog stuck open. Flipping `dismissed` forces the re-render.
+  // `hasSeenWelcome()` (short-circuited behind `mounted`, so it never runs on
+  // the server) keeps it from auto-opening again on later page loads.
+  const autoOpen = mounted && !dismissed && !hasSeenWelcome();
   const open = manualOpen || autoOpen;
 
   const handleOpenChange = useCallback((next: boolean) => {
@@ -74,6 +79,7 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
     } else {
       markSeen();
       setManualOpen(false);
+      setDismissed(true);
     }
   }, []);
 

--- a/test/components/welcome/WelcomeProvider.test.tsx
+++ b/test/components/welcome/WelcomeProvider.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  WelcomeProvider,
+  useWelcome,
+} from "@/components/welcome/WelcomeProvider";
+
+const STORAGE_KEY = "op-welcome-seen";
+const TITLE = "Welcome to Offroad Parks";
+
+// jsdom's built-in localStorage is stubbed out in this config (the env ships
+// with --localstorage-file misconfigured), so we install a lightweight shim
+// scoped to this file — same pattern as ParkAlertsBanner.test.tsx.
+beforeAll(() => {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: shim,
+  });
+});
+
+/** Test consumer that reopens the dialog via the context (the footer link). */
+function ReopenButton() {
+  const { openWelcome } = useWelcome();
+  return <button onClick={openWelcome}>reopen</button>;
+}
+
+describe("WelcomeProvider", () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("auto-opens for a first-time visitor", async () => {
+    render(
+      <WelcomeProvider>
+        <div>page</div>
+      </WelcomeProvider>,
+    );
+
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
+  });
+
+  // Regression: on a first visit the dialog's open state is driven purely by
+  // the localStorage-derived auto-open, so a bare setState(false) on close was
+  // a no-op React bailed out of, leaving the dialog stuck open in prod.
+  it("dismisses when 'Start exploring' is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <WelcomeProvider>
+        <div>page</div>
+      </WelcomeProvider>,
+    );
+
+    await user.click(await screen.findByText("Start exploring"));
+
+    await waitFor(() =>
+      expect(screen.queryByText(TITLE)).not.toBeInTheDocument(),
+    );
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+  });
+
+  it("dismisses when the X close button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <WelcomeProvider>
+        <div>page</div>
+      </WelcomeProvider>,
+    );
+
+    await screen.findByText(TITLE);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(TITLE)).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not auto-open once the visitor has seen it", () => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    render(
+      <WelcomeProvider>
+        <div>page</div>
+      </WelcomeProvider>,
+    );
+
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+  });
+
+  it("can be reopened via useWelcome after being dismissed", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(STORAGE_KEY, "1"); // returning visitor: no auto-open
+    render(
+      <WelcomeProvider>
+        <ReopenButton />
+      </WelcomeProvider>,
+    );
+
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("reopen"));
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
+
+    await user.click(screen.getByText("Start exploring"));
+    await waitFor(() =>
+      expect(screen.queryByText(TITLE)).not.toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Bug
Reported in prod: on a first visit, clicking **Start exploring** or the **X** did not dismiss the welcome popup.

## Cause
On a first visit the dialog's `open` is driven purely by the `localStorage`-derived `autoOpen`, not by `manualOpen` state. Closing called `setManualOpen(false)` — but `manualOpen` was already `false`, so React **bailed out with no re-render**. `localStorage` got written, but nothing re-read it, so the dialog stayed open.

## Fix
Track dismissal in a `dismissed` React state (the same approach `CookieConsent` uses) so the close always produces a state change → re-render → `open` becomes false. `localStorage` still gates auto-open across later page loads.

## Tests
New `WelcomeProvider` tests: auto-open for a first-time visitor, dismissal via **both** the CTA and the X, no auto-open once seen, and reopen via `useWelcome`. Full suite green (168 files, 2263 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)