### PR TITLE
Add read-only BETA_TESTER admin role

### DIFF
--- a/prisma/migrations/20260726030000_add_beta_tester_role/migration.sql
+++ b/prisma/migrations/20260726030000_add_beta_tester_role/migration.sql
@@ -1,0 +1,4 @@
+-- Add BETA_TESTER to the UserRole enum. Beta testers get a read-only view of
+-- the admin console (all viewing allowed, no mutations). Enforcement lives in
+-- src/lib/roles.ts — BETA_TESTER is never included in the admin/write role sets.
+ALTER TYPE "UserRole" ADD VALUE 'BETA_TESTER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,11 @@ enum UserRole {
   ADMIN
   OPERATOR
   SUPER_ADMIN
+  // Read-only access to the admin console for beta testers. Can view every
+  // admin page but cannot perform any mutating action — enforced server-side
+  // (never in the admin/write role sets) and surfaced in the UI as disabled,
+  // greyed-out controls. See src/lib/roles.ts.
+  BETA_TESTER
 }
 
 // Pre-grants — declare a role / operator membership that should be applied

--- a/src/app/admin/claims/page.tsx
+++ b/src/app/admin/claims/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CheckCircle, XCircle, Trash2, Building2, User, MapPin, Phone, Mail, MessageSquare } from "lucide-react";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 type ClaimStatus = "PENDING" | "APPROVED" | "REJECTED";
 
@@ -225,17 +226,19 @@ export default function AdminClaimsPage() {
                     <Badge variant={statusBadgeVariant(claim.status)}>
                       {claim.status}
                     </Badge>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                      onClick={() => handleDelete(claim.id, claim.claimantName)}
-                      disabled={actionLoading === claim.id}
-                      data-testid={`delete-${claim.id}`}
-                      title="Delete claim"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
+                    <ReadOnlyGate>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={() => handleDelete(claim.id, claim.claimantName)}
+                        disabled={actionLoading === claim.id}
+                        data-testid={`delete-${claim.id}`}
+                        title="Delete claim"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </ReadOnlyGate>
                   </div>
                 </div>
               </CardHeader>
@@ -301,16 +304,18 @@ export default function AdminClaimsPage() {
                 {claim.status === "PENDING" && (
                   <div className="flex flex-col gap-2 pt-1">
                     <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        className="flex-1"
-                        onClick={() => handleApprove(claim.id)}
-                        disabled={actionLoading === claim.id}
-                        data-testid={`approve-${claim.id}`}
-                      >
-                        <CheckCircle className="w-4 h-4 mr-1" />
-                        {actionLoading === claim.id ? "Processing…" : "Approve"}
-                      </Button>
+                      <ReadOnlyGate className="flex-1">
+                        <Button
+                          size="sm"
+                          className="flex-1"
+                          onClick={() => handleApprove(claim.id)}
+                          disabled={actionLoading === claim.id}
+                          data-testid={`approve-${claim.id}`}
+                        >
+                          <CheckCircle className="w-4 h-4 mr-1" />
+                          {actionLoading === claim.id ? "Processing…" : "Approve"}
+                        </Button>
+                      </ReadOnlyGate>
                       <Button
                         size="sm"
                         variant="destructive"
@@ -339,16 +344,18 @@ export default function AdminClaimsPage() {
                             }))
                           }
                         />
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          className="w-full"
-                          onClick={() => handleReject(claim.id)}
-                          disabled={actionLoading === claim.id}
-                          data-testid={`reject-confirm-${claim.id}`}
-                        >
-                          Confirm Rejection
-                        </Button>
+                        <ReadOnlyGate block className="w-full">
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            className="w-full"
+                            onClick={() => handleReject(claim.id)}
+                            disabled={actionLoading === claim.id}
+                            data-testid={`reject-confirm-${claim.id}`}
+                          >
+                            Confirm Rejection
+                          </Button>
+                        </ReadOnlyGate>
                       </div>
                     )}
                   </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -3,6 +3,11 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { AdminNav } from "@/components/admin/AdminNav";
