### PR TITLE
Contribution CTAs + structured weekly hours

### DIFF
--- a/prisma/migrations/20260728000000_park_structured_hours/migration.sql
+++ b/prisma/migrations/20260728000000_park_structured_hours/migration.sql
@@ -1,0 +1,6 @@
+-- Structured weekly opening hours (display-only). JSON blob shaped as
+-- { mon..sun: { open: "HH:MM", close: "HH:MM" } | { closed: true } | null }.
+-- Validated server-side via weeklyHoursSchema (src/lib/hours.ts). The existing
+-- free-text `datesOpen` column stays as "season notes" alongside this.
+-- Nullable, so existing rows simply have no structured hours.
+ALTER TABLE "Park" ADD COLUMN "hours" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,11 @@ model Park {
 
   // New operational fields
   datesOpen              String?
+  // Structured weekly opening hours (display-only). Shape: { mon..sun:
+  // { open: "HH:MM", close: "HH:MM" } | { closed: true } | null }. Validated
+  // via weeklyHoursSchema in src/lib/hours.ts. `datesOpen` remains the
+  // free-text "season notes" field alongside this.
+  hours                  Json?
   contactEmail           String?
   ownership              Ownership?
   permitRequired         Boolean?

--- a/src/app/admin/parks/[id]/edit/page.tsx
+++ b/src/app/admin/parks/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { ParkSubmissionForm } from "@/components/forms/ParkSubmissionForm";
 import { canAdminView } from "@/lib/roles";
+import { emptyWeeklyHours, parseWeeklyHours } from "@/lib/hours";
 
 interface EditParkPageProps {
   params: Promise<{
@@ -70,6 +71,7 @@ export default async function EditParkPage({ params }: EditParkPageProps) {
     vehicleTypes: park.vehicleTypes.map((v) => v.vehicleType),
     // New scalar fields
     datesOpen: park.datesOpen || "",
+    hours: parseWeeklyHours(park.hours) ?? emptyWeeklyHours(),
     contactEmail: park.contactEmail || "",
     ownership: park.ownership || "",
     permitRequired: park.permitRequired || false,

--- a/src/app/api/admin/parks/[id]/route.ts
+++ b/src/app/api/admin/parks/[id]/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from "next/server";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { generateMapHeroAsync } from "@/lib/map-hero/generate";
 import { normalizeStateName } from "@/lib/us-states";
+import { weeklyHoursSchema } from "@/lib/hours";
 
 interface RouteParams {
   params: Promise<{
@@ -78,6 +80,25 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       county: _co,
       ...parkData
     } = body;
+
+    // Validate structured weekly hours (Json). `null` clears the schedule; an
+    // object is validated against weeklyHoursSchema before being written.
+    if ("hours" in parkData) {
+      if (parkData.hours === null) {
+        parkData.hours = Prisma.JsonNull;
+      } else {
+        const parsedHours = weeklyHoursSchema.safeParse(parkData.hours);
+        if (!parsedHours.success) {
+          return NextResponse.json(
+            {
+              error: `Invalid hours: ${parsedHours.error.issues[0]?.message ?? "malformed schedule"}`,
+            },
+            { status: 400 }
+          );
+        }
+        parkData.hours = parsedHours.data;
+      }
+    }
 
     // Read existing coords so we can detect a change and regenerate the
     // map hero only when needed (OP-90).

--- a/src/app/api/operator/parks/[parkSlug]/route.ts
+++ b/src/app/api/operator/parks/[parkSlug]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { weeklyHoursSchema } from "@/lib/hours";
 
 export const runtime = "nodejs";
 
@@ -57,6 +59,7 @@ const PARK_SCALAR_SELECT = {
   campingPhone: true,
   notes: true,
   datesOpen: true,
+  hours: true,
   contactEmail: true,
   isFree: true,
   dayPassUSD: true,
@@ -173,6 +176,33 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (currentValue !== normalized) {
       updateData[key] = normalized;
       changes[key] = { from: currentValue, to: normalized };
+    }
+  }
+
+  // Structured weekly hours (Json). Validated explicitly (not part of the
+  // generic scalar loop). `null` clears the schedule; an object is validated
+  // against weeklyHoursSchema.
+  if ("hours" in body) {
+    const raw = body.hours;
+    if (raw === null) {
+      if (park.hours !== null) {
+        updateData.hours = Prisma.JsonNull;
+        changes.hours = { from: park.hours, to: null };
+      }
+    } else {
+      const parsedHours = weeklyHoursSchema.safeParse(raw);
+      if (!parsedHours.success) {
+        return NextResponse.json(
+          {
+            error: `Invalid hours: ${parsedHours.error.issues[0]?.message ?? "malformed schedule"}`,
+          },
+          { status: 400 }
+        );
+      }
+      if (JSON.stringify(park.hours) !== JSON.stringify(parsedHours.data)) {
+        updateData.hours = parsedHours.data;
+        changes.hours = { from: park.hours, to: parsedHours.data };
+      }
     }
   }
 

--- a/src/app/api/parks/submit/route.ts
+++ b/src/app/api/parks/submit/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { generateMapHeroAsync } from "@/lib/map-hero/generate";
 import { normalizeStateName } from "@/lib/us-states";
+import { weeklyHoursSchema, type WeeklyHours } from "@/lib/hours";
 import type {
   Amenity,
   Camping,
@@ -46,6 +47,7 @@ interface SubmitParkRequest {
   vehicleTypes?: string[];
   // New operational fields
   datesOpen?: string;
+  hours?: WeeklyHours | null;
   contactEmail?: string;
   ownership?: string;
   permitRequired?: boolean;
@@ -113,6 +115,21 @@ export async function POST(request: Request) {
       );
     }
 
+    // Validate structured weekly hours (display-only). Absent/null → no hours.
+    let hoursData: WeeklyHours | undefined;
+    if (data.hours != null) {
+      const parsedHours = weeklyHoursSchema.safeParse(data.hours);
+      if (!parsedHours.success) {
+        return NextResponse.json(
+          {
+            error: `Invalid hours: ${parsedHours.error.issues[0]?.message ?? "malformed schedule"}`,
+          },
+          { status: 400 },
+        );
+      }
+      hoursData = parsedHours.data;
+    }
+
     // Validate optional operator claim up-front so we don't create the park
     // only to fail on the claim afterwards.
     if (data.claim) {
@@ -171,6 +188,9 @@ export async function POST(request: Request) {
         submitterName: data.submitterName || null,
         // New operational fields
         datesOpen: data.datesOpen || null,
+        // Structured weekly hours (Json?). Omitted when absent so the column
+        // stays NULL.
+        hours: hoursData ?? undefined,
         contactEmail: data.contactEmail || null,
         ownership: data.ownership ? (data.ownership as Ownership) : null,
         permitRequired: data.permitRequired ?? null,

--- a/src/app/operator/[parkSlug]/settings/OperatorSettingsClient.tsx
+++ b/src/app/operator/[parkSlug]/settings/OperatorSettingsClient.tsx
@@ -8,7 +8,9 @@ import { CampingSection } from "@/components/forms/park-fields/CampingSection";
 import { RequirementsSection } from "@/components/forms/park-fields/RequirementsSection";
 import { TerrainCheckboxGroup } from "@/components/forms/park-fields/TerrainCheckboxGroup";
 import { VehicleTypesCheckboxGroup } from "@/components/forms/park-fields/VehicleTypesCheckboxGroup";
+import { WeeklyHoursEditor } from "@/components/forms/park-fields/WeeklyHoursEditor";
 import type { RequirementsValues } from "@/components/forms/park-fields/RequirementsSection";
+import { parseWeeklyHours, weeklyHoursSchema, type WeeklyHours } from "@/lib/hours";
 import { CheckCircle, MapPin } from "lucide-react";
 
 interface ParkData {
@@ -20,6 +22,7 @@ interface ParkData {
   campingPhone: string | null;
   notes: string | null;
   datesOpen: string | null;
+  hours: WeeklyHours | null;
   contactEmail: string | null;
   isFree: boolean | null;
   dayPassUSD: number | null;
@@ -58,7 +61,9 @@ export function OperatorSettingsClient({ parkSlug, parkName }: OperatorSettingsC
     fetch(`/api/operator/parks/${parkSlug}`)
       .then((r) => r.json())
       .then((data) => {
-        if (data.park) setPark(data.park);
+        if (data.park) {
+          setPark({ ...data.park, hours: parseWeeklyHours(data.park.hours) });
+        }
       })
       .catch(console.error)
       .finally(() => setIsLoading(false));
@@ -79,6 +84,17 @@ export function OperatorSettingsClient({ parkSlug, parkName }: OperatorSettingsC
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!park) return;
+
+    // Validate structured weekly hours before saving.
+    if (park.hours) {
+      const hoursResult = weeklyHoursSchema.safeParse(park.hours);
+      if (!hoursResult.success) {
+        setSaveError(
+          `Please fix the weekly hours: ${hoursResult.error.issues[0]?.message ?? "invalid hours"}`,
+        );
+        return;
+      }
+    }
 
     setSaveError(null);
     setSaveSuccess(false);
@@ -206,6 +222,18 @@ export function OperatorSettingsClient({ parkSlug, parkName }: OperatorSettingsC
                   placeholder="Year-round / May–October"
                 />
               </div>
+            </div>
+            <div>
+              <label className="text-sm font-medium block mb-1">Weekly Hours</label>
+              <p className="text-xs text-muted-foreground mb-3">
+                Set open and close times per day, or mark a day Closed. Leave a
+                day blank if hours are unknown. Use &ldquo;Dates Open&rdquo; for
+                season notes.
+              </p>
+              <WeeklyHoursEditor
+                value={park.hours}
+                onChange={(v) => handleChange("hours", v)}
+              />
             </div>
             <div>
               <label className="text-sm font-medium block mb-1">Description / Notes</label>

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -9,6 +9,7 @@ import type { ParkAlertDisplay } from "@/components/parks/ParkAlertsBanner";
 import { getActiveAlerts, getCurrentConditions, getForecast } from "@/lib/weather";
 import { SITE_URL } from "@/lib/site";
 import { JsonLd } from "@/components/seo/JsonLd";
+import { toOpeningHoursSpecification } from "@/lib/hours";
 
 interface ParkPageProps {
   params: Promise<{ id: string }>;
@@ -272,6 +273,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
   // Build schema.org TouristAttraction structured data for rich results.
   const canonicalUrl = `${SITE_URL}/parks/${dbPark.slug}`;
   const absoluteHero = toAbsoluteUrl(park.heroImage ?? park.mapHeroUrl);
+  // Structured weekly hours → schema.org OpeningHoursSpecification (SEO). Only
+  // days with an explicit open/close window contribute; empty → omitted.
+  const openingHours = toOpeningHoursSpecification(park.hours);
   const jsonLd: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "TouristAttraction",
@@ -303,6 +307,9 @@ export default async function ParkPage({ params }: ParkPageProps) {
             reviewCount: park.reviewCount,
           },
         }
+      : {}),
+    ...(openingHours.length > 0
+      ? { openingHoursSpecification: openingHours }
       : {}),
   };
 

--- a/src/components/forms/ParkSubmissionForm.tsx
+++ b/src/components/forms/ParkSubmissionForm.tsx
@@ -22,6 +22,8 @@ import { CampingSection } from "@/components/forms/park-fields/CampingSection";
 import { RequirementsSection } from "@/components/forms/park-fields/RequirementsSection";
 import { TerrainCheckboxGroup } from "@/components/forms/park-fields/TerrainCheckboxGroup";
 import { VehicleTypesCheckboxGroup } from "@/components/forms/park-fields/VehicleTypesCheckboxGroup";
+import { WeeklyHoursEditor } from "@/components/forms/park-fields/WeeklyHoursEditor";
+import { emptyWeeklyHours, weeklyHoursSchema, type WeeklyHours } from "@/lib/hours";
 import { Image as ImageIcon, Loader2, X } from "lucide-react";
 import Image from "next/image";
 import { ReadOnlyGate } from "@/components/admin/read-only";
@@ -50,6 +52,10 @@ interface FormData {
   vehicleTypes: string[];
   // Operations fields
   datesOpen: string;
+  // Structured weekly hours. Optional so callers passing initialData (admin
+  // edit) that predates this field, and legacy fixtures, still compile; the
+  // editor and validation default an absent value to an empty schedule.
+  hours?: WeeklyHours;
   contactEmail: string;
   ownership: string;
   // Requirements fields
@@ -123,6 +129,7 @@ export function ParkSubmissionForm({
       vehicleTypes: [],
       // Operations fields
       datesOpen: "",
+      hours: emptyWeeklyHours(),
       contactEmail: "",
       ownership: "",
       // Requirements fields
@@ -218,6 +225,19 @@ export function ParkSubmissionForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // Validate the structured weekly hours before submitting (display-only,
+    // but we still reject malformed windows like close-before-open).
+    const hoursResult = weeklyHoursSchema.safeParse(
+      formData.hours ?? emptyWeeklyHours(),
+    );
+    if (!hoursResult.success) {
+      alert(
+        `Please fix the weekly hours: ${hoursResult.error.issues[0]?.message ?? "invalid hours"}`,
+      );
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -257,6 +277,7 @@ export function ParkSubmissionForm({
             ? parseInt(formData.noiseLimitDBA)
             : null,
           ownership: formData.ownership || null,
+          hours: hoursResult.data,
           address: {
             streetAddress: formData.streetAddress || null,
             streetAddress2: formData.streetAddress2 || null,
@@ -545,6 +566,20 @@ export function ParkSubmissionForm({
               ))}
             </SelectContent>
           </Select>
+        </div>
+
+        {/* Weekly Hours */}
+        <div className="col-span-1 md:col-span-2">
+          <Label className="mb-1 block">Weekly Hours</Label>
+          <p className="text-xs text-muted-foreground mb-3">
+            Set open and close times per day, or mark a day Closed. Leave a day
+            blank if hours are unknown. Use &ldquo;Dates/Hours Open&rdquo; above
+            for season notes.
+          </p>
+          <WeeklyHoursEditor
+            value={formData.hours}
+            onChange={(v) => setFormData((prev) => ({ ...prev, hours: v }))}
+          />
         </div>
 
         {/* Pricing */}

--- a/src/components/forms/park-fields/WeeklyHoursEditor.tsx
+++ b/src/components/forms/park-fields/WeeklyHoursEditor.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  DAY_KEYS,
+  DAY_FULL_LABELS,
+  emptyWeeklyHours,
+  isClosed,
+  isOpenWindow,
+  type DayKey,
+  type WeeklyHours,
+} from "@/lib/hours";
+
+interface WeeklyHoursEditorProps {
+  /** Current schedule. `null`/`undefined` renders an all-unspecified grid. */
+  value: WeeklyHours | null | undefined;
+  onChange: (value: WeeklyHours) => void;
+}
+
+/**
+ * Reusable 7-row weekly-hours editor. Each row has an open time, a close time,
+ * and a "Closed" toggle. Leaving both times blank (and not closed) marks the
+ * day as unspecified (null). Times are native 24h "HH:MM" values; formatting
+ * to 12h happens at display time.
+ *
+ * Display-only feature: no "open now", no timezone. Shared by the park submit
+ * form, admin edit, and operator settings.
+ */
+export function WeeklyHoursEditor({ value, onChange }: WeeklyHoursEditorProps) {
+  const hours: WeeklyHours = value ?? emptyWeeklyHours();
+
+  const update = (day: DayKey, next: WeeklyHours[DayKey]) => {
+    onChange({ ...hours, [day]: next });
+  };
+
+  const setClosed = (day: DayKey, checked: boolean) => {
+    update(day, checked ? { closed: true } : null);
+  };
+
+  const setTime = (day: DayKey, which: "open" | "close", time: string) => {
+    const current = hours[day];
+    const open = which === "open" ? time : isOpenWindow(current) ? current.open : "";
+    const close = which === "close" ? time : isOpenWindow(current) ? current.close : "";
+    if (!open && !close) {
+      update(day, null);
+    } else {
+      update(day, { open, close });
+    }
+  };
+
+  return (
+    <div className="space-y-2" data-testid="weekly-hours-editor">
+      {DAY_KEYS.map((day) => {
+        const current = hours[day];
+        const closed = isClosed(current);
+        const open = isOpenWindow(current) ? current.open : "";
+        const close = isOpenWindow(current) ? current.close : "";
+
+        return (
+          <div
+            key={day}
+            className="grid grid-cols-[5.5rem_1fr_1fr_auto] items-center gap-2"
+            data-testid={`weekly-hours-row-${day}`}
+          >
+            <span className="text-sm font-medium">{DAY_FULL_LABELS[day]}</span>
+
+            <Input
+              type="time"
+              aria-label={`${DAY_FULL_LABELS[day]} opening time`}
+              value={open}
+              disabled={closed}
+              onChange={(e) => setTime(day, "open", e.target.value)}
+            />
+
+            <Input
+              type="time"
+              aria-label={`${DAY_FULL_LABELS[day]} closing time`}
+              value={close}
+              disabled={closed}
+              onChange={(e) => setTime(day, "close", e.target.value)}
+            />
+
+            <label className="flex items-center gap-1.5 text-sm">
+              <Checkbox
+                aria-label={`${DAY_FULL_LABELS[day]} closed`}
+                checked={closed}
+                onCheckedChange={(c) => setClosed(day, !!c)}
+              />
+              Closed
+            </label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/parks/EmptyParksInvite.tsx
+++ b/src/components/parks/EmptyParksInvite.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Empty state for the list view — a calm invitation to contribute when a
+ * completed load returns no parks. Keeps the plain "no matches" line, then
+ * offers a low-key prompt to add a missing park via `/submit`.
+ */
+export function EmptyParksInvite() {
+  return (
+    <div className="py-16 text-center text-muted-foreground">
+      <p>No parks match your filters.</p>
+      <div className="mt-6 space-y-3">
+        <p className="text-sm">
+          Know an offroad park or trail system that isn&rsquo;t here? Add it to
+          the map.
+        </p>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/submit">Submit a park</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -22,6 +22,7 @@ import { AppHeader } from "@/components/layout/AppHeader";
 import { SearchHeader } from "@/components/layout/SearchHeader";
 import { SearchFiltersPanel } from "@/components/parks/SearchFiltersPanel";
 import { ParkCard } from "@/components/parks/ParkCard";
+import { EmptyParksInvite } from "@/components/parks/EmptyParksInvite";
 import { RouteList } from "@/features/route-planner/RouteList";
 import { MyRoutesOverlayPanel } from "@/features/route-planner/MyRoutesOverlayPanel";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -511,12 +512,9 @@ function OffroadParksAppInner({
                   ))}
                 </div>
 
-                {/* Empty state — only when a completed load returned nothing. */}
-                {!isLoading && listParks.length === 0 && (
-                  <div className="py-16 text-center text-muted-foreground">
-                    No parks match your filters.
-                  </div>
-                )}
+                {/* Empty state — only when a completed load returned nothing.
+                    Doubles as a calm invitation to contribute a missing park. */}
+                {!isLoading && listParks.length === 0 && <EmptyParksInvite />}
 
                 {/* Loading / infinite-scroll region */}
                 {(isLoading || isLoadingMore) && (

--- a/src/features/map/MapView.tsx
+++ b/src/features/map/MapView.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 import { MapContainer, Polyline, TileLayer, useMapEvents } from "react-leaflet";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import type { Park, RouteWaypoint } from "@/lib/types";
 import { MapBoundsHandler } from "./components/MapBoundsHandler";
 import { MapVisibilityHandler } from "./components/MapVisibilityHandler";
@@ -286,6 +288,23 @@ export function MapView({
         <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-card px-4 py-2 rounded-full shadow-md text-sm text-muted-foreground z-[1000]">
           Showing {parksWithCoordinates.length} of {parks.length} parks with
           coordinates
+        </div>
+      )}
+      {/* Empty filtered set → a subtle invitation to add a park in this area.
+          Skipped when the caller frames the map itself (initialCenter, e.g. the
+          trail-overlay POC) so single-purpose maps aren't nagged. The wrapper
+          stays click-through so it never blocks panning; only the card
+          re-enables pointer events. */}
+      {!initialCenter && parks.length === 0 && (
+        <div className="pointer-events-none absolute inset-0 z-[1000] flex items-center justify-center p-4">
+          <div className="pointer-events-auto max-w-xs rounded-lg border bg-card/95 px-5 py-4 text-center shadow-md">
+            <p className="text-sm text-muted-foreground">
+              No parks in this area yet. Know one that belongs on the map?
+            </p>
+            <Button asChild variant="outline" size="sm" className="mt-3">
+              <Link href="/submit">Submit a park</Link>
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -36,7 +36,7 @@ import { AppHeader } from "@/components/layout/AppHeader";
 import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 import { useFavorites } from "@/hooks/useFavorites";
 import { formatDate } from "@/lib/formatting";
-import { SuggestCorrectionDialog } from "./components/SuggestCorrectionDialog";
+import { ContributeCard } from "./components/ContributeCard";
 import { findTrailOverlay } from "./trailOverlays";
 import type { TrailFeatureCollection } from "@/features/map/components/TrailOverlay";
 
@@ -97,6 +97,10 @@ function ParkDetailPageInner({
   const { promptSignIn } = useSignInPrompt();
   const { isFavorite, toggleFavorite } = useFavorites();
   const [showReviewForm, setShowReviewForm] = useState(false);
+  // Controlled tab state so the sidebar ContributeCard's "Add photos" button can
+  // jump the user to the Photos tab (where the uploader / sign-in prompt lives)
+  // without rebuilding the upload flow.
+  const [activeTab, setActiveTab] = useState("overview");
   // Share control: prefer the native Web Share API; otherwise copy the URL to
   // the clipboard and show a transient "Copied!" confirmation.
   const [shareCopied, setShareCopied] = useState(false);
@@ -335,7 +339,7 @@ function ParkDetailPageInner({
               column grows to the widest child (e.g. the tab bar / cards) and
               pushes the whole page past the viewport. */}
           <div className="lg:col-span-2 min-w-0">
-            <Tabs defaultValue="overview">
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
               <TabsList className="w-full justify-start mb-6">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="photos">
@@ -354,17 +358,6 @@ function ParkDetailPageInner({
                 <ParkOverviewCard park={park} />
                 <ParkAttributesCards park={park} />
                 <ParkOperationalCard park={park} />
-                {/* Low-key crowdsourced-correction affordance. The dialog
-                    renders its own trigger and self-gates on auth. */}
-                <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-muted/30 px-4 py-3">
-                  <p className="text-sm text-muted-foreground">
-                    See something wrong or out of date?
-                  </p>
-                  <SuggestCorrectionDialog
-                    parkSlug={park.id}
-                    parkName={park.name}
-                  />
-                </div>
               </TabsContent>
 
               {/* Photos Tab */}
@@ -631,6 +624,14 @@ function ParkDetailPageInner({
                   </div>
                 )
               )}
+              {/* Consolidated, always-visible contribution card. Keeps the
+                  correction dialog + photo prompt near the top of the sidebar
+                  instead of buried at the bottom of the page. */}
+              <ContributeCard
+                parkSlug={park.id}
+                parkName={park.name}
+                onAddPhotos={() => setActiveTab("photos")}
+              />
               <TrailConditionsDisplay parkSlug={park.id} />
               {/* OP-53: NWS forecast + current. Renders nothing when both
                   are empty (parks without coords or outside NWS coverage). */}
@@ -640,14 +641,18 @@ function ParkDetailPageInner({
               />
               <ParkContactSidebar park={park} />
               <CampingInfoCard park={park} />
-              <ParkClaimCTA
-                parkSlug={park.id}
-                isLoggedIn={!!session?.user}
-                hasOperator={park.hasOperator}
-                existingClaim={existingClaim}
-                isOperatorOfPark={isOperatorOfPark}
-                operatorName={operatorName}
-              />
+              {/* Full claim flow. The ContributeCard's "Claim it" pointer
+                  links to this `#claim` anchor so the form lives in one place. */}
+              <div id="claim" className="scroll-mt-24">
+                <ParkClaimCTA
+                  parkSlug={park.id}
+                  isLoggedIn={!!session?.user}
+                  hasOperator={park.hasOperator}
+                  existingClaim={existingClaim}
+                  isOperatorOfPark={isOperatorOfPark}
+                  operatorName={operatorName}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/features/parks/detail/components/ContributeCard.tsx
+++ b/src/features/parks/detail/components/ContributeCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { Camera, ClipboardCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SuggestCorrectionDialog } from "./SuggestCorrectionDialog";
+
+interface ContributeCardProps {
+  /** Slug of the park (park.id) — passed through to the correction dialog. */
+  parkSlug: string;
+  /** Park name, shown in the correction dialog copy. */
+  parkName: string;
+  /**
+   * Switches the detail page to the Photos tab, where the uploader / sign-in
+   * prompt lives. Keeps photo contribution in one place instead of rebuilding
+   * the uploader here.
+   */
+  onAddPhotos: () => void;
+}
+
+/**
+ * A single, understated "accuracy" card for the park-detail sidebar. Gathers
+ * the crowd-sourced contribution affordances that were previously scattered
+ * down the page — suggest a correction, add photos, and claim the listing —
+ * into one calm, always-available spot (Wikipedia-style: edit is invited, never
+ * shouty). The claim affordance is a short pointer to the full `ParkClaimCTA`
+ * (mounted lower in the sidebar under `#claim`), so the claim form is not
+ * duplicated.
+ */
+export function ContributeCard({
+  parkSlug,
+  parkName,
+  onAddPhotos,
+}: ContributeCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <ClipboardCheck className="w-4 h-4" />
+          Help keep this listing accurate
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          This is a community directory. Spot something off, or been here
+          yourself? Lend a hand.
+        </p>
+        <div className="flex flex-col gap-2">
+          <SuggestCorrectionDialog parkSlug={parkSlug} parkName={parkName} />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onAddPhotos}
+            className="justify-center"
+          >
+            <Camera className="w-4 h-4 mr-1.5" />
+            Add photos
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Own or manage this park?{" "}
+          <Link
+            href="#claim"
+            className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
+          >
+            Claim it
+          </Link>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/parks/detail/components/ParkOperationalCard.tsx
+++ b/src/features/parks/detail/components/ParkOperationalCard.tsx
@@ -3,9 +3,16 @@ import { Badge } from "@/components/ui/badge";
 import type { Park } from "@/lib/types";
 import { formatOwnership } from "@/lib/formatting";
 import {
+  DAY_KEYS,
+  DAY_SHORT_LABELS,
+  formatDayHours,
+  hasAnyHours,
+} from "@/lib/hours";
+import {
   Building2,
   Calendar,
   ChevronsLeftRight,
+  Clock,
   CreditCard,
   FileWarning,
   Flag,
@@ -38,7 +45,10 @@ function Row({ icon: Icon, label, value }: RowProps) {
 }
 
 export function ParkOperationalCard({ park }: ParkOperationalCardProps) {
+  const showHours = hasAnyHours(park.hours);
+
   const hasAny =
+    showHours ||
     park.datesOpen ||
     park.ownership ||
     park.permitRequired ||
@@ -60,10 +70,35 @@ export function ParkOperationalCard({ park }: ParkOperationalCardProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
+        {showHours && (
+          <Row
+            icon={Clock}
+            label="Hours"
+            value={
+              <ul className="space-y-0.5" data-testid="weekly-hours-list">
+                {DAY_KEYS.map((day) => {
+                  const text = formatDayHours(park.hours?.[day]);
+                  return (
+                    <li
+                      key={day}
+                      className="flex justify-between gap-4 tabular-nums"
+                    >
+                      <span className="text-muted-foreground">
+                        {DAY_SHORT_LABELS[day]}
+                      </span>
+                      <span>{text || "—"}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            }
+          />
+        )}
+
         {park.datesOpen && (
           <Row
             icon={Calendar}
-            label="Open"
+            label="Season"
             value={park.datesOpen}
           />
         )}

--- a/src/lib/field-coverage.ts
+++ b/src/lib/field-coverage.ts
@@ -73,6 +73,7 @@ export const PARK_TO_FORM_FIELD_MAP = {
 
   // Operational
   datesOpen: "datesOpen",
+  hours: "hours", // structured weekly-hours editor (WeeklyHoursEditor)
   contactEmail: "contactEmail",
   ownership: "ownership",
   permitRequired: "permitRequired",
@@ -128,6 +129,9 @@ export const BULK_UPLOAD_FIELD_MAP = {
   vehicleTypes: "vehicleTypes",
   // Operational fields
   datesOpen: "datesOpen",
+  // NOTE: `hours` (structured weekly schedule) is intentionally NOT captured
+  // via CSV bulk upload — it is a nested JSON shape that doesn't map to a flat
+  // CSV column. It is collected only through the human form surfaces.
   contactEmail: "contactEmail",
   ownership: "ownership",
   permitRequired: "permitRequired",

--- a/src/lib/hours.ts
+++ b/src/lib/hours.ts
@@ -1,0 +1,246 @@
+/**
+ * Structured weekly opening hours (display-only).
+ *
+ * A park's hours are stored as a JSON blob of 7 day keys (mon..sun), each of
+ * which is one of:
+ *   - `{ open: "HH:MM", close: "HH:MM" }` — open during that window (24h times)
+ *   - `{ closed: true }`                  — explicitly closed that day
+ *   - `null`                              — unknown / unspecified
+ *
+ * This is a pure display feature: no "open now" computation, no timezone, and
+ * no discovery filtering. The free-text `Park.datesOpen` field remains the
+ * "season notes" alongside this structured schedule.
+ */
+import { z } from "zod";
+
+/** Ordered day keys (Monday-first) used throughout the app. */
+export const DAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+
+export type DayKey = (typeof DAY_KEYS)[number];
+
+/** Short labels for compact rows/grouping (e.g. "Mon"). */
+export const DAY_SHORT_LABELS: Record<DayKey, string> = {
+  mon: "Mon",
+  tue: "Tue",
+  wed: "Wed",
+  thu: "Thu",
+  fri: "Fri",
+  sat: "Sat",
+  sun: "Sun",
+};
+
+/** Full labels (e.g. "Monday"). */
+export const DAY_FULL_LABELS: Record<DayKey, string> = {
+  mon: "Monday",
+  tue: "Tuesday",
+  wed: "Wednesday",
+  thu: "Thursday",
+  fri: "Friday",
+  sat: "Saturday",
+  sun: "Sunday",
+};
+
+// 24-hour "HH:MM" — 00:00 through 23:59.
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/** Convert an "HH:MM" string to minutes-since-midnight. */
+function toMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(":").map(Number);
+  return h * 60 + m;
+}
+
+const timeSchema = z
+  .string()
+  .regex(TIME_REGEX, "Time must be in 24-hour HH:MM format");
+
+const openCloseSchema = z
+  .object({
+    open: timeSchema,
+    close: timeSchema,
+  })
+  .strict()
+  .refine((v) => toMinutes(v.open) < toMinutes(v.close), {
+    message: "Opening time must be before closing time",
+    path: ["close"],
+  });
+
+const closedSchema = z.object({ closed: z.literal(true) }).strict();
+
+/** A single day's value: open window, explicitly closed, or unspecified. */
+const dayHoursSchema = z.union([openCloseSchema, closedSchema]);
+const dayValueSchema = dayHoursSchema.nullable();
+
+/**
+ * Zod schema for a full weekly schedule. All 7 keys are required (the editor
+ * always emits all of them); a day the operator left blank is `null`.
+ */
+export const weeklyHoursSchema = z.object({
+  mon: dayValueSchema,
+  tue: dayValueSchema,
+  wed: dayValueSchema,
+  thu: dayValueSchema,
+  fri: dayValueSchema,
+  sat: dayValueSchema,
+  sun: dayValueSchema,
+});
+
+export type DayHours = z.infer<typeof dayHoursSchema>;
+export type WeeklyHours = z.infer<typeof weeklyHoursSchema>;
+
+/** A blank schedule with every day unspecified (null). */
+export function emptyWeeklyHours(): WeeklyHours {
+  return {
+    mon: null,
+    tue: null,
+    wed: null,
+    thu: null,
+    fri: null,
+    sat: null,
+    sun: null,
+  };
+}
+
+/**
+ * Coerce arbitrary JSON into a WeeklyHours value, or null when it isn't a
+ * valid schedule. Handy for reading DB/form JSON before display.
+ */
+export function parseWeeklyHours(value: unknown): WeeklyHours | null {
+  const result = weeklyHoursSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+/** Type guard: a day value that represents an explicit closure. */
+export function isClosed(day: DayHours | null | undefined): day is { closed: true } {
+  return !!day && "closed" in day && day.closed === true;
+}
+
+/** Type guard: a day value with an open/close window. */
+export function isOpenWindow(
+  day: DayHours | null | undefined,
+): day is { open: string; close: string } {
+  return !!day && "open" in day && "close" in day;
+}
+
+/** True when every day is unspecified (null/absent) — nothing to display. */
+export function hasAnyHours(hours: WeeklyHours | null | undefined): boolean {
+  if (!hours) return false;
+  return DAY_KEYS.some((k) => hours[k] != null);
+}
+
+/**
+ * Format a 24-hour "HH:MM" string as a 12-hour clock time, e.g.
+ * "08:00" -> "8:00 AM", "13:30" -> "1:30 PM", "00:00" -> "12:00 AM".
+ */
+export function formatTime(hhmm: string): string {
+  const [hStr, mStr] = hhmm.split(":");
+  const h = Number(hStr);
+  const period = h < 12 ? "AM" : "PM";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return `${hour12}:${mStr.padStart(2, "0")} ${period}`;
+}
+
+/**
+ * Human-readable label for a single day's hours.
+ * - open window -> "8:00 AM – 6:00 PM"
+ * - closed      -> "Closed"
+ * - null/unset  -> "" (caller decides how to render unspecified)
+ */
+export function formatDayHours(day: DayHours | null | undefined): string {
+  if (isClosed(day)) return "Closed";
+  if (isOpenWindow(day)) {
+    return `${formatTime(day.open)} – ${formatTime(day.close)}`;
+  }
+  return "";
+}
+
+/** A serialized, comparable key for a day value (for grouping). */
+function dayValueKey(day: DayHours | null): string {
+  if (day == null) return "null";
+  if (isClosed(day)) return "closed";
+  return `${(day as { open: string }).open}-${(day as { close: string }).close}`;
+}
+
+export type WeeklyHoursGroup = {
+  /** Day-label range, e.g. "Mon" or "Mon – Fri". */
+  label: string;
+  /** Formatted hours text, e.g. "8:00 AM – 6:00 PM" or "Closed". */
+  hours: string;
+};
+
+/**
+ * Group consecutive days that share the same hours into a compact list.
+ * Unspecified (null) days are omitted. Returns e.g.
+ * `[{ label: "Mon – Fri", hours: "8:00 AM – 6:00 PM" }, { label: "Sat", hours: "Closed" }]`.
+ */
+export function formatWeeklyHours(
+  hours: WeeklyHours | null | undefined,
+): WeeklyHoursGroup[] {
+  if (!hours) return [];
+
+  const groups: WeeklyHoursGroup[] = [];
+  let runStart: DayKey | null = null;
+  let runEnd: DayKey | null = null;
+  let runKey: string | null = null;
+
+  const flush = () => {
+    if (runStart == null || runEnd == null) return;
+    const label =
+      runStart === runEnd
+        ? DAY_SHORT_LABELS[runStart]
+        : `${DAY_SHORT_LABELS[runStart]} – ${DAY_SHORT_LABELS[runEnd]}`;
+    groups.push({ label, hours: formatDayHours(hours[runStart]) });
+  };
+
+  for (const key of DAY_KEYS) {
+    const value = hours[key];
+    if (value == null) {
+      // Unspecified day breaks any run and is not shown.
+      flush();
+      runStart = runEnd = runKey = null;
+      continue;
+    }
+    const vKey = dayValueKey(value);
+    if (runKey === vKey) {
+      runEnd = key;
+    } else {
+      flush();
+      runStart = runEnd = key;
+      runKey = vKey;
+    }
+  }
+  flush();
+
+  return groups;
+}
+
+/** A schema.org OpeningHoursSpecification object for JSON-LD. */
+export type OpeningHoursSpecification = {
+  "@type": "OpeningHoursSpecification";
+  dayOfWeek: string;
+  opens: string;
+  closes: string;
+};
+
+/**
+ * Map structured weekly hours to schema.org `OpeningHoursSpecification`
+ * objects for JSON-LD structured data. Only days with an explicit open/close
+ * window produce a spec; closed and unspecified days are omitted.
+ */
+export function toOpeningHoursSpecification(
+  hours: WeeklyHours | null | undefined,
+): OpeningHoursSpecification[] {
+  if (!hours) return [];
+  const specs: OpeningHoursSpecification[] = [];
+  for (const key of DAY_KEYS) {
+    const value = hours[key];
+    if (isOpenWindow(value)) {
+      specs.push({
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: `https://schema.org/${DAY_FULL_LABELS[key]}`,
+        opens: value.open,
+        closes: value.close,
+      });
+    }
+  }
+  return specs;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { WeeklyHours } from "./hours";
+
 // Route builder types
 export type RouteWaypoint = {
   id: string;
@@ -168,6 +170,10 @@ export type DbPark = {
   status: ParkStatus;
   // New operational fields
   datesOpen: string | null;
+  // Structured weekly hours JSON (display-only). Prisma types this as
+  // JsonValue; the transform casts it to the WeeklyHours shape. Optional so
+  // callers using a narrower select (or older fixtures) still satisfy DbPark.
+  hours?: unknown;
   contactEmail: string | null;
   ownership: Ownership | null;
   permitRequired: boolean | null;
@@ -244,6 +250,9 @@ export type Park = {
   mapHeroUrl?: string | null;
   // New operational fields
   datesOpen?: string;
+  // Structured weekly opening hours (display-only). Passed through from the
+  // DB Json column; validated on write via weeklyHoursSchema.
+  hours?: WeeklyHours | null;
   contactEmail?: string;
   ownership?: Ownership;
   permitRequired?: boolean;
@@ -409,6 +418,8 @@ export function transformDbPark(dbPark: DbPark): Park {
     mapHeroUrl: dbPark.mapHeroUrl ?? undefined,
     // New operational fields
     datesOpen: dbPark.datesOpen ?? undefined,
+    // Structured weekly hours — pass the JSON through, typed to the shape.
+    hours: (dbPark.hours as WeeklyHours | null | undefined) ?? undefined,
     contactEmail: dbPark.contactEmail ?? undefined,
     ownership: dbPark.ownership ?? undefined,
     permitRequired: dbPark.permitRequired ?? undefined,

--- a/test/app/api/admin/parks/[id]/route.test.ts
+++ b/test/app/api/admin/parks/[id]/route.test.ts
@@ -688,6 +688,74 @@ describe("PATCH /api/admin/parks/[id]", () => {
     expect(updateCall.data).not.toHaveProperty("county");
   });
 
+  it("persists valid structured hours passed through the update", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "admin-123", role: "ADMIN" },
+    } as any);
+    vi.mocked(prisma.park.update).mockResolvedValue({
+      id: "park-123",
+      slug: "updated",
+    } as any);
+
+    const hours = {
+      mon: { open: "08:00", close: "18:00" },
+      tue: null,
+      wed: null,
+      thu: null,
+      fri: null,
+      sat: { closed: true },
+      sun: null,
+    };
+
+    const request = new Request(
+      "http://localhost:3000/api/admin/parks/park-123",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...validUpdateData, hours }),
+      },
+    );
+
+    await PATCH(request, { params: Promise.resolve({ id: "park-123" }) });
+
+    const updateCall = vi.mocked(prisma.park.update).mock.calls[0][0] as any;
+    expect(updateCall.data.hours).toEqual(hours);
+  });
+
+  it("returns 400 when hours are malformed", async () => {
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "admin-123", role: "ADMIN" },
+    } as any);
+
+    const request = new Request(
+      "http://localhost:3000/api/admin/parks/park-123",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...validUpdateData,
+          hours: {
+            mon: { open: "99:99", close: "18:00" },
+            tue: null,
+            wed: null,
+            thu: null,
+            fri: null,
+            sat: null,
+            sun: null,
+          },
+        }),
+      },
+    );
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ id: "park-123" }),
+    });
+    const data = await response.json();
+    expect(response.status).toBe(400);
+    expect(data.error).toMatch(/invalid hours/i);
+    expect(prisma.park.update).not.toHaveBeenCalled();
+  });
+
   it("should preserve other park fields not in update data", async () => {
     // Arrange
     vi.mocked(auth).mockResolvedValue({

--- a/test/app/api/operator/parks/[parkSlug]/route.test.ts
+++ b/test/app/api/operator/parks/[parkSlug]/route.test.ts
@@ -53,6 +53,7 @@ const mockPark = {
   campingPhone: null,
   notes: "Great park",
   datesOpen: null,
+  hours: null,
   contactEmail: null,
   isFree: false,
   dayPassUSD: 25,
@@ -180,6 +181,70 @@ describe("PATCH /api/operator/parks/[parkSlug]", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.success).toBe(true);
+  });
+
+  it("validates and persists structured weekly hours", async () => {
+    (auth as any).mockResolvedValue(operatorSession);
+    (prisma.park.findUnique as any).mockResolvedValue(mockPark);
+
+    const hours = {
+      mon: { open: "08:00", close: "18:00" },
+      tue: null,
+      wed: null,
+      thu: null,
+      fri: null,
+      sat: { closed: true },
+      sun: null,
+    };
+
+    const updateSpy = vi.fn().mockResolvedValue({ ...mockPark, hours });
+    (prisma.$transaction as any).mockImplementation(async (fn: any) =>
+      fn({
+        park: {
+          update: updateSpy,
+          findUnique: vi.fn().mockResolvedValue({ ...mockPark, hours }),
+        },
+        parkTerrain: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkAmenity: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkCamping: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkVehicleType: { deleteMany: vi.fn(), createMany: vi.fn() },
+        parkEditLog: { create: vi.fn().mockResolvedValue({ id: "log-1" }) },
+      }),
+    );
+
+    const response = await PATCH(makePatchRequest({ hours }), {
+      params: Promise.resolve({ parkSlug: "test-park" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ hours }) }),
+    );
+  });
+
+  it("rejects malformed hours with a 400 and does not write", async () => {
+    (auth as any).mockResolvedValue(operatorSession);
+    (prisma.park.findUnique as any).mockResolvedValue(mockPark);
+
+    const response = await PATCH(
+      makePatchRequest({
+        hours: {
+          mon: { open: "08:00", close: "07:00" }, // close before open
+          tue: null,
+          wed: null,
+          thu: null,
+          fri: null,
+          sat: null,
+          sun: null,
+        },
+      }),
+      { params: Promise.resolve({ parkSlug: "test-park" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toMatch(/invalid hours/i);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("revalidates the home grid + park detail page after a successful update", async () => {

--- a/test/app/api/parks/submit/route.test.ts
+++ b/test/app/api/parks/submit/route.test.ts
@@ -899,4 +899,72 @@ describe("POST /api/parks/submit", () => {
       }),
     );
   });
+
+  describe("structured weekly hours", () => {
+    const validHours = {
+      mon: { open: "08:00", close: "18:00" },
+      tue: null,
+      wed: null,
+      thu: null,
+      fri: null,
+      sat: { closed: true },
+      sun: null,
+    };
+
+    beforeEach(() => {
+      vi.mocked(auth).mockResolvedValue({
+        user: { id: "user-123", role: "USER" },
+      } as any);
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.park.create).mockResolvedValue({
+        id: "park-123",
+        slug: "test-park",
+      } as any);
+    });
+
+    it("persists valid hours on the created park", async () => {
+      const request = new Request("http://localhost:3000/api/parks/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...validParkData, hours: validHours }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      expect(prisma.park.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ hours: validHours }),
+        }),
+      );
+    });
+
+    it("omits hours (column stays NULL) when not provided", async () => {
+      const request = new Request("http://localhost:3000/api/parks/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validParkData),
+      });
+
+      await POST(request);
+      const createArg = vi.mocked(prisma.park.create).mock.calls[0][0] as any;
+      expect(createArg.data.hours).toBeUndefined();
+    });
+
+    it("rejects malformed hours with a 400", async () => {
+      const request = new Request("http://localhost:3000/api/parks/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...validParkData,
+          hours: { ...validHours, mon: { open: "18:00", close: "08:00" } },
+        }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+      expect(response.status).toBe(400);
+      expect(data.error).toMatch(/invalid hours/i);
+      expect(prisma.park.create).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/app/parks/[id]/page.test.tsx
+++ b/test/app/parks/[id]/page.test.tsx
@@ -330,6 +330,59 @@ describe("Park Detail Page", () => {
       expect(screen.getByTestId("photos-count")).toHaveTextContent("1 photos");
     });
 
+    it("includes openingHoursSpecification in JSON-LD when hours are set", async () => {
+      vi.mocked(prisma.park.findUnique).mockResolvedValue({
+        ...mockDbPark,
+        hours: {
+          mon: { open: "08:00", close: "18:00" },
+          tue: null,
+          wed: null,
+          thu: null,
+          fri: null,
+          sat: { closed: true },
+          sun: null,
+        },
+      } as any);
+      vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const component = await ParkPage({
+        params: Promise.resolve({ id: "test-park" }),
+      });
+      const { container } = render(component);
+
+      const script = container.querySelector(
+        'script[type="application/ld+json"]',
+      );
+      expect(script).not.toBeNull();
+      const data = JSON.parse(script!.innerHTML);
+      expect(data.openingHoursSpecification).toEqual([
+        {
+          "@type": "OpeningHoursSpecification",
+          dayOfWeek: "https://schema.org/Monday",
+          opens: "08:00",
+          closes: "18:00",
+        },
+      ]);
+    });
+
+    it("omits openingHoursSpecification from JSON-LD when hours are absent", async () => {
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(mockDbPark as any);
+      vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);
+      vi.mocked(auth).mockResolvedValue(null as any);
+
+      const component = await ParkPage({
+        params: Promise.resolve({ id: "test-park" }),
+      });
+      const { container } = render(component);
+
+      const script = container.querySelector(
+        'script[type="application/ld+json"]',
+      );
+      const data = JSON.parse(script!.innerHTML);
+      expect(data.openingHoursSpecification).toBeUndefined();
+    });
+
     it("should handle park with no photos", async () => {
       vi.mocked(prisma.park.findUnique).mockResolvedValue(mockDbPark as any);
       vi.mocked(prisma.parkPhoto.findMany).mockResolvedValue([]);

--- a/test/components/forms/park-fields/WeeklyHoursEditor.test.tsx
+++ b/test/components/forms/park-fields/WeeklyHoursEditor.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { WeeklyHoursEditor } from "@/components/forms/park-fields/WeeklyHoursEditor";
+import { emptyWeeklyHours, type WeeklyHours } from "@/lib/hours";
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+      {...props}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+
+describe("WeeklyHoursEditor", () => {
+  it("renders a row for all seven days", () => {
+    render(<WeeklyHoursEditor value={emptyWeeklyHours()} onChange={vi.fn()} />);
+    for (const day of [
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+      "Sunday",
+    ]) {
+      expect(screen.getByText(day)).toBeInTheDocument();
+      expect(screen.getByLabelText(`${day} opening time`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`${day} closing time`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`${day} closed`)).toBeInTheDocument();
+    }
+  });
+
+  it("handles a null/undefined value by rendering an empty grid", () => {
+    render(<WeeklyHoursEditor value={null} onChange={vi.fn()} />);
+    expect(screen.getByLabelText("Monday opening time")).toHaveValue("");
+  });
+
+  it("emits an open/close window when times are entered", () => {
+    const onChange = vi.fn();
+    render(<WeeklyHoursEditor value={emptyWeeklyHours()} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Monday opening time"), {
+      target: { value: "08:00" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mon: { open: "08:00", close: "" } }),
+    );
+  });
+
+  it("preserves the other time when one is edited", () => {
+    const value: WeeklyHours = {
+      ...emptyWeeklyHours(),
+      mon: { open: "08:00", close: "" },
+    };
+    const onChange = vi.fn();
+    render(<WeeklyHoursEditor value={value} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Monday closing time"), {
+      target: { value: "18:00" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mon: { open: "08:00", close: "18:00" } }),
+    );
+  });
+
+  it("clears a day back to null when both times are emptied", () => {
+    const value: WeeklyHours = {
+      ...emptyWeeklyHours(),
+      mon: { open: "08:00", close: "" },
+    };
+    const onChange = vi.fn();
+    render(<WeeklyHoursEditor value={value} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Monday opening time"), {
+      target: { value: "" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ mon: null }),
+    );
+  });
+
+  it("marks a day closed when the Closed toggle is checked", () => {
+    const onChange = vi.fn();
+    render(<WeeklyHoursEditor value={emptyWeeklyHours()} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText("Saturday closed"));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sat: { closed: true } }),
+    );
+  });
+
+  it("clears the closed flag back to null when unchecked", () => {
+    const value: WeeklyHours = { ...emptyWeeklyHours(), sat: { closed: true } };
+    const onChange = vi.fn();
+    render(<WeeklyHoursEditor value={value} onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText("Saturday closed"));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sat: null }),
+    );
+  });
+
+  it("disables the time inputs for a closed day", () => {
+    const value: WeeklyHours = { ...emptyWeeklyHours(), sat: { closed: true } };
+    render(<WeeklyHoursEditor value={value} onChange={vi.fn()} />);
+    expect(screen.getByLabelText("Saturday opening time")).toBeDisabled();
+    expect(screen.getByLabelText("Saturday closing time")).toBeDisabled();
+  });
+});

--- a/test/components/parks/EmptyParksInvite.test.tsx
+++ b/test/components/parks/EmptyParksInvite.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { EmptyParksInvite } from "@/components/parks/EmptyParksInvite";
+
+describe("EmptyParksInvite", () => {
+  it("keeps the plain 'no matches' line", () => {
+    render(<EmptyParksInvite />);
+
+    expect(
+      screen.getByText(/no parks match your filters/i),
+    ).toBeInTheDocument();
+  });
+
+  it("invites the user to add a missing park", () => {
+    render(<EmptyParksInvite />);
+
+    expect(
+      screen.getByText(/know an offroad park or trail system that isn/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Submit button linking to /submit", () => {
+    render(<EmptyParksInvite />);
+
+    const link = screen.getByRole("link", { name: /submit a park/i });
+    expect(link).toHaveAttribute("href", "/submit");
+  });
+});

--- a/test/features/map/MapView.test.tsx
+++ b/test/features/map/MapView.test.tsx
@@ -510,6 +510,39 @@ describe("MapView", () => {
     });
   });
 
+  describe("empty-state contribution invite", () => {
+    it("shows an invitation to add a park when the filtered set is empty", () => {
+      render(<MapView parks={[]} />);
+
+      expect(
+        screen.getByText(/no parks in this area yet/i),
+      ).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: /submit a park/i });
+      expect(link).toHaveAttribute("href", "/submit");
+    });
+
+    it("does not show the invite when parks are present", () => {
+      render(<MapView parks={[mockPark1]} />);
+
+      expect(
+        screen.queryByText(/no parks in this area yet/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /submit a park/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show the invite when the caller frames the map via initialCenter", () => {
+      render(
+        <MapView parks={[]} initialCenter={[40, -100]} initialZoom={7} />,
+      );
+
+      expect(
+        screen.queryByText(/no parks in this area yet/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("custom waypoints", () => {
     const customWaypoint: RouteWaypoint = {
       id: "wp-custom-1",

--- a/test/features/parks/detail/ParkDetailPage.test.tsx
+++ b/test/features/parks/detail/ParkDetailPage.test.tsx
@@ -671,6 +671,46 @@ describe("ParkDetailPage", () => {
     });
   });
 
+  describe("ContributeCard (sidebar accuracy card)", () => {
+    it("renders the consolidated 'Help keep this listing accurate' card in the sidebar", () => {
+      const { container } = render(
+        <ParkDetailPage park={mockPark} photos={[]} />,
+      );
+
+      const sidebar = container.querySelector(".lg\\:col-span-1");
+      expect(sidebar).not.toBeNull();
+      const heading = screen.getByText(/help keep this listing accurate/i);
+      expect(sidebar).toContainElement(heading);
+      // The correction dialog now lives inside this card (single mount).
+      expect(sidebar).toContainElement(
+        screen.getByTestId("suggest-correction-dialog"),
+      );
+    });
+
+    it("offers an 'Add photos' affordance", () => {
+      render(<ParkDetailPage park={mockPark} photos={[]} />);
+
+      expect(
+        screen.getByRole("button", { name: /^add photos$/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("points to the claim flow via the #claim anchor", () => {
+      render(<ParkDetailPage park={mockPark} photos={[]} />);
+
+      const link = screen.getByRole("link", { name: /claim it/i });
+      expect(link).toHaveAttribute("href", "#claim");
+    });
+
+    it("no longer renders the old inline correction prompt in the Overview tab", () => {
+      render(<ParkDetailPage park={mockPark} photos={[]} />);
+
+      expect(
+        screen.queryByText(/see something wrong or out of date/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("Data freshness / provenance", () => {
     it("renders a 'Last verified' line when lastResearchedAt is present", () => {
       const park = { ...mockPark, lastResearchedAt: "2026-01-15T00:00:00.000Z" };

--- a/test/features/parks/detail/components/ContributeCard.test.tsx
+++ b/test/features/parks/detail/components/ContributeCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { ContributeCard } from "@/features/parks/detail/components/ContributeCard";
+
+// Stub the correction dialog — we only care that ContributeCard mounts it with
+// the right props, not its internals.
+vi.mock(
+  "@/features/parks/detail/components/SuggestCorrectionDialog",
+  () => ({
+    SuggestCorrectionDialog: ({ parkSlug, parkName }: any) => (
+      <div data-testid="suggest-correction-dialog">
+        correction:{parkSlug}:{parkName}
+      </div>
+    ),
+  }),
+);
+
+describe("ContributeCard", () => {
+  const noop = () => {};
+
+  it("renders the 'Help keep this listing accurate' title", () => {
+    render(
+      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
+    );
+
+    expect(
+      screen.getByText(/help keep this listing accurate/i),
+    ).toBeInTheDocument();
+  });
+
+  it("mounts the correction dialog with the park slug and name", () => {
+    render(
+      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
+    );
+
+    const dialog = screen.getByTestId("suggest-correction-dialog");
+    expect(dialog).toHaveTextContent("correction:test-park:Test Park");
+  });
+
+  it("renders an 'Add photos' button that calls onAddPhotos when clicked", async () => {
+    const onAddPhotos = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ContributeCard
+        parkSlug="test-park"
+        parkName="Test Park"
+        onAddPhotos={onAddPhotos}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /add photos/i }));
+
+    expect(onAddPhotos).toHaveBeenCalledOnce();
+  });
+
+  it("renders a subtle claim pointer linking to the #claim anchor", () => {
+    render(
+      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
+    );
+
+    expect(screen.getByText(/own or manage this park/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /claim it/i });
+    expect(link).toHaveAttribute("href", "#claim");
+  });
+});

--- a/test/features/parks/detail/components/ParkOperationalCard.test.tsx
+++ b/test/features/parks/detail/components/ParkOperationalCard.test.tsx
@@ -44,11 +44,54 @@ describe("ParkOperationalCard", () => {
     expect(screen.getByText("Park Details")).toBeInTheDocument();
   });
 
-  it("should display datesOpen", () => {
+  it("should display datesOpen as a Season row", () => {
     const park = { ...basePark, datesOpen: "May 1 – October 31" };
     render(<ParkOperationalCard park={park} />);
     expect(screen.getByText("May 1 – October 31")).toBeInTheDocument();
-    expect(screen.getByText("Open")).toBeInTheDocument();
+    expect(screen.getByText("Season")).toBeInTheDocument();
+  });
+
+  it("renders a structured weekly schedule when hours are set", () => {
+    const park: Park = {
+      ...basePark,
+      hours: {
+        mon: { open: "08:00", close: "18:00" },
+        tue: { open: "08:00", close: "18:00" },
+        wed: null,
+        thu: null,
+        fri: null,
+        sat: { closed: true },
+        sun: null,
+      },
+    };
+    render(<ParkOperationalCard park={park} />);
+    // Card is shown purely because hours are present.
+    expect(screen.getByText("Hours")).toBeInTheDocument();
+    expect(screen.getByTestId("weekly-hours-list")).toBeInTheDocument();
+    // Formatted 12h window appears (twice — Mon and Tue).
+    expect(screen.getAllByText("8:00 AM – 6:00 PM")).toHaveLength(2);
+    // Explicit closure renders as "Closed".
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+    // Unspecified days render as an em dash placeholder.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("does not render the Hours row when every day is unspecified", () => {
+    const park: Park = {
+      ...basePark,
+      hours: {
+        mon: null,
+        tue: null,
+        wed: null,
+        thu: null,
+        fri: null,
+        sat: null,
+        sun: null,
+      },
+    };
+    const { container } = render(<ParkOperationalCard park={park} />);
+    // All-null hours count as empty, so the card hides entirely.
+    expect(container.firstChild).toBeNull();
   });
 
   it("should display formatted ownership", () => {

--- a/test/lib/field-coverage.test.ts
+++ b/test/lib/field-coverage.test.ts
@@ -31,6 +31,10 @@ describe("field-coverage", () => {
       expect(PARK_TO_FORM_FIELD_MAP.state).toBe("addressState");
     });
 
+    it("maps the structured weekly hours field to its form field", () => {
+      expect(PARK_TO_FORM_FIELD_MAP.hours).toBe("hours");
+    });
+
     it("preserves nested address mappings", () => {
       expect(PARK_TO_FORM_FIELD_MAP.address.streetAddress).toBe("streetAddress");
       expect(PARK_TO_FORM_FIELD_MAP.address.zipCode).toBe("zipCode");
@@ -57,6 +61,12 @@ describe("field-coverage", () => {
         "maxVehicleWidthInches"
       );
       expect(BULK_UPLOAD_FIELD_MAP.noiseLimitDBA).toBe("noiseLimitDBA");
+    });
+
+    it("intentionally excludes structured hours from CSV bulk upload", () => {
+      // `hours` is a nested JSON shape captured only via the human form
+      // surfaces, not flat CSV columns.
+      expect("hours" in BULK_UPLOAD_FIELD_MAP).toBe(false);
     });
 
     it("keeps state/city as flat CSV columns", () => {

--- a/test/lib/hours.test.ts
+++ b/test/lib/hours.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import {
+  DAY_KEYS,
+  weeklyHoursSchema,
+  emptyWeeklyHours,
+  parseWeeklyHours,
+  hasAnyHours,
+  isClosed,
+  isOpenWindow,
+  formatTime,
+  formatDayHours,
+  formatWeeklyHours,
+  toOpeningHoursSpecification,
+  type WeeklyHours,
+} from "@/lib/hours";
+
+const fullWeek = (): WeeklyHours => ({
+  mon: { open: "08:00", close: "18:00" },
+  tue: { open: "08:00", close: "18:00" },
+  wed: { open: "08:00", close: "18:00" },
+  thu: { open: "08:00", close: "18:00" },
+  fri: { open: "08:00", close: "18:00" },
+  sat: { closed: true },
+  sun: null,
+});
+
+describe("hours: constants", () => {
+  it("orders days Monday-first", () => {
+    expect(DAY_KEYS).toEqual(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
+  });
+});
+
+describe("weeklyHoursSchema", () => {
+  it("accepts an all-null (empty) schedule", () => {
+    expect(weeklyHoursSchema.safeParse(emptyWeeklyHours()).success).toBe(true);
+  });
+
+  it("accepts open windows, closed days, and null", () => {
+    expect(weeklyHoursSchema.safeParse(fullWeek()).success).toBe(true);
+  });
+
+  it("rejects non-HH:MM time strings", () => {
+    const bad = { ...emptyWeeklyHours(), mon: { open: "8am", close: "18:00" } };
+    const result = weeklyHoursSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects 24:00 and other out-of-range times", () => {
+    const bad = { ...emptyWeeklyHours(), mon: { open: "24:00", close: "25:00" } };
+    expect(weeklyHoursSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects a window where close is not after open", () => {
+    const bad = { ...emptyWeeklyHours(), mon: { open: "18:00", close: "08:00" } };
+    const result = weeklyHoursSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/before closing/i);
+    }
+  });
+
+  it("rejects equal open and close times", () => {
+    const bad = { ...emptyWeeklyHours(), mon: { open: "08:00", close: "08:00" } };
+    expect(weeklyHoursSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects extra keys on a day object", () => {
+    const bad = {
+      ...emptyWeeklyHours(),
+      mon: { open: "08:00", close: "18:00", note: "x" },
+    };
+    expect(weeklyHoursSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejects closed:false (only closed:true is valid)", () => {
+    const bad = { ...emptyWeeklyHours(), mon: { closed: false } };
+    expect(weeklyHoursSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("requires all seven day keys", () => {
+    const bad = { mon: null };
+    expect(weeklyHoursSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("parseWeeklyHours", () => {
+  it("returns the parsed schedule for valid input", () => {
+    expect(parseWeeklyHours(fullWeek())).toEqual(fullWeek());
+  });
+
+  it("returns null for invalid or non-object input", () => {
+    expect(parseWeeklyHours(null)).toBeNull();
+    expect(parseWeeklyHours("nope")).toBeNull();
+    expect(parseWeeklyHours({ mon: { open: "bad" } })).toBeNull();
+  });
+});
+
+describe("hasAnyHours", () => {
+  it("is false for null/undefined and all-null schedules", () => {
+    expect(hasAnyHours(null)).toBe(false);
+    expect(hasAnyHours(undefined)).toBe(false);
+    expect(hasAnyHours(emptyWeeklyHours())).toBe(false);
+  });
+
+  it("is true when at least one day is specified (open or closed)", () => {
+    expect(hasAnyHours({ ...emptyWeeklyHours(), sat: { closed: true } })).toBe(true);
+    expect(
+      hasAnyHours({ ...emptyWeeklyHours(), mon: { open: "09:00", close: "17:00" } }),
+    ).toBe(true);
+  });
+});
+
+describe("type guards", () => {
+  it("isClosed only matches { closed: true }", () => {
+    expect(isClosed({ closed: true })).toBe(true);
+    expect(isClosed(null)).toBe(false);
+    expect(isClosed({ open: "08:00", close: "18:00" })).toBe(false);
+  });
+
+  it("isOpenWindow only matches open/close windows", () => {
+    expect(isOpenWindow({ open: "08:00", close: "18:00" })).toBe(true);
+    expect(isOpenWindow({ closed: true })).toBe(false);
+    expect(isOpenWindow(null)).toBe(false);
+  });
+});
+
+describe("formatTime", () => {
+  it("converts 24h to 12h with AM/PM", () => {
+    expect(formatTime("08:00")).toBe("8:00 AM");
+    expect(formatTime("13:30")).toBe("1:30 PM");
+    expect(formatTime("00:00")).toBe("12:00 AM");
+    expect(formatTime("12:00")).toBe("12:00 PM");
+    expect(formatTime("23:45")).toBe("11:45 PM");
+  });
+});
+
+describe("formatDayHours", () => {
+  it("formats an open window, closed, and unspecified", () => {
+    expect(formatDayHours({ open: "08:00", close: "18:00" })).toBe(
+      "8:00 AM – 6:00 PM",
+    );
+    expect(formatDayHours({ closed: true })).toBe("Closed");
+    expect(formatDayHours(null)).toBe("");
+    expect(formatDayHours(undefined)).toBe("");
+  });
+});
+
+describe("formatWeeklyHours", () => {
+  it("groups consecutive days with identical hours", () => {
+    const groups = formatWeeklyHours(fullWeek());
+    expect(groups).toEqual([
+      { label: "Mon – Fri", hours: "8:00 AM – 6:00 PM" },
+      { label: "Sat", hours: "Closed" },
+    ]);
+  });
+
+  it("omits unspecified days and breaks runs across them", () => {
+    const hours: WeeklyHours = {
+      ...emptyWeeklyHours(),
+      mon: { open: "09:00", close: "17:00" },
+      wed: { open: "09:00", close: "17:00" },
+    };
+    const groups = formatWeeklyHours(hours);
+    // Tue (null) breaks the run so Mon and Wed are separate single-day groups.
+    expect(groups).toEqual([
+      { label: "Mon", hours: "9:00 AM – 5:00 PM" },
+      { label: "Wed", hours: "9:00 AM – 5:00 PM" },
+    ]);
+  });
+
+  it("returns an empty list for null/empty schedules", () => {
+    expect(formatWeeklyHours(null)).toEqual([]);
+    expect(formatWeeklyHours(emptyWeeklyHours())).toEqual([]);
+  });
+});
+
+describe("toOpeningHoursSpecification", () => {
+  it("emits a spec only for open days, using schema.org day URLs", () => {
+    const specs = toOpeningHoursSpecification(fullWeek());
+    expect(specs).toHaveLength(5);
+    expect(specs[0]).toEqual({
+      "@type": "OpeningHoursSpecification",
+      dayOfWeek: "https://schema.org/Monday",
+      opens: "08:00",
+      closes: "18:00",
+    });
+    // No spec for the closed Saturday or unspecified Sunday.
+    const days = specs.map((s) => s.dayOfWeek);
+    expect(days).not.toContain("https://schema.org/Saturday");
+    expect(days).not.toContain("https://schema.org/Sunday");
+  });
+
+  it("returns an empty array for null/empty schedules", () => {
+    expect(toOpeningHoursSpecification(null)).toEqual([]);
+    expect(toOpeningHoursSpecification(emptyWeeklyHours())).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-ups to the pre-launch batch (#196), toward the "Wikipedia of nationwide offroad opportunities" goal: make contributing feel invited at the right moments, and give parks real weekly hours.

### Contribution CTAs (make submitting more visible, not naggy)
- **Empty search results & empty map regions now invite a submission** instead of dead-ending. Searching an area with no matches shows "Know an offroad park or trail system that isn't here? Add it to the map." → `/submit`. The map shows the same, unobtrusively, only when the filtered set is empty (suppressed on single-park/detail maps).
- **New "Help keep this listing accurate" sidebar card** on the park detail page consolidates Suggest-a-correction, Add-photos, and Claim into one calm, above-the-fold affordance — previously these were scattered near the bottom of the page. Wikipedia-style: always available, never shouty.

### Structured weekly hours (display-only)
- New `Park.hours` JSON column with `weeklyHoursSchema` + formatters in `src/lib/hours.ts` (per-day open/close, closed, or unspecified).
- Reusable `WeeklyHoursEditor` used in the submit form, admin edit, and operator settings; validated server-side in each write route.
- Compact weekly schedule rendered on the park detail page; the old free-text `datesOpen` is kept and relabeled **"Season"** notes; `openingHoursSpecification` added to the `TouristAttraction` JSON-LD (SEO).
- **Deliberately out of scope** (per product decision): "open now", per-park timezone, and the open-now discovery filter. Map-marker clustering also remains deferred.

## Schema / migration
- `Park.hours JSONB` (nullable). Migration `20260728000000_park_structured_hours` applies at deploy via `prisma migrate deploy`; hand-authored (no DB in the build sandbox) and verified to generate cleanly.

## Testing
- Every change covered by tests. Full suite **2446 passing** (2 skipped), `tsc --noEmit` clean, `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McL16nM82aQydjmDWW73zq)_