### PR TITLE
Allow BETA_TESTER as a pre-grant role

### DIFF
--- a/src/app/api/admin/pre-grants/route.ts
+++ b/src/app/api/admin/pre-grants/route.ts
@@ -4,7 +4,13 @@ import { prisma } from "@/lib/prisma";
 
 export const runtime = "nodejs";
 
-const ASSIGNABLE_ROLES = ["USER", "OPERATOR", "ADMIN", "SUPER_ADMIN"] as const;
+const ASSIGNABLE_ROLES = [
+  "USER",
+  "BETA_TESTER",
+  "OPERATOR",
+  "ADMIN",
+  "SUPER_ADMIN",
+] as const;
 type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
 
 interface SuperAdminContext {

--- a/test/app/api/admin/pre-grants/route.test.ts
+++ b/test/app/api/admin/pre-grants/route.test.ts
@@ -156,6 +156,29 @@ describe("POST /api/admin/pre-grants", () => {
     });
   });
 
+  it("accepts BETA_TESTER as a grantable role", async () => {
+    vi.mocked(auth).mockResolvedValue(superAdmin as any);
+    vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.userPreGrant.create).mockResolvedValue({
+      id: "pg-beta",
+      email: "beta@y.com",
+      grantRole: "BETA_TESTER",
+      operatorParkSlug: null,
+    } as any);
+
+    const res = await POST(
+      jsonRequest({ email: "beta@y.com", grantRole: "BETA_TESTER" }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(prisma.userPreGrant.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        email: "beta@y.com",
+        grantRole: "BETA_TESTER",
+      }),
+    });
+  });
+
   it("creates a pre-grant with role + operator slug after validating the park", async () => {
     vi.mocked(auth).mockResolvedValue(superAdmin as any);
     vi.mocked(prisma.userPreGrant.findUnique).mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Follow-up to #191. Pre-granting the new `BETA_TESTER` role by email was rejected with **"Invalid role"** because the pre-grants POST route (`src/app/api/admin/pre-grants/route.ts`) carries its own `ASSIGNABLE_ROLES` allowlist that still excluded `BETA_TESTER` — separate from the role picker and the user-role API that were already updated.

## Change

- Add `BETA_TESTER` to the pre-grants route's `ASSIGNABLE_ROLES`, matching the People & Access role picker and `PATCH /api/admin/users/[id]/role`.
- Add a regression test asserting `BETA_TESTER` is accepted as a grantable pre-grant role.

## Testing

- Full suite green: **2267 passing / 2 skipped** (pre-commit hook).
- `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AH8BYC7Gq9nVg7TirdxAx

---
_Generated by [Claude Code](https://claude.ai/code/session_013AH8BYC7Gq9nVg7TirdxAx)_