### PR TITLE
feat(auth): route signed-in-only prompts through the themed sign-in CTA

### DIFF
--- a/src/app/submit/SubmitSignInGate.tsx
+++ b/src/app/submit/SubmitSignInGate.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect } from "react";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { Button } from "@/components/ui/button";
+import { LockedGate } from "@/components/LockedGate";
+import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
+
+const DESCRIPTION =
+  "Sign in to submit a park and help the community grow the map.";
+
+/**
+ * Shown on /submit when a signed-out visitor lands there (via the "Submit Park"
+ * nav, footer, or a direct link). Instead of bouncing them to the native
+ * NextAuth page, it pops the themed sign-in dialog on arrival and leaves an
+ * on-brand CTA behind it so they can reopen it if dismissed.
+ */
+export function SubmitSignInGate() {
+  const { promptSignIn } = useSignInPrompt();
+
+  // Pop the sign-in dialog as soon as they arrive.
+  useEffect(() => {
+    promptSignIn({ description: DESCRIPTION });
+  }, [promptSignIn]);
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <AppHeader showBackButton />
+      <main className="flex-1 flex items-center justify-center px-6 py-16">
+        <div className="w-full max-w-md text-center flex flex-col items-center">
+          <LockedGate className="w-56 mb-6" />
+
+          <p className="text-sm font-bold uppercase tracking-widest text-primary">
+            Sign in required
+          </p>
+          <h1 className="mt-3 text-3xl sm:text-4xl font-extrabold tracking-tight text-foreground">
+            Submit a park
+          </h1>
+          <p className="mt-4 text-base text-muted-foreground leading-7">
+            Adding a park takes a free account so we can credit your submission
+            and follow up if we have questions.
+          </p>
+
+          <div className="mt-8">
+            <Button
+              size="lg"
+              onClick={() => promptSignIn({ description: DESCRIPTION })}
+            >
+              Sign in to continue
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,13 +1,13 @@
-import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { ParkSubmissionForm } from "@/components/forms/ParkSubmissionForm";
 import { SubmitParkClient } from "./SubmitParkClient";
+import { SubmitSignInGate } from "./SubmitSignInGate";
 
 export default async function SubmitParkPage() {
   const session = await auth();
 
   if (!session?.user) {
-    redirect("/api/auth/signin?callbackUrl=/submit");
+    return <SubmitSignInGate />;
   }
 
   const user = {

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -33,6 +33,7 @@ import { TrailConditionsDisplay } from "@/features/trail-conditions/TrailConditi
 import { useReviews } from "@/hooks/useReviews";
 import { useParkReview } from "@/hooks/useParkReview";
 import { AppHeader } from "@/components/layout/AppHeader";
+import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 import { findTrailOverlay } from "./trailOverlays";
 import type { TrailFeatureCollection } from "@/features/map/components/TrailOverlay";
 
@@ -90,6 +91,7 @@ function ParkDetailPageInner({
 }: ParkDetailPageProps) {
   const router = useRouter();
   const { data: session } = useSession();
+  const { promptSignIn } = useSignInPrompt();
   const [showReviewForm, setShowReviewForm] = useState(false);
 
   // Trail-geometry overlay for the Location tab. Source priority:
@@ -312,15 +314,26 @@ function ParkDetailPageInner({
                     parkSlug={park.id}
                     onSuccess={handlePhotoUploadSuccess}
                   />
-                ) : photos.length === 0 ? (
-                  <div className="text-center py-6 px-4 border border-dashed border-border rounded-lg bg-muted/30">
+                ) : (
+                  <div className="text-center py-6 px-4 border border-dashed border-border rounded-lg bg-muted/30 space-y-3">
                     <p className="text-sm text-muted-foreground">
-                      {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                      <a href="/api/auth/signin" className="text-primary underline underline-offset-2 font-medium hover:opacity-80">Sign in</a>
-                      {" "}to be the first to add photos for this park.
+                      {photos.length === 0
+                        ? "Been here? Add the first photos of this park."
+                        : "Been here? Share your own photos of this park."}
                     </p>
+                    <Button
+                      size="sm"
+                      onClick={() =>
+                        promptSignIn({
+                          description:
+                            "Sign in to add your photos of this park.",
+                        })
+                      }
+                    >
+                      Sign in to add photos
+                    </Button>
                   </div>
-                ) : null}
+                )}
               </TabsContent>
 
               {/* Reviews Tab */}
@@ -340,6 +353,27 @@ function ParkDetailPageInner({
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-6">
+                    {/* Signed-out prompt to contribute a review */}
+                    {!session?.user && (
+                      <div className="text-center py-6 px-4 border border-dashed border-border rounded-lg bg-muted/30 space-y-3">
+                        <p className="text-sm text-muted-foreground">
+                          Been here? Sign in to rate this park and share your
+                          experience.
+                        </p>
+                        <Button
+                          size="sm"
+                          onClick={() =>
+                            promptSignIn({
+                              description:
+                                "Sign in to write a review and rate this park.",
+                            })
+                          }
+                        >
+                          Sign in to write a review
+                        </Button>
+                      </div>
+                    )}
+
                     {/* User's own review or form */}
                     {session?.user && (showReviewForm || userReview) && (
                       <div className="border-b pb-6">

--- a/src/features/trail-conditions/TrailConditionsDisplay.tsx
+++ b/src/features/trail-conditions/TrailConditionsDisplay.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { TrailConditionForm } from "./TrailConditionForm";
@@ -29,6 +30,7 @@ const COLOR_CLASS: Record<string, string> = {
 
 export function TrailConditionsDisplay({ parkSlug }: TrailConditionsDisplayProps) {
   const { data: session } = useSession();
+  const { promptSignIn } = useSignInPrompt();
   const [conditions, setConditions] = useState<TrailConditionReport[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -114,10 +116,17 @@ export function TrailConditionsDisplay({ parkSlug }: TrailConditionsDisplayProps
 
         {!session?.user && (
           <p className="text-xs text-muted-foreground">
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a href="/api/auth/signin" className="text-primary underline underline-offset-2 font-medium hover:opacity-80">
+            <button
+              type="button"
+              onClick={() =>
+                promptSignIn({
+                  description: "Sign in to report current trail conditions.",
+                })
+              }
+              className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
+            >
               Sign in
-            </a>{" "}
+            </button>{" "}
             to report trail conditions.
           </p>
         )}

--- a/test/app/submit/page.test.tsx
+++ b/test/app/submit/page.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import SubmitParkPage from "@/app/submit/page";
 import { auth } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import { vi } from "vitest";
 
 // Mock dependencies
@@ -11,6 +10,12 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+}));
+
+vi.mock("@/app/submit/SubmitSignInGate", () => ({
+  SubmitSignInGate: () => (
+    <div data-testid="submit-signin-gate">Sign in required</div>
+  ),
 }));
 
 vi.mock("next/link", () => ({
@@ -32,17 +37,16 @@ describe("SubmitParkPage", () => {
     vi.clearAllMocks();
   });
 
-  it("should redirect to signin when not authenticated", async () => {
+  it("should render the themed sign-in gate when not authenticated", async () => {
     vi.mocked(auth).mockResolvedValue(null as any);
-    vi.mocked(redirect).mockImplementation(() => {
-      throw new Error("NEXT_REDIRECT");
-    });
 
-    await expect(SubmitParkPage()).rejects.toThrow("NEXT_REDIRECT");
+    const component = await SubmitParkPage();
+    render(component);
 
-    expect(redirect).toHaveBeenCalledWith(
-      "/api/auth/signin?callbackUrl=/submit",
-    );
+    expect(screen.getByTestId("submit-signin-gate")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("park-submission-form"),
+    ).not.toBeInTheDocument();
   });
 
   it("should render submit page for authenticated user", async () => {

--- a/test/features/parks/detail/ParkDetailPage.test.tsx
+++ b/test/features/parks/detail/ParkDetailPage.test.tsx
@@ -309,22 +309,28 @@ describe("ParkDetailPage", () => {
     expect(screen.queryByTestId("photo-upload-form")).not.toBeInTheDocument();
   });
 
-  it("should show sign-in CTA when unauthenticated and no photos", () => {
+  it("should show a photos sign-in CTA when unauthenticated and no photos", () => {
     vi.mocked(useSession).mockReturnValue({ data: null } as any);
 
     render(<ParkDetailPage park={mockPark} photos={[]} />);
 
-    // Multiple "Sign in" links may exist (photos CTA + trail conditions) — check photos-specific text
-    expect(screen.getAllByText(/sign in/i).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText(/to be the first to add photos/i)).toBeInTheDocument();
+    // "be the first" copy for an empty gallery, plus the CTA button.
+    expect(screen.getByText(/add the first photos/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in to add photos/i }),
+    ).toBeInTheDocument();
   });
 
-  it("should not show sign-in CTA when unauthenticated but photos exist", () => {
+  it("should show a photos sign-in CTA when unauthenticated and photos exist", () => {
     vi.mocked(useSession).mockReturnValue({ data: null } as any);
 
     render(<ParkDetailPage park={mockPark} photos={mockPhotos} />);
 
-    expect(screen.queryByText(/to be the first to add photos/i)).not.toBeInTheDocument();
+    // Non-empty gallery gets the "share your own" copy, still with the CTA.
+    expect(screen.getByText(/share your own photos/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in to add photos/i }),
+    ).toBeInTheDocument();
   });
 
   it("should render photo upload form when authenticated", () => {


### PR DESCRIPTION
Replaces the remaining direct `/api/auth/signin` links with the themed sign-in popup (`useSignInPrompt`), so gating a contribution feels on-brand instead of dumping users on the native NextAuth page.

## Changes
- **Park detail → Photos tab:** the "Sign in" link → a "Sign in to add photos" button that pops the CTA. Now shown for signed-out users whether or not photos already exist ("Add the first photos…" vs "Share your own photos…").
- **Park detail → Reviews tab:** new signed-out prompt — "Been here? Sign in to rate this park…" → CTA.
- **Trail conditions:** the "Sign in to report" link now opens the popup.
- **/submit:** instead of redirecting signed-out visitors to the native NextAuth page, renders a themed "Submit a park — sign in required" gate (`LockedGate`) that pops the CTA on arrival — covers the nav, footer, and direct-link entry points.

Server-side auth gates on admin/operator/profile/routes pages are left as-is (hard gates, not contribute CTAs).

## Tests
Updated the 2 affected tests (submit page now renders the gate; photos CTA copy/behavior). Full suite green (168 files, 2263 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)