+import {
+  AdminReadOnlyProvider,
+  ReadOnlyBanner,
+} from "@/components/admin/read-only";
+import { canAdminView, isReadOnlyAdmin } from "@/lib/roles";
 import { LogOut } from "lucide-react";
 
 export default async function AdminLayout({
@@ -17,13 +22,16 @@ export default async function AdminLayout({
   }
 
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
+  if (!canAdminView(userRole)) {
     redirect("/");
   }
   const isSuperAdmin = userRole === "SUPER_ADMIN";
+  const readOnly = isReadOnlyAdmin(userRole);
 
   return (
+    <AdminReadOnlyProvider isReadOnly={readOnly}>
     <div className="min-h-screen bg-background text-foreground">
+      {readOnly && <ReadOnlyBanner />}
       {/* Admin Header */}
       <header className="bg-card border-b border-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -55,5 +63,6 @@ export default async function AdminLayout({
         <main className="flex-1 min-w-0 p-4 sm:p-6 lg:p-8">{children}</main>
       </div>
     </div>
+    </AdminReadOnlyProvider>
   );
 }

--- a/src/app/admin/operators/OperatorManagementClient.tsx
+++ b/src/app/admin/operators/OperatorManagementClient.tsx
@@ -13,6 +13,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 export interface AdminOperatorRow {
   id: string;
@@ -282,14 +283,16 @@ export function OperatorManagementClient({ initialOperators }: Props) {
             hint="User must already exist. If not, use Pre-grants."
           />
           <div className="md:col-span-2">
-            <button
-              type="submit"
-              disabled={creating || pending}
-              className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50 inline-flex items-center gap-1"
-            >
-              <Plus className="w-4 h-4" />
-              {creating ? "Creating…" : "Create operator"}
-            </button>
+            <ReadOnlyGate>
+              <button
+                type="submit"
+                disabled={creating || pending}
+                className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/90 disabled:opacity-50 inline-flex items-center gap-1"
+              >
+                <Plus className="w-4 h-4" />
+                {creating ? "Creating…" : "Create operator"}
+              </button>
+            </ReadOnlyGate>
           </div>
         </form>
       </section>
@@ -492,14 +495,16 @@ function OperatorRow({
         <div className="flex items-center gap-2">
           {editing ? (
             <>
-              <button
-                type="button"
-                disabled={saving}
-                onClick={saveEdit}
-                className="text-xs rounded-md bg-primary text-primary-foreground px-3 py-1 hover:bg-primary/90 disabled:opacity-50"
-              >
-                {saving ? "Saving…" : "Save"}
-              </button>
+              <ReadOnlyGate>
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={saveEdit}
+                  className="text-xs rounded-md bg-primary text-primary-foreground px-3 py-1 hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {saving ? "Saving…" : "Save"}
+                </button>
+              </ReadOnlyGate>
               <button
                 type="button"
                 onClick={() => {
@@ -524,15 +529,17 @@ function OperatorRow({
               >
                 Edit
               </button>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={onDeleteOperator}
-                className="text-xs rounded-md border border-red-300 text-red-700 px-2 py-1 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40 inline-flex items-center gap-1"
-              >
-                <Trash2 className="w-3 h-3" />
-                Delete
-              </button>
+              <ReadOnlyGate>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={onDeleteOperator}
+                  className="text-xs rounded-md border border-red-300 text-red-700 px-2 py-1 hover:bg-red-50 disabled:opacity-50 dark:border-red-900 dark:text-red-300 dark:hover:bg-red-950/40 inline-flex items-center gap-1"
+                >
+                  <Trash2 className="w-3 h-3" />
+                  Delete
+                </button>
+              </ReadOnlyGate>
             </>
           )}
         </div>
@@ -555,16 +562,18 @@ function OperatorRow({
                     <Link href={`/parks/${p.slug}`} className="text-sm hover:underline">
                       {p.name}
                     </Link>
-                    <button
-                      type="button"
-                      disabled={busy}
-                      onClick={() => onDetachPark(p.id, p.name)}
-                      className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
-                      title="Detach park"
-                    >
-                      <X className="w-3 h-3" />
-                      Detach
-                    </button>
+                    <ReadOnlyGate>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => onDetachPark(p.id, p.name)}
+                        className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
+                        title="Detach park"
+                      >
+                        <X className="w-3 h-3" />
+                        Detach
+                      </button>
+                    </ReadOnlyGate>
                   </li>
                 ))}
               </ul>
@@ -585,13 +594,15 @@ function OperatorRow({
                 placeholder="park-slug-to-attach"
                 className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 text-sm"
               />
-              <button
-                type="submit"
-                disabled={busy || !attachSlug.trim()}
-                className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
-              >
-                Attach
-              </button>
+              <ReadOnlyGate>
+                <button
+                  type="submit"
+                  disabled={busy || !attachSlug.trim()}
+                  className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
+                >
+                  Attach
+                </button>
+              </ReadOnlyGate>
             </form>
           </div>
 
@@ -615,16 +626,18 @@ function OperatorRow({
                           {m.role}
                         </span>
                       </div>
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => onRemoveUser(m.user.id, label)}
-                        className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
-                        title="Remove user"
-                      >
-                        <X className="w-3 h-3" />
-                        Remove
-                      </button>
+                      <ReadOnlyGate>
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => onRemoveUser(m.user.id, label)}
+                          className="text-xs text-muted-foreground hover:text-red-700 disabled:opacity-50 inline-flex items-center gap-1"
+                          title="Remove user"
+                        >
+                          <X className="w-3 h-3" />
+                          Remove
+                        </button>
+                      </ReadOnlyGate>
                     </li>
                   );
                 })}
@@ -655,13 +668,15 @@ function OperatorRow({
                 <option value="OWNER">OWNER</option>
                 <option value="MEMBER">MEMBER</option>
               </select>
-              <button
-                type="submit"
-                disabled={busy || !addUserEmail.trim()}
-                className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
-              >
-                Add
-              </button>
+              <ReadOnlyGate>
+                <button
+                  type="submit"
+                  disabled={busy || !addUserEmail.trim()}
+                  className="text-xs rounded-md border border-border px-3 py-1.5 hover:bg-accent disabled:opacity-50"
+                >
+                  Add
+                </button>
+              </ReadOnlyGate>
             </form>
           </div>
         </div>

--- a/src/app/admin/operators/page.tsx
+++ b/src/app/admin/operators/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 import { PeopleTabs } from "@/components/admin/PeopleTabs";
+import { canAdminView } from "@/lib/roles";
 import {
   OperatorManagementClient,
   type AdminOperatorRow,
@@ -10,7 +11,7 @@ import {
 export default async function AdminOperatorsPage() {
   const session = await auth();
   const role = (session?.user as { role?: string })?.role;
-  if (role !== "ADMIN" && role !== "SUPER_ADMIN") {
+  if (!canAdminView(role)) {
     redirect("/");
   }
   const isSuperAdmin = role === "SUPER_ADMIN";

--- a/src/app/admin/parks/[id]/edit/page.tsx
+++ b/src/app/admin/parks/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { ParkSubmissionForm } from "@/components/forms/ParkSubmissionForm";
+import { canAdminView } from "@/lib/roles";
 
 interface EditParkPageProps {
   params: Promise<{
@@ -17,7 +18,7 @@ export default async function EditParkPage({ params }: EditParkPageProps) {
     redirect("/api/auth/signin");
   }
 
-  if (session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
+  if (!canAdminView(session.user.role)) {
     redirect("/");
   }
 

--- a/src/app/admin/parks/bulk-upload/page.tsx
+++ b/src/app/admin/parks/bulk-upload/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { BulkParkUpload } from "@/components/admin/BulkParkUpload";
+import { canAdminView } from "@/lib/roles";
 
 export const metadata = {
   title: "Bulk Upload Parks - Admin",
@@ -15,9 +16,9 @@ export default async function BulkUploadPage() {
     redirect("/api/auth/signin");
   }
 
-  // Require admin role
+  // Require admin view access (read-only beta testers see a disabled form)
   const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
+  if (!canAdminView(userRole)) {
     redirect("/");
   }
 

--- a/src/app/admin/photos/bulk-upload/page.tsx
+++ b/src/app/admin/photos/bulk-upload/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useCallback } from "react";
 import { Upload, X, Check, AlertCircle, Loader2 } from "lucide-react";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 interface ParkOption {
   id: string;
@@ -324,23 +325,25 @@ export default function BulkPhotoUploadPage() {
 
           {/* Upload button */}
           <div className="flex items-center gap-4">
-            <button
-              onClick={handleUpload}
-              disabled={uploading || readyCount === 0}
-              className="px-6 py-2.5 bg-primary text-primary-foreground font-medium rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
-            >
-              {uploading ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Uploading...
-                </>
-              ) : (
-                <>
-                  <Upload className="w-4 h-4" />
-                  Upload {readyCount} photo{readyCount !== 1 ? "s" : ""}
-                </>
-              )}
-            </button>
+            <ReadOnlyGate>
+              <button
+                onClick={handleUpload}
+                disabled={uploading || readyCount === 0}
+                className="px-6 py-2.5 bg-primary text-primary-foreground font-medium rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 transition-colors"
+              >
+                {uploading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Uploading...
+                  </>
+                ) : (
+                  <>
+                    <Upload className="w-4 h-4" />
+                    Upload {readyCount} photo{readyCount !== 1 ? "s" : ""}
+                  </>
+                )}
+              </button>
+            </ReadOnlyGate>
             {readyCount < entries.length && (
               <p className="text-sm text-muted-foreground">
                 {entries.length - readyCount} photo

--- a/src/app/admin/pre-grants/PreGrantManagementClient.tsx
+++ b/src/app/admin/pre-grants/PreGrantManagementClient.tsx
@@ -4,9 +4,15 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, Trash2 } from "lucide-react";
 
-type Role = "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN";
+type Role = "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | "BETA_TESTER";
 
-const ASSIGNABLE_ROLES: Role[] = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"];
+const ASSIGNABLE_ROLES: Role[] = [
+  "USER",
+  "BETA_TESTER",
+  "OPERATOR",
+  "ADMIN",
+  "SUPER_ADMIN",
+];
 
 export interface PreGrantRow {
   id: string;
@@ -31,6 +37,8 @@ function roleBadgeClass(role: string | null): string {
       return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
     case "OPERATOR":
       return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+    case "BETA_TESTER":
+      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
     case "USER":
       return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300";
     default:

--- a/src/app/api/admin/ai-research/dashboard/route.ts
+++ b/src/app/api/admin/ai-research/dashboard/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdminView } from "@/lib/api-helpers";
 import { prisma } from "@/lib/prisma";
 import type { AIResearchDashboard, ResearchStatus, ResearchSessionSummary } from "@/lib/types";
 
 export async function GET() {
-  const adminResult = await requireAdmin();
+  const adminResult = await requireAdminView();
   if (adminResult instanceof NextResponse) return adminResult;
 
   const [

--- a/src/app/api/admin/ai-research/discovery/candidates/route.ts
+++ b/src/app/api/admin/ai-research/discovery/candidates/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, requireAdminView } from "@/lib/api-helpers";
 import { prisma } from "@/lib/prisma";
 import { researchPark } from "@/lib/ai/research-pipeline";
 import { generateMapHeroAsync } from "@/lib/map-hero/generate";
@@ -26,7 +26,7 @@ async function ensureUniqueSlug(baseSlug: string): Promise<string> {
 
 // GET — List ParkCandidate records
 export async function GET(request: Request) {
-  const adminResult = await requireAdmin();
+  const adminResult = await requireAdminView();
   if (adminResult instanceof NextResponse) return adminResult;
 
   const { searchParams } = new URL(request.url);

--- a/src/app/api/admin/ai-research/domains/route.ts
+++ b/src/app/api/admin/ai-research/domains/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, requireAdminView } from "@/lib/api-helpers";
 import { prisma } from "@/lib/prisma";
 import type { DomainReliabilitySummary } from "@/lib/types";
 
 export async function GET() {
-  const adminResult = await requireAdmin();
+  const adminResult = await requireAdminView();
   if (adminResult instanceof NextResponse) return adminResult;
 
   const domains = await prisma.domainReliability.findMany({

--- a/src/app/api/admin/ai-research/pending-reviews/route.ts
+++ b/src/app/api/admin/ai-research/pending-reviews/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdminView } from "@/lib/api-helpers";
 import { prisma } from "@/lib/prisma";
 import { getCurrentFieldValue } from "@/lib/ai/research-lifecycle";
 import type { FieldExtractionSummary, DbPark } from "@/lib/types";
@@ -22,7 +22,7 @@ function normalizeForComparison(jsonStr: string): string {
 }
 
 export async function GET(request: Request) {
-  const adminResult = await requireAdmin();
+  const adminResult = await requireAdminView();
   if (adminResult instanceof NextResponse) return adminResult;
 
   const url = new URL(request.url);

--- a/src/app/api/admin/ai-research/sources/route.ts
+++ b/src/app/api/admin/ai-research/sources/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, requireAdminView } from "@/lib/api-helpers";
 import { prisma } from "@/lib/prisma";
 import type { DataSourceSummary } from "@/lib/types";
 import { normalizeUrl } from "@/lib/ai/source-discovery";
 
 export async function GET(request: Request) {
-  const adminResult = await requireAdmin();
+  const adminResult = await requireAdminView();
   if (adminResult instanceof NextResponse) return adminResult;
 
   const url = new URL(request.url);

--- a/src/app/api/admin/claims/route.ts
+++ b/src/app/api/admin/claims/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { canAdminView } from "@/lib/roles";
 
 export const runtime = "nodejs";
 
@@ -9,7 +10,7 @@ type ClaimStatus = "PENDING" | "APPROVED" | "REJECTED";
 // GET /api/admin/claims?status=PENDING&page=1&limit=20
 export async function GET(request: Request) {
   const session = await auth();
-  if (!session?.user?.id || session.user.role !== "ADMIN" && session.user.role !== "SUPER_ADMIN") {
+  if (!session?.user?.id || !canAdminView(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/operators/route.ts
+++ b/src/app/api/admin/operators/route.ts
@@ -8,13 +8,13 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, requireAdminView } from "@/lib/api-helpers";
 
 export const runtime = "nodejs";
 
 // GET /api/admin/operators — list all operators with their parks + users.
 export async function GET(): Promise<NextResponse> {
-  const authResult = await requireAdmin();
+  const authResult = await requireAdminView();
   if (authResult instanceof NextResponse) return authResult;
 
   const operators = await prisma.operator.findMany({

--- a/src/app/api/admin/parks/list/route.ts
+++ b/src/app/api/admin/parks/list/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { canAdminView } from "@/lib/roles";
 
 export const runtime = "nodejs";
 
@@ -12,8 +13,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
+  if (!canAdminView(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/reviews/route.ts
+++ b/src/app/api/admin/reviews/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { canAdminView } from "@/lib/roles";
 import { transformDbReview } from "@/lib/types";
 import type { DbReview, ReviewStatus } from "@/lib/types";
 
 export const runtime = "nodejs";
 
-// GET /api/admin/reviews - Get all reviews (admin only)
+// GET /api/admin/reviews - Get all reviews (admin view access)
 export async function GET(request: Request) {
   const session = await auth();
 
@@ -14,9 +15,8 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Check admin role
-  const userRole = (session.user as { role?: string })?.role;
-  if (userRole !== "ADMIN" && userRole !== "SUPER_ADMIN") {
+  // Allow admin viewers (incl. read-only beta testers) to browse reviews.
+  if (!canAdminView(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/admin/users/[id]/role/route.ts
+++ b/src/app/api/admin/users/[id]/role/route.ts
@@ -4,7 +4,13 @@ import { prisma } from "@/lib/prisma";
 
 export const runtime = "nodejs";
 
-const ASSIGNABLE_ROLES = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"] as const;
+const ASSIGNABLE_ROLES = [
+  "USER",
+  "BETA_TESTER",
+  "OPERATOR",
+  "ADMIN",
+  "SUPER_ADMIN",
+] as const;
 type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
 // PATCH /api/admin/users/[id]/role — only SUPER_ADMIN may promote/demote users.

--- a/src/components/admin/BulkParkUpload.tsx
+++ b/src/components/admin/BulkParkUpload.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import * as Papa from "papaparse";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import { ALL_TERRAIN_TYPES, ALL_AMENITIES, ALL_CAMPING_TYPES, ALL_VEHICLE_TYPES, ALL_OWNERSHIP_TYPES, US_STATES } from "@/lib/constants";
 
 interface BulkParkInput {
@@ -602,15 +603,17 @@ export function BulkParkUpload() {
 
       {/* Actions */}
       <div className="flex gap-3">
-        <Button
-          onClick={handleSubmit}
-          disabled={parks.length === 0 || isUploading}
-          size="lg"
-        >
-          {isUploading
-            ? "Uploading..."
-            : `Upload ${parks.length} Park${parks.length !== 1 ? "s" : ""}`}
-        </Button>
+        <ReadOnlyGate>
+          <Button
+            onClick={handleSubmit}
+            disabled={parks.length === 0 || isUploading}
+            size="lg"
+          >
+            {isUploading
+              ? "Uploading..."
+              : `Upload ${parks.length} Park${parks.length !== 1 ? "s" : ""}`}
+          </Button>
+        </ReadOnlyGate>
         <Button
           onClick={handleReset}
           variant="outline"

--- a/src/components/admin/BulkResearchBar.tsx
+++ b/src/components/admin/BulkResearchBar.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, Layers } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 type Props = {
   /** Park ids currently listed (the active filter/search result). */
@@ -74,23 +75,25 @@ export function BulkResearchBar({ parkIds, queuedCount }: Props) {
             )}
           </p>
         </div>
-        <Button
-          onClick={handleQueue}
-          disabled={submitting || parkIds.length === 0}
-          size="sm"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-              Queuing...
-            </>
-          ) : (
-            <>
-              <Layers className="w-4 h-4 mr-1" />
-              Queue {parkIds.length} park{parkIds.length === 1 ? "" : "s"}
-            </>
-          )}
-        </Button>
+        <ReadOnlyGate>
+          <Button
+            onClick={handleQueue}
+            disabled={submitting || parkIds.length === 0}
+            size="sm"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                Queuing...
+              </>
+            ) : (
+              <>
+                <Layers className="w-4 h-4 mr-1" />
+                Queue {parkIds.length} park{parkIds.length === 1 ? "" : "s"}
+              </>
+            )}
+          </Button>
+        </ReadOnlyGate>
       </div>
       {result && (
         <div

--- a/src/components/admin/DomainReliabilityTable.tsx
+++ b/src/components/admin/DomainReliabilityTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, Pencil, Trash2, Check, X, Lock, LockOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import type { DomainReliabilitySummary } from "@/lib/types";
 
 type Props = {
@@ -202,9 +203,11 @@ export function DomainReliabilityTable({ domains }: Props) {
                 />
                 Blocked
               </label>
-              <Button type="submit" size="sm" disabled={adding}>
-                Add
-              </Button>
+              <ReadOnlyGate>
+                <Button type="submit" size="sm" disabled={adding}>
+                  Add
+                </Button>
+              </ReadOnlyGate>
               <Button
                 type="button"
                 variant="ghost"
@@ -331,16 +334,18 @@ export function DomainReliabilityTable({ domains }: Props) {
                     <div className="flex items-center gap-1">
                       {editingId === domain.id ? (
                         <>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() => handleSave(domain.id)}
-                            disabled={saving}
-                            title="Save"
-                            className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
-                          >
-                            <Check className="w-4 h-4" />
-                          </Button>
+                          <ReadOnlyGate>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleSave(domain.id)}
+                              disabled={saving}
+                              title="Save"
+                              className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
+                            >
+                              <Check className="w-4 h-4" />
+                            </Button>
+                          </ReadOnlyGate>
                           <Button
                             variant="ghost"
                             size="icon-sm"
@@ -353,25 +358,27 @@ export function DomainReliabilityTable({ domains }: Props) {
                         </>
                       ) : (
                         <>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() =>
-                              handleToggleLock(domain.id, domain.locked)
-                            }
-                            title={
-                              domain.locked
-                                ? "Unpin — allow auto-tuning"
-                                : "Pin score — skip auto-tuning"
-                            }
-                            className="text-muted-foreground hover:text-primary hover:bg-primary/10"
-                          >
-                            {domain.locked ? (
-                              <Lock className="w-4 h-4" />
-                            ) : (
-                              <LockOpen className="w-4 h-4" />
-                            )}
-                          </Button>
+                          <ReadOnlyGate>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() =>
+                                handleToggleLock(domain.id, domain.locked)
+                              }
+                              title={
+                                domain.locked
+                                  ? "Unpin — allow auto-tuning"
+                                  : "Pin score — skip auto-tuning"
+                              }
+                              className="text-muted-foreground hover:text-primary hover:bg-primary/10"
+                            >
+                              {domain.locked ? (
+                                <Lock className="w-4 h-4" />
+                              ) : (
+                                <LockOpen className="w-4 h-4" />
+                              )}
+                            </Button>
+                          </ReadOnlyGate>
                           <Button
                             variant="ghost"
                             size="icon-sm"
@@ -381,17 +388,19 @@ export function DomainReliabilityTable({ domains }: Props) {
                           >
                             <Pencil className="w-4 h-4" />
                           </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon-sm"
-                            onClick={() =>
-                              handleDelete(domain.id, domain.domainPattern)
-                            }
-                            title="Delete"
-                            className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
+                          <ReadOnlyGate>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() =>
+                                handleDelete(domain.id, domain.domainPattern)
+                              }
+                              title="Delete"
+                              className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          </ReadOnlyGate>
                         </>
                       )}
                     </div>

--- a/src/components/admin/DomainSuggestions.tsx
+++ b/src/components/admin/DomainSuggestions.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, ShieldAlert, Sparkles, Ban } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 export type DomainBlockSuggestion = {
   domainPattern: string;
@@ -84,24 +85,26 @@ export function DomainSuggestions({ suggestions }: Props) {
         <p className="text-xs text-muted-foreground">
           Reliability scores auto-tune nightly from your approve/reject feedback.
         </p>
-        <Button
-          onClick={handleAutoTune}
-          disabled={tuning}
-          size="sm"
-          variant="outline"
-        >
-          {tuning ? (
-            <>
-              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-              Tuning...
-            </>
-          ) : (
-            <>
-              <Sparkles className="w-4 h-4 mr-1" />
-              Auto-tune now
-            </>
-          )}
-        </Button>
+        <ReadOnlyGate>
+          <Button
+            onClick={handleAutoTune}
+            disabled={tuning}
+            size="sm"
+            variant="outline"
+          >
+            {tuning ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                Tuning...
+              </>
+            ) : (
+              <>
+                <Sparkles className="w-4 h-4 mr-1" />
+                Auto-tune now
+              </>
+            )}
+          </Button>
+        </ReadOnlyGate>
       </div>
 
       {tuneResult && (
@@ -140,20 +143,22 @@ export function DomainSuggestions({ suggestions }: Props) {
                     {Math.round(s.accuracy * 100)}% accurate over {s.reviewCount} reviews
                   </span>
                 </span>
-                <Button
-                  onClick={() => handleBlock(s)}
-                  disabled={blockingPattern !== null}
-                  size="sm"
-                  variant="outline"
-                  className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
-                >
-                  {blockingPattern === s.domainPattern ? (
-                    <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-                  ) : (
-                    <Ban className="w-4 h-4 mr-1" />
-                  )}
-                  Block
-                </Button>
+                <ReadOnlyGate>
+                  <Button
+                    onClick={() => handleBlock(s)}
+                    disabled={blockingPattern !== null}
+                    size="sm"
+                    variant="outline"
+                    className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
+                  >
+                    {blockingPattern === s.domainPattern ? (
+                      <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                    ) : (
+                      <Ban className="w-4 h-4 mr-1" />
+                    )}
+                    Block
+                  </Button>
+                </ReadOnlyGate>
               </li>
             ))}
           </ul>

--- a/src/components/admin/FieldExtractionReview.tsx
+++ b/src/components/admin/FieldExtractionReview.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle, XCircle, ExternalLink, CheckCheck, XOctagon, Pencil, Check, X, Quote } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import type { FieldExtractionSummary } from "@/lib/types";
 import { FIELD_DISPLAY_NAMES } from "@/lib/ai/field-display-names";
 import {
@@ -307,26 +308,28 @@ export function FieldExtractionReview({ extractions }: Props) {
             </h2>
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground mr-2">{parkExtractions.length} field{parkExtractions.length !== 1 ? "s" : ""}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleBulkApprove(parkId, parkExtractions.map(e => e.id))}
-                disabled={processingId !== null || processingBulk !== null}
-                className="text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/50 hover:bg-green-50 dark:hover:bg-green-900/20"
-              >
-                <CheckCheck className="w-4 h-4 mr-1" />
-                Approve All
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleBulkReject(parkId, parkExtractions.map(e => e.id))}
-                disabled={processingId !== null || processingBulk !== null}
-                className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
-              >
-                <XOctagon className="w-4 h-4 mr-1" />
-                Reject All
-              </Button>
+              <ReadOnlyGate>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBulkApprove(parkId, parkExtractions.map(e => e.id))}
+                  disabled={processingId !== null || processingBulk !== null}
+                  className="text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/50 hover:bg-green-50 dark:hover:bg-green-900/20"
+                >
+                  <CheckCheck className="w-4 h-4 mr-1" />
+                  Approve All
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleBulkReject(parkId, parkExtractions.map(e => e.id))}
+                  disabled={processingId !== null || processingBulk !== null}
+                  className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
+                >
+                  <XOctagon className="w-4 h-4 mr-1" />
+                  Reject All
+                </Button>
+              </ReadOnlyGate>
             </div>
           </div>
           <div className="divide-y divide-border">
@@ -368,16 +371,18 @@ export function FieldExtractionReview({ extractions }: Props) {
                           <p className="mt-1 text-xs text-red-600 dark:text-red-400">{editError}</p>
                         )}
                         <div className="mt-2 flex items-center gap-2">
-                          <Button
-                            size="sm"
-                            onClick={() => saveEdit(extraction)}
-                            disabled={processingId !== null}
-                            className="text-green-700 dark:text-green-400"
-                            variant="outline"
-                          >
-                            <Check className="w-4 h-4 mr-1" />
-                            Approve with edit
-                          </Button>
+                          <ReadOnlyGate>
+                            <Button
+                              size="sm"
+                              onClick={() => saveEdit(extraction)}
+                              disabled={processingId !== null}
+                              className="text-green-700 dark:text-green-400"
+                              variant="outline"
+                            >
+                              <Check className="w-4 h-4 mr-1" />
+                              Approve with edit
+                            </Button>
+                          </ReadOnlyGate>
                           <Button
                             size="sm"
                             variant="ghost"
@@ -426,26 +431,28 @@ export function FieldExtractionReview({ extractions }: Props) {
                     >
                       <Pencil className="w-4 h-4" />
                     </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleApprove(extraction.id)}
-                      disabled={processingId !== null}
-                      title="Approve — apply this value to the live park"
-                      className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
-                    >
-                      <CheckCircle className="w-5 h-5" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleReject(extraction.id)}
-                      disabled={processingId !== null}
-                      title="Deny — discard this proposed change"
-                      className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
-                    >
-                      <XCircle className="w-5 h-5" />
-                    </Button>
+                    <ReadOnlyGate>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => handleApprove(extraction.id)}
+                        disabled={processingId !== null}
+                        title="Approve — apply this value to the live park"
+                        className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
+                      >
+                        <CheckCircle className="w-5 h-5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => handleReject(extraction.id)}
+                        disabled={processingId !== null}
+                        title="Deny — discard this proposed change"
+                        className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
+                      >
+                        <XCircle className="w-5 h-5" />
+                      </Button>
+                    </ReadOnlyGate>
                   </div>
                 </div>
               </div>

--- a/src/components/admin/MapHeroBackfillRunner.tsx
+++ b/src/components/admin/MapHeroBackfillRunner.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import { Card } from "@/components/ui/card";
 import { Loader2, Play, Square, AlertCircle, CheckCircle2 } from "lucide-react";
 
@@ -106,10 +107,12 @@ export function MapHeroBackfillRunner({ initialRemaining }: { initialRemaining: 
             Stop
           </Button>
         ) : (
-          <Button onClick={start} disabled={state.remaining === 0}>
-            <Play className="w-4 h-4 mr-2" />
-            {state.remaining === 0 ? "All parks covered" : "Run backfill"}
-          </Button>
+          <ReadOnlyGate>
+            <Button onClick={start} disabled={state.remaining === 0}>
+              <Play className="w-4 h-4 mr-2" />
+              {state.remaining === 0 ? "All parks covered" : "Run backfill"}
+            </Button>
+          </ReadOnlyGate>
         )}
         {state.running && (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/src/components/admin/MapHeroesSection.tsx
+++ b/src/components/admin/MapHeroesSection.tsx
@@ -55,6 +55,7 @@ export async function MapHeroesSection() {
         />
       </div>
 
+      {/* The runner self-gates its Run button for read-only viewers. */}
       <MapHeroBackfillRunner initialRemaining={needingBackfill} />
     </section>
   );

--- a/src/components/admin/ParkDiscoveryTable.tsx
+++ b/src/components/admin/ParkDiscoveryTable.tsx
@@ -13,6 +13,7 @@ import {
   ListPlus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import type { ParkCandidateSummary } from "@/lib/types";
 import Link from "next/link";
 
@@ -291,23 +292,25 @@ export function ParkDiscoveryTable({ candidates }: Props) {
               ))}
             </select>
           </div>
-          <Button
-            onClick={handleDiscover}
-            disabled={discovering || !discoverState}
-            size="sm"
-          >
-            {discovering ? (
-              <>
-                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-                Searching...
-              </>
-            ) : (
-              <>
-                <Search className="w-4 h-4 mr-1" />
-                Search
-              </>
-            )}
-          </Button>
+          <ReadOnlyGate>
+            <Button
+              onClick={handleDiscover}
+              disabled={discovering || !discoverState}
+              size="sm"
+            >
+              {discovering ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Searching...
+                </>
+              ) : (
+                <>
+                  <Search className="w-4 h-4 mr-1" />
+                  Search
+                </>
+              )}
+            </Button>
+          </ReadOnlyGate>
         </div>
         {discoverResult && (
           <div
@@ -364,24 +367,26 @@ export function ParkDiscoveryTable({ candidates }: Props) {
           </div>
         </div>
         <div className="mt-3">
-          <Button
-            onClick={handleSeed}
-            disabled={seeding || !seedState || seedNameCount === 0}
-            size="sm"
-          >
-            {seeding ? (
-              <>
-                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-                Seeding...
-              </>
-            ) : (
-              <>
-                <ListPlus className="w-4 h-4 mr-1" />
-                Seed {seedNameCount > 0 ? `${seedNameCount} ` : ""}Name
-                {seedNameCount === 1 ? "" : "s"}
-              </>
-            )}
-          </Button>
+          <ReadOnlyGate>
+            <Button
+              onClick={handleSeed}
+              disabled={seeding || !seedState || seedNameCount === 0}
+              size="sm"
+            >
+              {seeding ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                  Seeding...
+                </>
+              ) : (
+                <>
+                  <ListPlus className="w-4 h-4 mr-1" />
+                  Seed {seedNameCount > 0 ? `${seedNameCount} ` : ""}Name
+                  {seedNameCount === 1 ? "" : "s"}
+                </>
+              )}
+            </Button>
+          </ReadOnlyGate>
         </div>
         {seedResult && (
           <div
@@ -398,36 +403,38 @@ export function ParkDiscoveryTable({ candidates }: Props) {
 
       {/* Bulk Actions */}
       {pendingCandidates.length > 0 && (
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleBulkAccept}
-            disabled={isProcessing}
-            className="text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/50 hover:bg-green-50 dark:hover:bg-green-900/20"
-          >
-            {processingBulk === "accept" ? (
-              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-            ) : (
-              <CheckCheck className="w-4 h-4 mr-1" />
-            )}
-            Accept All Pending ({pendingCandidates.length})
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleBulkReject}
-            disabled={isProcessing}
-            className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
-          >
-            {processingBulk === "reject" ? (
-              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-            ) : (
-              <XOctagon className="w-4 h-4 mr-1" />
-            )}
-            Reject All Pending ({pendingCandidates.length})
-          </Button>
-        </div>
+        <ReadOnlyGate>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleBulkAccept}
+              disabled={isProcessing}
+              className="text-green-700 dark:text-green-400 border-green-300 dark:border-green-900/50 hover:bg-green-50 dark:hover:bg-green-900/20"
+            >
+              {processingBulk === "accept" ? (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              ) : (
+                <CheckCheck className="w-4 h-4 mr-1" />
+              )}
+              Accept All Pending ({pendingCandidates.length})
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleBulkReject}
+              disabled={isProcessing}
+              className="text-red-700 dark:text-red-400 border-red-300 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              {processingBulk === "reject" ? (
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+              ) : (
+                <XOctagon className="w-4 h-4 mr-1" />
+              )}
+              Reject All Pending ({pendingCandidates.length})
+            </Button>
+          </div>
+        </ReadOnlyGate>
       )}
 
       {/* Candidates Table */}
@@ -507,67 +514,69 @@ export function ParkDiscoveryTable({ candidates }: Props) {
                   </td>
                   <td className="px-4 py-3">
                     {candidate.status === "PENDING" ? (
-                      <div className="flex items-center gap-1">
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          onClick={() => handleAccept(candidate.id)}
-                          disabled={isProcessing}
-                          title="Accept — create park"
-                          className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
-                        >
-                          {processingId === candidate.id ? (
-                            <Loader2 className="w-5 h-5 animate-spin" />
-                          ) : (
-                            <CheckCircle className="w-5 h-5" />
-                          )}
-                        </Button>
-                        {showRejectInput === candidate.id ? (
-                          <div className="flex items-center gap-1">
-                            <input
-                              type="text"
-                              placeholder="Reason (optional)"
-                              value={rejectReasons[candidate.id] || ""}
-                              onChange={(e) =>
-                                setRejectReasons((prev) => ({
-                                  ...prev,
-                                  [candidate.id]: e.target.value,
-                                }))
-                              }
-                              className="w-32 rounded-md border border-input bg-background text-foreground px-2 py-1 text-xs focus:border-destructive focus:ring-1 focus:ring-destructive"
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter")
-                                  handleReject(candidate.id);
-                                if (e.key === "Escape")
-                                  setShowRejectInput(null);
-                              }}
-                            />
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              onClick={() => handleReject(candidate.id)}
-                              disabled={isProcessing}
-                              title="Confirm reject"
-                              className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
-                            >
-                              <XCircle className="w-4 h-4" />
-                            </Button>
-                          </div>
-                        ) : (
+                      <ReadOnlyGate>
+                        <div className="flex items-center gap-1">
                           <Button
                             variant="ghost"
                             size="icon-sm"
-                            onClick={() =>
-                              setShowRejectInput(candidate.id)
-                            }
+                            onClick={() => handleAccept(candidate.id)}
                             disabled={isProcessing}
-                            title="Reject"
-                            className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
+                            title="Accept — create park"
+                            className="text-green-600 dark:text-green-400 hover:text-green-700 dark:hover:text-green-300 hover:bg-green-50 dark:hover:bg-green-900/20"
                           >
-                            <XCircle className="w-5 h-5" />
+                            {processingId === candidate.id ? (
+                              <Loader2 className="w-5 h-5 animate-spin" />
+                            ) : (
+                              <CheckCircle className="w-5 h-5" />
+                            )}
                           </Button>
-                        )}
-                      </div>
+                          {showRejectInput === candidate.id ? (
+                            <div className="flex items-center gap-1">
+                              <input
+                                type="text"
+                                placeholder="Reason (optional)"
+                                value={rejectReasons[candidate.id] || ""}
+                                onChange={(e) =>
+                                  setRejectReasons((prev) => ({
+                                    ...prev,
+                                    [candidate.id]: e.target.value,
+                                  }))
+                                }
+                                className="w-32 rounded-md border border-input bg-background text-foreground px-2 py-1 text-xs focus:border-destructive focus:ring-1 focus:ring-destructive"
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter")
+                                    handleReject(candidate.id);
+                                  if (e.key === "Escape")
+                                    setShowRejectInput(null);
+                                }}
+                              />
+                              <Button
+                                variant="ghost"
+                                size="icon-sm"
+                                onClick={() => handleReject(candidate.id)}
+                                disabled={isProcessing}
+                                title="Confirm reject"
+                                className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
+                              >
+                                <XCircle className="w-4 h-4" />
+                              </Button>
+                            </div>
+                          ) : (
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() =>
+                                setShowRejectInput(candidate.id)
+                              }
+                              disabled={isProcessing}
+                              title="Reject"
+                              className="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20"
+                            >
+                              <XCircle className="w-5 h-5" />
+                            </Button>
+                          )}
+                        </div>
+                      </ReadOnlyGate>
                     ) : null}
                   </td>
                 </tr>

--- a/src/components/admin/ParkManagementTable.tsx
+++ b/src/components/admin/ParkManagementTable.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Camera, CheckCircle, Edit, MapPin, Trash2, XCircle } from "lucide-react";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 type ParkStatus = "PENDING" | "APPROVED" | "REJECTED" | "DRAFT";
 
@@ -152,7 +153,7 @@ export function ParkManagementTable({
   const renderActions = (park: Park) => (
     <>
       {park.status === "PENDING" && (
-        <>
+        <ReadOnlyGate>
           <button
             onClick={() => handleApprove(park.id)}
             disabled={processingId === park.id}
@@ -169,7 +170,7 @@ export function ParkManagementTable({
           >
             <XCircle className="w-5 h-5" />
           </button>
-        </>
+        </ReadOnlyGate>
       )}
       <a
         href={`/admin/parks/${park.id}/edit`}
@@ -178,14 +179,16 @@ export function ParkManagementTable({
       >
         <Edit className="w-5 h-5" />
       </a>
-      <button
-        onClick={() => handleDelete(park.id, park.name)}
-        disabled={processingId === park.id}
-        className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-200 disabled:opacity-50 disabled:cursor-not-allowed"
-        title="Delete"
-      >
-        <Trash2 className="w-5 h-5" />
-      </button>
+      <ReadOnlyGate>
+        <button
+          onClick={() => handleDelete(park.id, park.name)}
+          disabled={processingId === park.id}
+          className="text-red-600 dark:text-red-400 hover:text-red-900 dark:hover:text-red-200 disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Delete"
+        >
+          <Trash2 className="w-5 h-5" />
+        </button>
+      </ReadOnlyGate>
     </>
   );
 

--- a/src/components/admin/SourceManagementTable.tsx
+++ b/src/components/admin/SourceManagementTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Plus, ExternalLink, Play, Loader2, ShieldCheck, ShieldOff, SkipForward, RotateCcw, Ban, Unlock } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import type { DataSourceSummary } from "@/lib/types";
 
 type Props = {
@@ -95,23 +96,25 @@ export function SourceManagementTable({ sources, parkId }: Props) {
             Crawl all sources, discover new ones via web search, and extract park data using AI.
           </p>
         </div>
-        <Button
-          onClick={handleResearch}
-          disabled={researching}
-          size="sm"
-        >
-          {researching ? (
-            <>
-              <Loader2 className="w-4 h-4 mr-1 animate-spin" />
-              Researching...
-            </>
-          ) : (
-            <>
-              <Play className="w-4 h-4 mr-1" />
-              Run Research
-            </>
-          )}
-        </Button>
+        <ReadOnlyGate>
+          <Button
+            onClick={handleResearch}
+            disabled={researching}
+            size="sm"
+          >
+            {researching ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                Researching...
+              </>
+            ) : (
+              <>
+                <Play className="w-4 h-4 mr-1" />
+                Run Research
+              </>
+            )}
+          </Button>
+        </ReadOnlyGate>
       </div>
       {researchResult && (
         <div
@@ -148,10 +151,12 @@ export function SourceManagementTable({ sources, parkId }: Props) {
             />
             Official
           </label>
-          <Button type="submit" size="sm" disabled={adding}>
-            <Plus className="w-4 h-4 mr-1" />
-            Add
-          </Button>
+          <ReadOnlyGate>
+            <Button type="submit" size="sm" disabled={adding}>
+              <Plus className="w-4 h-4 mr-1" />
+              Add
+            </Button>
+          </ReadOnlyGate>
         </div>
       </form>
 
@@ -221,6 +226,7 @@ export function SourceManagementTable({ sources, parkId }: Props) {
                     </span>
                   </td>
                   <td className="px-4 py-3">
+                    <ReadOnlyGate>
                     <div className="flex items-center gap-1">
                       {source.crawlStatus === "WRONG_PARK" ? (
                         <Button
@@ -307,6 +313,7 @@ export function SourceManagementTable({ sources, parkId }: Props) {
                         </>
                       )}
                     </div>
+                    </ReadOnlyGate>
                   </td>
                 </tr>
               ))}

--- a/src/components/admin/UserManagementTable.tsx
+++ b/src/components/admin/UserManagementTable.tsx
@@ -4,10 +4,16 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Users as UsersIcon } from "lucide-react";
 
-export type AssignableRole = "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN";
+export type AssignableRole =
+  | "USER"
+  | "OPERATOR"
+  | "ADMIN"
+  | "SUPER_ADMIN"
+  | "BETA_TESTER";
 
 const ASSIGNABLE_ROLES: AssignableRole[] = [
   "USER",
+  "BETA_TESTER",
   "OPERATOR",
   "ADMIN",
   "SUPER_ADMIN",
@@ -38,6 +44,8 @@ function roleBadgeClass(role: string): string {
       return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300";
     case "OPERATOR":
       return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+    case "BETA_TESTER":
+      return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
     default:
       return "bg-muted text-foreground";
   }

--- a/src/components/admin/read-only.tsx
+++ b/src/components/admin/read-only.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  type ReactNode,
+} from "react";
+import { Eye } from "lucide-react";
+import { READ_ONLY_ADMIN_MESSAGE } from "@/lib/roles";
+
+/**
+ * Read-only admin UI primitives.
+ *
+ * When a BETA_TESTER opens the admin console the whole tree is put in
+ * read-only mode. Mutating controls get wrapped in <ReadOnlyGate> which greys
+ * them out, swallows clicks, and shows a "view-only" popover on hover.
+ * Navigation, filtering and search controls are left alone so beta testers can
+ * still explore. Server-side guards (requireAdmin) are the real enforcement —
+ * this layer is purely UX.
+ */
+
+const AdminReadOnlyContext = createContext(false);
+
+/** Provides the read-only flag to every admin client component. */
+export function AdminReadOnlyProvider({
+  isReadOnly,
+  children,
+}: {
+  isReadOnly: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <AdminReadOnlyContext.Provider value={isReadOnly}>
+      {children}
+    </AdminReadOnlyContext.Provider>
+  );
+}
+
+/** True when the current viewer has view-only (beta tester) admin access. */
+export function useAdminReadOnly(): boolean {
+  return useContext(AdminReadOnlyContext);
+}
+
+/**
+ * Wraps a mutating control (button, form, link that performs an action). In
+ * read-only mode it renders the child greyed and inert, and shows a popover on
+ * hover explaining that the viewer only has view access. Outside read-only
+ * mode it renders the child untouched.
+ *
+ * Interaction is blocked with `inert` on an inner wrapper (removes the subtree
+ * from tab order and swallows pointer/keyboard events) while the outer wrapper
+ * keeps pointer events so the hover popover still fires.
+ */
+export function ReadOnlyGate({
+  children,
+  message = READ_ONLY_ADMIN_MESSAGE,
+  className = "",
+  block = false,
+}: {
+  children: ReactNode;
+  /** Popover copy. Defaults to the shared view-only message. */
+  message?: string;
+  /** Extra classes on the outer wrapper. */
+  className?: string;
+  /** Use an inline-block wrapper instead of inline-flex (for block controls). */
+  block?: boolean;
+}) {
+  const isReadOnly = useAdminReadOnly();
+
+  if (!isReadOnly) return <>{children}</>;
+
+  return (
+    <span
+      className={`group/readonly relative ${
+        block ? "inline-block" : "inline-flex"
+      } cursor-not-allowed align-middle ${className}`}
+    >
+      {/*
+        `inert` makes the subtree non-interactive and non-focusable; opacity +
+        cursor communicate "disabled". The wrapper span above still receives
+        hover, which drives the popover below.
+      */}
+      <span inert aria-hidden="true" className="pointer-events-none opacity-50">
+        {children}
+      </span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-1/2 top-full z-50 mt-2 hidden w-56 -translate-x-1/2 rounded-md border border-border bg-popover px-3 py-2 text-xs font-medium text-popover-foreground shadow-md group-hover/readonly:block"
+      >
+        {message}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * Sticky banner shown at the top of the admin console for read-only viewers.
+ */
+export function ReadOnlyBanner() {
+  return (
+    <div className="flex items-center gap-2 border-b border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+      <Eye className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+      <span>
+        <strong className="font-semibold">View-only beta access.</strong> You
+        can browse the admin tooling, but actions are disabled.
+      </span>
+    </div>
+  );
+}

--- a/src/components/forms/ParkSubmissionForm.tsx
+++ b/src/components/forms/ParkSubmissionForm.tsx
@@ -24,6 +24,7 @@ import { TerrainCheckboxGroup } from "@/components/forms/park-fields/TerrainChec
 import { VehicleTypesCheckboxGroup } from "@/components/forms/park-fields/VehicleTypesCheckboxGroup";
 import { Image as ImageIcon, Loader2, X } from "lucide-react";
 import Image from "next/image";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 
 interface FormData {
   name: string;
@@ -901,20 +902,22 @@ export function ParkSubmissionForm({
       )}
 
       <div className="flex gap-3">
-        <Button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? (
-            <>
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              {isEditMode ? "Updating..." : "Submitting..."}
-            </>
-          ) : isEditMode ? (
-            "Update Park"
-          ) : isAdminForm ? (
-            "Create Park"
-          ) : (
-            "Submit for Review"
-          )}
-        </Button>
+        <ReadOnlyGate>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                {isEditMode ? "Updating..." : "Submitting..."}
+              </>
+            ) : isEditMode ? (
+              "Update Park"
+            ) : isAdminForm ? (
+              "Create Park"
+            ) : (
+              "Submit for Review"
+            )}
+          </Button>
+        </ReadOnlyGate>
         <Button
           type="button"
           variant="outline"

--- a/src/components/layout/UserMenu.tsx
+++ b/src/components/layout/UserMenu.tsx
@@ -23,7 +23,10 @@ interface UserMenuProps {
 
 export function UserMenu({ user, onSignOut }: UserMenuProps) {
   const isAdmin = user.role === "ADMIN" || user.role === "SUPER_ADMIN";
-  const showPrivilegedSection = isAdmin || user.role === "OPERATOR";
+  // Beta testers get read-only admin access — surface the Admin Panel link,
+  // but not operator tooling.
+  const canViewAdmin = isAdmin || user.role === "BETA_TESTER";
+  const showPrivilegedSection = canViewAdmin || user.role === "OPERATOR";
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -40,7 +43,7 @@ export function UserMenu({ user, onSignOut }: UserMenuProps) {
         {showPrivilegedSection && (
           <>
             <DropdownMenuSeparator />
-            {isAdmin && (
+            {canViewAdmin && (
               <DropdownMenuItem asChild>
                 <Link href="/admin" className="cursor-pointer">
                   <Settings className="w-4 h-4 mr-2" />
@@ -48,12 +51,14 @@ export function UserMenu({ user, onSignOut }: UserMenuProps) {
                 </Link>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem asChild>
-              <Link href="/operator" className="cursor-pointer">
-                <Building2 className="w-4 h-4 mr-2" />
-                Manage Parks
-              </Link>
-            </DropdownMenuItem>
+            {user.role !== "BETA_TESTER" && (
+              <DropdownMenuItem asChild>
+                <Link href="/operator" className="cursor-pointer">
+                  <Building2 className="w-4 h-4 mr-2" />
+                  Manage Parks
+                </Link>
+              </DropdownMenuItem>
+            )}
           </>
         )}
         <DropdownMenuSeparator />

--- a/src/components/moderation/ConditionModerationTable.tsx
+++ b/src/components/moderation/ConditionModerationTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, ExternalLink, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import Link from "next/link";
 import {
   CONDITION_LABELS,
@@ -232,25 +233,27 @@ export function ConditionModerationTable({
 
                     <td className="px-6 py-4">
                       {isPending ? (
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            onClick={() => handleApprove(condition.id)}
-                            disabled={processingId === condition.id}
-                          >
-                            <Check className="w-4 h-4 mr-1" />
-                            Approve
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => handleReject(condition.id)}
-                            disabled={processingId === condition.id}
-                          >
-                            <X className="w-4 h-4 mr-1" />
-                            Reject
-                          </Button>
-                        </div>
+                        <ReadOnlyGate>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => handleApprove(condition.id)}
+                              disabled={processingId === condition.id}
+                            >
+                              <Check className="w-4 h-4 mr-1" />
+                              Approve
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => handleReject(condition.id)}
+                              disabled={processingId === condition.id}
+                            >
+                              <X className="w-4 h-4 mr-1" />
+                              Reject
+                            </Button>
+                          </div>
+                        </ReadOnlyGate>
                       ) : (
                         <span className="text-xs text-green-600 dark:text-green-400 font-medium">
                           Published

--- a/src/components/moderation/PhotoModerationTable.tsx
+++ b/src/components/moderation/PhotoModerationTable.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Check, ExternalLink, Trash2, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import Link from "next/link";
 
 export interface ModerationPhoto {
@@ -136,33 +137,35 @@ export function PhotoModerationTable({
   };
 
   const renderPhotoActions = (photo: ModerationPhoto) => (
-    <div className="flex gap-2 pt-2">
-      {photo.status === "PENDING" && (
-        <>
-          <Button size="sm" onClick={() => handleApprove(photo.id)} disabled={processingId === photo.id} className="flex-1">
-            <Check className="w-4 h-4 mr-1" /> Approve
+    <ReadOnlyGate>
+      <div className="flex gap-2 pt-2">
+        {photo.status === "PENDING" && (
+          <>
+            <Button size="sm" onClick={() => handleApprove(photo.id)} disabled={processingId === photo.id} className="flex-1">
+              <Check className="w-4 h-4 mr-1" /> Approve
+            </Button>
+            <Button size="sm" variant="destructive" onClick={() => handleReject(photo.id)} disabled={processingId === photo.id} className="flex-1">
+              <X className="w-4 h-4 mr-1" /> Reject
+            </Button>
+          </>
+        )}
+        {photo.status === "REJECTED" && (
+          <>
+            <Button size="sm" onClick={() => handleApprove(photo.id)} disabled={processingId === photo.id} className="flex-1">
+              <Check className="w-4 h-4 mr-1" /> Approve
+            </Button>
+            <Button size="sm" variant="destructive" onClick={() => handleDelete(photo.id)} disabled={processingId === photo.id}>
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </>
+        )}
+        {photo.status === "APPROVED" && (
+          <Button size="sm" variant="destructive" onClick={() => handleDelete(photo.id)} disabled={processingId === photo.id} className="flex-1">
+            <Trash2 className="w-4 h-4 mr-1" /> Delete
           </Button>
-          <Button size="sm" variant="destructive" onClick={() => handleReject(photo.id)} disabled={processingId === photo.id} className="flex-1">
-            <X className="w-4 h-4 mr-1" /> Reject
-          </Button>
-        </>
-      )}
-      {photo.status === "REJECTED" && (
-        <>
-          <Button size="sm" onClick={() => handleApprove(photo.id)} disabled={processingId === photo.id} className="flex-1">
-            <Check className="w-4 h-4 mr-1" /> Approve
-          </Button>
-          <Button size="sm" variant="destructive" onClick={() => handleDelete(photo.id)} disabled={processingId === photo.id}>
-            <Trash2 className="w-4 h-4" />
-          </Button>
-        </>
-      )}
-      {photo.status === "APPROVED" && (
-        <Button size="sm" variant="destructive" onClick={() => handleDelete(photo.id)} disabled={processingId === photo.id} className="flex-1">
-          <Trash2 className="w-4 h-4 mr-1" /> Delete
-        </Button>
-      )}
-    </div>
+        )}
+      </div>
+    </ReadOnlyGate>
   );
 
   const renderPhotoCard = (photo: ModerationPhoto) => (

--- a/src/components/moderation/ReviewModerationTable.tsx
+++ b/src/components/moderation/ReviewModerationTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { ReadOnlyGate } from "@/components/admin/read-only";
 import {
   Table,
   TableBody,
@@ -84,51 +85,53 @@ export function ReviewModerationTable({
     const isApproved = review.status === "APPROVED";
 
     return (
-      <div className="flex gap-2">
-        {!isApproved && (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => handleAction(review.id, "approve")}
-            disabled={processingId === review.id}
-          >
-            Approve
-          </Button>
-        )}
-        {isHidden ? (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => handleAction(review.id, "restore")}
-            disabled={processingId === review.id}
-          >
-            Restore
-          </Button>
-        ) : (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => handleAction(review.id, "hide")}
-            disabled={processingId === review.id}
-          >
-            Hide
-          </Button>
-        )}
-        {actions.delete && (
-          <Button
-            size="sm"
-            variant="destructive"
-            onClick={() => {
-              if (confirm("Are you sure you want to permanently delete this review?")) {
-                handleAction(review.id, "delete");
-              }
-            }}
-            disabled={processingId === review.id}
-          >
-            Delete
-          </Button>
-        )}
-      </div>
+      <ReadOnlyGate>
+        <div className="flex gap-2">
+          {!isApproved && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleAction(review.id, "approve")}
+              disabled={processingId === review.id}
+            >
+              Approve
+            </Button>
+          )}
+          {isHidden ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleAction(review.id, "restore")}
+              disabled={processingId === review.id}
+            >
+              Restore
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleAction(review.id, "hide")}
+              disabled={processingId === review.id}
+            >
+              Hide
+            </Button>
+          )}
+          {actions.delete && (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={() => {
+                if (confirm("Are you sure you want to permanently delete this review?")) {
+                  handleAction(review.id, "delete");
+                }
+              }}
+              disabled={processingId === review.id}
+            >
+              Delete
+            </Button>
+          )}
+        </div>
+      </ReadOnlyGate>
     );
   };
 

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -6,15 +6,15 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import type { Session } from "next-auth";
 import { auth } from "@/lib/auth";
+import { canAdminWrite, canAdminView } from "@/lib/roles";
 
 /** A session that is guaranteed to have a user (post-auth-guard). */
 type AuthenticatedSession = Session & { user: NonNullable<Session["user"]> };
 
-/** Roles that grant access to the admin console. */
-const ADMIN_ROLES = new Set(["ADMIN", "SUPER_ADMIN"]);
-
 /**
- * Verify the request comes from an authenticated admin (ADMIN or SUPER_ADMIN).
+ * Verify the request comes from an admin allowed to MUTATE (ADMIN or
+ * SUPER_ADMIN). Read-only beta testers are rejected here — use this guard on
+ * every mutating handler (POST/PATCH/PUT/DELETE).
  * Returns the session on success, or a NextResponse 401/403 on failure.
  *
  * Usage:
@@ -29,7 +29,26 @@ export async function requireAdmin(): Promise<
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  if (!ADMIN_ROLES.has(session.user.role ?? "")) {
+  if (!canAdminWrite(session.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return session as AuthenticatedSession;
+}
+
+/**
+ * Verify the request comes from a user allowed to VIEW the admin console
+ * (ADMIN, SUPER_ADMIN, or read-only BETA_TESTER). Use this on read-only
+ * handlers (GET) that back admin pages, so beta testers can browse the data.
+ * Returns the session on success, or a NextResponse 401/403 on failure.
+ */
+export async function requireAdminView(): Promise<
+  AuthenticatedSession | NextResponse
+> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!canAdminView(session.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   return session as AuthenticatedSession;

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,41 @@
+/**
+ * Central role helpers for the admin console.
+ *
+ * Two distinct capabilities gate the admin area:
+ *   - VIEW  — can open admin pages and read admin data (GET endpoints).
+ *   - WRITE — can perform mutating admin actions (POST/PATCH/PUT/DELETE).
+ *
+ * BETA_TESTER has VIEW but not WRITE: a read-only tour of the admin tooling.
+ * Every mutating guard must use the WRITE set (`ADMIN_ROLES`) so beta testers
+ * are rejected server-side; page/GET guards use the VIEW set. The read-only UI
+ * (greyed buttons + "view-only" popover) is driven by `isReadOnlyAdmin`, but is
+ * cosmetic only — the server is the source of truth.
+ */
+
+/** Roles allowed to perform mutating admin actions. */
+export const ADMIN_ROLES = ["ADMIN", "SUPER_ADMIN"] as const;
+
+/** Roles allowed to VIEW the admin console (includes read-only beta testers). */
+export const ADMIN_VIEW_ROLES = [...ADMIN_ROLES, "BETA_TESTER"] as const;
+
+/** True if the role may perform mutating admin actions. */
+export function canAdminWrite(role: string | null | undefined): boolean {
+  return role != null && (ADMIN_ROLES as readonly string[]).includes(role);
+}
+
+/** True if the role may view the admin console (write access or read-only). */
+export function canAdminView(role: string | null | undefined): boolean {
+  return role != null && (ADMIN_VIEW_ROLES as readonly string[]).includes(role);
+}
+
+/**
+ * True if the role can view but NOT modify the admin console. Drives the
+ * read-only UI treatment (disabled controls + "view-only" popover).
+ */
+export function isReadOnlyAdmin(role: string | null | undefined): boolean {
+  return canAdminView(role) && !canAdminWrite(role);
+}
+
+/** Shared copy for the read-only popover / banner. */
+export const READ_ONLY_ADMIN_MESSAGE =
+  "You have view-only beta access — admin actions are disabled.";

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -9,13 +9,13 @@ declare module "next-auth" {
       name?: string | null;
       email?: string | null;
       image?: string | null;
-      /** User role — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | undefined */
+      /** User role — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | "BETA_TESTER" | undefined */
       role?: string;
     };
   }
 
   interface User {
-    /** User role stored in DB — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | null */
+    /** User role stored in DB — "USER" | "OPERATOR" | "ADMIN" | "SUPER_ADMIN" | "BETA_TESTER" | null */
     role?: string | null;
   }
 }

--- a/test/lib/api-helpers.test.ts
+++ b/test/lib/api-helpers.test.ts
@@ -1,6 +1,7 @@
 import {
   parseJsonBody,
   requireAdmin,
+  requireAdminView,
   requireAuth,
   requireSuperAdmin,
 } from "@/lib/api-helpers";
@@ -73,6 +74,56 @@ describe("requireAdmin", () => {
     expect(result).not.toBeInstanceOf(NextResponse);
     expect(result).toEqual(session);
   });
+
+  it("should return 403 for a read-only beta tester (no write access)", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "beta-1", role: "BETA_TESTER" },
+    });
+
+    const result = await requireAdmin();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+  });
+});
+
+describe("requireAdminView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 401 when no session", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await requireAdminView();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(401);
+  });
+
+  it("should return 403 for a regular user", async () => {
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "user-1", role: "USER" },
+    });
+
+    const result = await requireAdminView();
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+  });
+
+  it.each(["ADMIN", "SUPER_ADMIN", "BETA_TESTER"])(
+    "should return the session for %s (view access)",
+    async (role) => {
+      const session = { user: { id: `${role}-1`, role } };
+      (auth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
+
+      const result = await requireAdminView();
+
+      expect(result).not.toBeInstanceOf(NextResponse);
+      expect(result).toEqual(session);
+    },
+  );
 });
 
 describe("requireSuperAdmin", () => {


### PR DESCRIPTION
## Summary

Introduces a **`BETA_TESTER`** user role that grants a **view-only tour of the admin console**. Beta testers can browse every admin page but cannot perform any mutating action.

## Enforcement (server-side — source of truth)

- New `BETA_TESTER` value on the `UserRole` enum + migration.
- Central role helpers in `src/lib/roles.ts` (`canAdminWrite` / `canAdminView` / `isReadOnlyAdmin`) and a new `requireAdminView()` guard.
- Mutating routes keep `requireAdmin` (ADMIN / SUPER_ADMIN only), so beta testers are rejected from **every** write automatically. Read-only GET handlers and the admin layout/pages were widened to view access so beta testers can read the data.

## UI (cosmetic layer)

- `AdminReadOnlyProvider` context + a sticky **"View-only beta access"** banner.
- A `ReadOnlyGate` wrapper that greys out, makes inert (blocks pointer + keyboard), and shows a hover popover on mutating controls. Navigation, filtering, and search stay usable.
- `ReadOnlyGate` applied to the mutating action buttons across admin tables, moderation views (parks, photos, reviews, conditions, claims), bulk upload/research, AI-research tooling, operators, and the park submission/edit form. It renders children verbatim outside the read-only context, so normal admin and operator views are unaffected.
- `BETA_TESTER` is assignable via the People & Access role picker and pre-grants (with its own badge); the Admin Panel link appears for beta testers in the user menu, while operator tooling does not.

## Scope note

Pre-grants stays SUPER_ADMIN-only (restricted even for regular admins), so beta testers don't see that tab — it's already conditionally hidden, so there's no dead link.

## Testing

- `tsc --noEmit` clean, `eslint` clean.
- Full suite green: **2266 passing / 2 skipped**.
- New tests cover `requireAdmin` rejecting `BETA_TESTER` and `requireAdminView` admitting the view roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AH8BYC7Gq9nVg7TirdxAx

---
_Generated by [Claude Code](https://claude.ai/code/session_013AH8BYC7Gq9nVg7TirdxAx)_