### PR TITLE
feat(auth): friendlier sign-in illustration + finish CTA coverage

### DIFF
--- a/src/app/submit/SubmitSignInGate.tsx
+++ b/src/app/submit/SubmitSignInGate.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { Button } from "@/components/ui/button";
-import { LockedGate } from "@/components/LockedGate";
+import { TrailSign } from "@/components/TrailSign";
 import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 
 const DESCRIPTION =
@@ -12,23 +11,19 @@ const DESCRIPTION =
 /**
  * Shown on /submit when a signed-out visitor lands there (via the "Submit Park"
  * nav, footer, or a direct link). Instead of bouncing them to the native
- * NextAuth page, it pops the themed sign-in dialog on arrival and leaves an
- * on-brand CTA behind it so they can reopen it if dismissed.
+ * NextAuth page, it shows an on-brand "sign in required" barrier; the button
+ * opens the themed sign-in dialog on demand (no auto-popup — the page itself is
+ * the gate).
  */
 export function SubmitSignInGate() {
   const { promptSignIn } = useSignInPrompt();
-
-  // Pop the sign-in dialog as soon as they arrive.
-  useEffect(() => {
-    promptSignIn({ description: DESCRIPTION });
-  }, [promptSignIn]);
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <AppHeader showBackButton />
       <main className="flex-1 flex items-center justify-center px-6 py-16">
         <div className="w-full max-w-md text-center flex flex-col items-center">
-          <LockedGate className="w-56 mb-6" />
+          <TrailSign className="w-56 mb-6" />
 
           <p className="text-sm font-bold uppercase tracking-widest text-primary">
             Sign in required

--- a/src/components/TrailSign.tsx
+++ b/src/components/TrailSign.tsx
@@ -1,0 +1,53 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Hand-authored cartoon "trail signpost" illustration for the sign-in prompt —
+ * a friendly wayfinding post with directional boards. Replaces the padlocked
+ * gate, which read as an error ("something's locked/wrong") rather than a warm
+ * "sign in to keep exploring."
+ *
+ * Drawn with `currentColor` and Tailwind text-color utilities so it adapts to
+ * light and dark themes (same family as {@link BrokenTruck} / {@link TrailMap}):
+ * the boards read in the brand `text-primary` orange while the post, bolts and
+ * shadow pick up `text-foreground` / `text-muted-foreground`. No hard-coded hex.
+ */
+export function TrailSign({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 260 190"
+      role="img"
+      aria-label="A trail signpost with directional boards"
+      className={cn("h-auto w-full", className)}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Ground / dust shadow */}
+      <g className="text-muted-foreground">
+        <ellipse cx="130" cy="172" rx="86" ry="8" fill="currentColor" opacity="0.14" />
+      </g>
+
+      {/* Signpost */}
+      <g className="text-foreground" fill="currentColor">
+        <rect x="123" y="40" width="13" height="128" rx="4" />
+        {/* Rounded finial cap */}
+        <circle cx="129.5" cy="42" r="8" />
+      </g>
+
+      {/* Directional boards (brand orange), alternating left / right */}
+      <g className="text-primary" fill="currentColor">
+        {/* points right */}
+        <polygon points="92,58 168,58 186,70 168,82 92,82" />
+        {/* points left */}
+        <polygon points="167,92 91,92 73,104 91,116 167,116" />
+        {/* points right */}
+        <polygon points="100,126 158,126 176,138 158,150 100,150" />
+      </g>
+
+      {/* Mounting bolts on each board (over the post) */}
+      <g className="text-background" fill="currentColor">
+        <circle cx="129.5" cy="70" r="2.6" />
+        <circle cx="129.5" cy="104" r="2.6" />
+        <circle cx="129.5" cy="138" r="2.6" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/auth/SignInRequiredDialog.tsx
+++ b/src/components/auth/SignInRequiredDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { GoogleLogo } from "@/components/auth/GoogleLogo";
-import { LockedGate } from "@/components/LockedGate";
+import { TrailSign } from "@/components/TrailSign";
 
 const DEFAULT_DESCRIPTION =
   "Sign in to save favorites, plan routes, and leave reviews. It's free and takes a second.";
@@ -27,7 +27,7 @@ export interface SignInRequiredDialogProps {
 /**
  * Themed "you need to sign in" popup — the rugged, on-brand replacement for the
  * native `alert("Please sign in…")` we used to gate favorites and other
- * signed-in-only actions. Mirrors the 404 page's look (the {@link LockedGate}
+ * signed-in-only actions. Mirrors the 404 page's look (the {@link TrailSign}
  * illustration, an uppercase eyebrow, an extrabold heading and muted body copy)
  * so a blocked action feels like part of the trail, not a browser interruption.
  */
@@ -41,7 +41,7 @@ export function SignInRequiredDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">
         <div className="flex flex-col items-center text-center">
-          <LockedGate className="w-44 mb-5" />
+          <TrailSign className="w-44 mb-5" />
 
           <p className="text-xs font-bold uppercase tracking-widest text-primary">
             Sign in required

--- a/src/features/parks/detail/components/ParkClaimCTA.tsx
+++ b/src/features/parks/detail/components/ParkClaimCTA.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Building2, ChevronDown, ChevronUp, CheckCircle, XCircle } f
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 
 interface ParkClaimCTAProps {
   parkSlug: string;
@@ -28,6 +29,7 @@ interface ClaimFormData {
 }
 
 export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim, isOperatorOfPark, operatorName }: ParkClaimCTAProps) {
+  const { promptSignIn } = useSignInPrompt();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(
@@ -178,13 +180,17 @@ export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim,
 
         {!isLoggedIn ? (
           <p className="text-xs text-muted-foreground">
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-            <a
-              href="/api/auth/signin"
+            <button
+              type="button"
+              onClick={() =>
+                promptSignIn({
+                  description: "Sign in to claim and manage this park.",
+                })
+              }
               className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
             >
               Sign in
-            </a>{" "}
+            </button>{" "}
             to claim this park.
           </p>
         ) : (

--- a/test/features/parks/detail/components/ParkClaimCTA.test.tsx
+++ b/test/features/parks/detail/components/ParkClaimCTA.test.tsx
@@ -87,13 +87,14 @@ describe("ParkClaimCTA", () => {
     expect(screen.getByText("Own or manage this park?")).toBeInTheDocument();
   });
 
-  it("shows sign-in link when not logged in", () => {
+  it("shows a sign-in prompt button when not logged in", () => {
     render(
       <ParkClaimCTA parkSlug="test-park" isLoggedIn={false} />
     );
-    const signInLink = screen.getByText("Sign in");
-    expect(signInLink).toBeInTheDocument();
-    expect(signInLink.closest("a")).toHaveAttribute("href", "/api/auth/signin");
+    // The "Sign in" affordance is a button that opens the themed sign-in
+    // dialog (via useSignInPrompt), not a link to the native NextAuth page.
+    const signIn = screen.getByRole("button", { name: "Sign in" });
+    expect(signIn).toBeInTheDocument();
     expect(screen.getByText(/to claim this park/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Follow-ups on the themed sign-in CTA.

## Changes
- **Friendlier illustration.** The padlocked `LockedGate` read as an error ("something's locked/wrong"). Replaced it on the sign-in popup and the submit gate with a welcoming **`TrailSign`** wayfinding signpost (same `currentColor`/theme-token style, verified light + dark).
- **No redundant double prompt on /submit.** The gate no longer auto-pops the dialog on arrival — the page barrier *is* the gate; its "Sign in to continue" button opens the dialog on demand.
- **Last missing CTA.** The "Own or manage this park?" card's `/api/auth/signin` link now opens the themed sign-in dialog like the others.

## Tests
Updated the `ParkClaimCTA` test (sign-in is now a prompt button, not a native link). Full suite green (168 files, 2263 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)