### PR TITLE
fix(filters): let desktop facet sidebar scroll independently

### DIFF
--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -420,8 +420,15 @@ function OffroadParksAppInner({
           {/* Desktop sidebar — hidden on mobile, shown in the sheet above.
               Sticks beneath the pinned header while the list scrolls. */}
           <div
-            className="hidden w-72 shrink-0 lg:block lg:sticky lg:self-start lg:max-h-[calc(100vh-1rem)] lg:overflow-y-auto"
-            style={{ top: stickyOffset ? stickyOffset + 16 : undefined }}
+            className="hidden w-72 shrink-0 lg:block lg:sticky lg:self-start lg:overflow-y-auto"
+            style={{
+              top: stickyOffset ? stickyOffset + 16 : undefined,
+              // Fit the scroll box within the space visible below the pinned
+              // header (top offset) with a matching 16px gap at the bottom, so
+              // the facets' own scrollbar reveals every filter without needing
+              // to scroll the whole page down first.
+              maxHeight: `calc(100vh - ${stickyOffset + 32}px)`,
+            }}
           >
             {filtersPanel}
           </div>


### PR DESCRIPTION
## Problem

On desktop, you couldn't scroll to the bottom of the filters/facets sidebar unless you scrolled the whole main page to its end. With few filters selected the list stays short, so the tail of the facets could stay unreachable for a long time — a byproduct of making the sidebar sticky when the facets box is taller than a typical monitor's viewport.

## Cause

In `src/components/ui/OffroadParksApp.tsx`, the sticky desktop sidebar pinned itself at `top: stickyOffset + 16px` (directly beneath the pinned header) but capped its height at `max-h-[calc(100vh-1rem)]`, which ignored that top offset. The scroll box was therefore taller than the space actually visible below the header, so its bottom `stickyOffset` pixels hung off-screen. The sidebar's own `overflow-y-auto` scrollbar couldn't reveal those trailing facets, leaving page-scroll as the only way to reach them.

## Fix

Compute the sidebar's `max-height` as `calc(100vh - stickyOffset - 32px)` so the scroll box fits exactly within the viewport below the header (with a matching 16px bottom gap). Its own scrollbar now exposes every filter without touching the page scroll.

CSS-only change scoped to the desktop (`lg:`) sidebar — the mobile filter sheet and overall page layout are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01553qa1frEnYKSXqBw8nJnY

---
_Generated by [Claude Code](https://claude.ai/code/session_01553qa1frEnYKSXqBw8nJnY)_