### PR TITLE
feat(map): export routes to Google/Apple Maps + GPX; platform-aware directions

### DIFF
--- a/src/features/map/components/RouteExportControls.tsx
+++ b/src/features/map/components/RouteExportControls.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, Navigation } from "lucide-react";
+import type { RouteWaypoint } from "@/lib/types";
+import {
+  appleMapsDirectionsUrl,
+  buildRouteGpx,
+  downloadTextFile,
+  googleMapsDirectionsUrl,
+  MAX_GOOGLE_WAYPOINTS,
+  toFilenameStem,
+} from "@/features/map/utils/export";
+
+interface RouteExportControlsProps {
+  waypoints: RouteWaypoint[];
+  routeGeometry?: GeoJSON.LineString | null;
+  /** Route name, used for the GPX filename and metadata. */
+  title?: string;
+}
+
+/**
+ * "Navigate & Export" controls for a built route: open the full multi-stop
+ * route in Google Maps, open it (start → end) in Apple Maps, or download a GPX
+ * for offline GPS apps (Gaia GPS, onX Offroad, Avenza, Garmin).
+ *
+ * All actions are client-side deep links / file generation — no API keys and
+ * no metered requests. Renders nothing for routes with fewer than 2 stops.
+ */
+export function RouteExportControls({
+  waypoints,
+  routeGeometry,
+  title,
+}: RouteExportControlsProps) {
+  const google = useMemo(() => googleMapsDirectionsUrl(waypoints), [waypoints]);
+  const apple = useMemo(() => appleMapsDirectionsUrl(waypoints), [waypoints]);
+
+  if (waypoints.length < 2 || !google || !apple) return null;
+
+  const handleDownloadGpx = () => {
+    const name = title?.trim() || "Offroad Parks route";
+    const gpx = buildRouteGpx({ title: name, waypoints, geometry: routeGeometry });
+    downloadTextFile(`${toFilenameStem(name)}.gpx`, "application/gpx+xml", gpx);
+  };
+
+  return (
+    <div className="mt-4 pt-4 border-t">
+      <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+        Navigate &amp; Export
+      </p>
+      <div className="space-y-2">
+        <Button
+          asChild
+          variant="default"
+          size="sm"
+          className="w-full"
+        >
+          <a href={google.url} target="_blank" rel="noopener noreferrer">
+            <Navigation className="w-3 h-3 mr-1" />
+            Open in Google Maps
+          </a>
+        </Button>
+        <Button asChild variant="outline" size="sm" className="w-full">
+          <a href={apple} target="_blank" rel="noopener noreferrer">
+            <Navigation className="w-3 h-3 mr-1" />
+            Open in Apple Maps
+          </a>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={handleDownloadGpx}
+        >
+          <Download className="w-3 h-3 mr-1" />
+          Download GPX
+        </Button>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        {google.truncated
+          ? `Google Maps supports up to ${MAX_GOOGLE_WAYPOINTS} stops between start and end — extra stops are dropped there. `
+          : ""}
+        Apple Maps routes start → end; download the GPX for every stop offline.
+      </p>
+    </div>
+  );
+}

--- a/src/features/map/utils/export.ts
+++ b/src/features/map/utils/export.ts
@@ -1,0 +1,181 @@
+import type { RouteWaypoint } from "@/lib/types";
+
+/**
+ * Route export & external-navigation helpers.
+ *
+ * These build deep links into the Google Maps / Apple Maps apps and produce a
+ * downloadable GPX file for offline GPS apps (Gaia GPS, onX Offroad, Avenza,
+ * Garmin). Everything here is client-side — no API keys, no metered calls.
+ */
+
+type LatLng = { lat: number; lng: number };
+
+/**
+ * Google Maps' consumer directions URL accepts at most 9 intermediate
+ * waypoints (between origin and destination). Beyond that Maps silently drops
+ * the extras, so we cap and report truncation to the caller.
+ */
+export const MAX_GOOGLE_WAYPOINTS = 9;
+
+const coord = (p: LatLng) => `${p.lat.toFixed(6)},${p.lng.toFixed(6)}`;
+
+/**
+ * Build a Google Maps directions deep link for a multi-stop route. Uses the
+ * first waypoint as origin, the last as destination, and the middle ones as
+ * `waypoints`. Opens the native app on mobile, the web map on desktop.
+ *
+ * Returns `null` when there are fewer than 2 stops. `truncated` is `true` when
+ * the route had more intermediate stops than Google's URL API supports.
+ */
+export function googleMapsDirectionsUrl(
+  waypoints: LatLng[],
+): { url: string; truncated: boolean } | null {
+  if (waypoints.length < 2) return null;
+
+  const origin = waypoints[0];
+  const destination = waypoints[waypoints.length - 1];
+  const middle = waypoints.slice(1, -1);
+  const included = middle.slice(0, MAX_GOOGLE_WAYPOINTS);
+
+  const params = new URLSearchParams({
+    api: "1",
+    origin: coord(origin),
+    destination: coord(destination),
+    travelmode: "driving",
+  });
+  if (included.length > 0) {
+    params.set("waypoints", included.map(coord).join("|"));
+  }
+
+  return {
+    url: `https://www.google.com/maps/dir/?${params.toString()}`,
+    truncated: middle.length > included.length,
+  };
+}
+
+/** Single-destination Google Maps directions link (from the user's location). */
+export function googleMapsDestinationUrl(dest: LatLng): string {
+  const params = new URLSearchParams({
+    api: "1",
+    destination: coord(dest),
+    travelmode: "driving",
+  });
+  return `https://www.google.com/maps/dir/?${params.toString()}`;
+}
+
+/**
+ * Build an Apple Maps directions deep link. Apple's URL scheme has no reliable
+ * multi-stop support, so a multi-waypoint route is expressed as start → end
+ * (intermediate stops are carried by the GPX export instead).
+ */
+export function appleMapsDirectionsUrl(waypoints: LatLng[]): string | null {
+  if (waypoints.length < 2) return null;
+  const origin = waypoints[0];
+  const destination = waypoints[waypoints.length - 1];
+  const params = new URLSearchParams({
+    saddr: coord(origin),
+    daddr: coord(destination),
+    dirflg: "d",
+  });
+  return `https://maps.apple.com/?${params.toString()}`;
+}
+
+/** Single-destination Apple Maps directions link (from the user's location). */
+export function appleMapsDestinationUrl(dest: LatLng): string {
+  const params = new URLSearchParams({ daddr: coord(dest), dirflg: "d" });
+  return `https://maps.apple.com/?${params.toString()}`;
+}
+
+/**
+ * Best-effort detection of Apple platforms (iOS/iPadOS/macOS) so the UI can
+ * lead with Apple Maps. Safe to call on the server — returns `false` when
+ * there's no `navigator`.
+ */
+export function isAppleDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  // iPadOS 13+ reports as "Macintosh"; the touch-point check disambiguates.
+  const iPadOS = /Macintosh/.test(ua) && navigator.maxTouchPoints > 1;
+  return /iPhone|iPad|iPod/.test(ua) || /Macintosh/.test(ua) || iPadOS;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Serialize a route to GPX 1.1. Named stops become `<wpt>` elements; the
+ * road-following track (from the stored GeoJSON `LineString`, or a coarse
+ * straight-line fallback across the stops) becomes a `<trk>`.
+ */
+export function buildRouteGpx(input: {
+  title: string;
+  waypoints: RouteWaypoint[];
+  geometry?: GeoJSON.LineString | null;
+}): string {
+  const { title, waypoints, geometry } = input;
+  const safeTitle = escapeXml(title.trim() || "Offroad Parks route");
+
+  const wpts = waypoints
+    .map(
+      (w, i) =>
+        `  <wpt lat="${w.lat.toFixed(6)}" lon="${w.lng.toFixed(6)}">\n` +
+        `    <name>${escapeXml(w.label || `Stop ${i + 1}`)}</name>\n` +
+        `  </wpt>`,
+    )
+    .join("\n");
+
+  // Prefer the real road-following geometry; fall back to the stops themselves.
+  const trackPoints: [number, number][] =
+    geometry && Array.isArray(geometry.coordinates)
+      ? geometry.coordinates.map(([lng, lat]) => [lat, lng])
+      : waypoints.map((w) => [w.lat, w.lng]);
+
+  const trkpts = trackPoints
+    .map(([lat, lng]) => `      <trkpt lat="${lat.toFixed(6)}" lon="${lng.toFixed(6)}"/>`)
+    .join("\n");
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<gpx version="1.1" creator="Offroad Parks" xmlns="http://www.topografix.com/GPX/1/1" ` +
+    `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ` +
+    `xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">\n` +
+    `  <metadata>\n    <name>${safeTitle}</name>\n  </metadata>\n` +
+    `${wpts}\n` +
+    `  <trk>\n    <name>${safeTitle}</name>\n    <trkseg>\n${trkpts}\n    </trkseg>\n  </trk>\n` +
+    `</gpx>\n`
+  );
+}
+
+/** Turn a route title into a safe download filename stem. */
+export function toFilenameStem(title: string, fallback = "offroad-parks-route"): string {
+  const stem = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return stem || fallback;
+}
+
+/** Trigger a client-side download of a text payload as a file. */
+export function downloadTextFile(
+  filename: string,
+  mimeType: string,
+  content: string,
+): void {
+  if (typeof document === "undefined") return;
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/src/features/parks/detail/components/DirectionsLinks.tsx
+++ b/src/features/parks/detail/components/DirectionsLinks.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { MapPin } from "lucide-react";
+import {
+  appleMapsDestinationUrl,
+  googleMapsDestinationUrl,
+  isAppleDevice,
+} from "@/features/map/utils/export";
+
+interface DirectionsLinksProps {
+  lat: number;
+  lng: number;
+}
+
+const noopSubscribe = () => () => {};
+
+/**
+ * Read whether the viewer is on an Apple device without a hydration mismatch:
+ * the server snapshot is always `false` (Google-first), and React swaps to the
+ * real client value after hydration.
+ */
+function useIsAppleDevice(): boolean {
+  return useSyncExternalStore(
+    noopSubscribe,
+    () => isAppleDevice(),
+    () => false,
+  );
+}
+
+/**
+ * Platform-aware "Get Directions" links for a single park. Leads with the
+ * viewer's native maps app (Apple Maps on iOS/macOS, otherwise Google Maps)
+ * and offers the other as a secondary option. Both are plain deep links —
+ * no API key, no metered calls.
+ *
+ * Rendered client-side because the preferred app depends on `navigator`; it
+ * defaults to Google Maps first during SSR/hydration and swaps to Apple on
+ * Apple devices once mounted.
+ */
+export function DirectionsLinks({ lat, lng }: DirectionsLinksProps) {
+  const apple = useIsAppleDevice();
+
+  const googleUrl = googleMapsDestinationUrl({ lat, lng });
+  const appleUrl = appleMapsDestinationUrl({ lat, lng });
+
+  const primary = apple
+    ? { href: appleUrl, label: "Get Directions (Apple Maps)" }
+    : { href: googleUrl, label: "Get Directions (Google Maps)" };
+  const secondary = apple
+    ? { href: googleUrl, label: "Open in Google Maps" }
+    : { href: appleUrl, label: "Open in Apple Maps" };
+
+  return (
+    <div className="space-y-2">
+      <a
+        href={primary.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 text-primary hover:underline"
+      >
+        <MapPin className="w-4 h-4 shrink-0" />
+        {primary.label}
+      </a>
+      <a
+        href={secondary.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:underline"
+      >
+        {secondary.label}
+      </a>
+    </div>
+  );
+}

--- a/src/features/parks/detail/components/ParkContactSidebar.tsx
+++ b/src/features/parks/detail/components/ParkContactSidebar.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import type { Park } from "@/lib/types";
 import { ExternalLink, Mail, MapPin, Phone } from "lucide-react";
 import { formatPhone } from "@/lib/formatting";
+import { DirectionsLinks } from "./DirectionsLinks";
 
 interface ParkContactSidebarProps {
   park: Park;
@@ -85,15 +86,7 @@ export function ParkContactSidebar({ park }: ParkContactSidebarProps) {
         )}
 
         {park.coords && (
-          <a
-            href={`https://www.google.com/maps/dir/?api=1&destination=${park.coords.lat},${park.coords.lng}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-primary hover:underline"
-          >
-            <MapPin className="w-4 h-4 shrink-0" />
-            Get Directions
-          </a>
+          <DirectionsLinks lat={park.coords.lat} lng={park.coords.lng} />
         )}
 
         <div className="pt-4 border-t text-xs text-muted-foreground">

--- a/src/features/route-planner/RouteList.tsx
+++ b/src/features/route-planner/RouteList.tsx
@@ -8,6 +8,7 @@ import { geocodeSuggestions } from "@/features/map/utils/routing";
 import type { RouteResult } from "@/features/map/utils/routing";
 import { RouteListHeader } from "./components/RouteListHeader";
 import { RouteListItem } from "./components/RouteListItem";
+import { RouteExportControls } from "@/features/map/components/RouteExportControls";
 import { ShareRouteDialog } from "./ShareRouteDialog";
 import { Button } from "@/components/ui/button";
 import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
@@ -351,6 +352,15 @@ export function RouteList({
             </div>
           )}
         </div>
+
+        {/* Navigate & Export (any visitor, 2+ waypoints) — hand the route off
+            to Google/Apple Maps or download a GPX for offline GPS apps. No
+            account required, so this sits above the Save & Share gate. */}
+        <RouteExportControls
+          waypoints={waypoints}
+          routeGeometry={routeResult?.geometry}
+          title={routeTitle}
+        />
 
         {/* Save & Share (authenticated, 2+ waypoints) */}
         {isAuthenticated && waypoints.length >= 2 && (onSaveRoute || onUpdateRoute) && (

--- a/test/features/parks/detail/components/ParkContactSidebar.test.tsx
+++ b/test/features/parks/detail/components/ParkContactSidebar.test.tsx
@@ -79,13 +79,17 @@ describe("ParkContactSidebar", () => {
   it("should display get directions link when coords provided", () => {
     render(<ParkContactSidebar park={basePark} />);
 
-    const link = screen.getByText("Get Directions");
+    // Directions are platform-aware; jsdom is not an Apple device, so Google
+    // Maps is the primary link and Apple Maps the secondary option.
+    const link = screen.getByText("Get Directions (Google Maps)");
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      "href",
-      "https://www.google.com/maps/dir/?api=1&destination=34.0522,-118.2437",
-    );
+    const href = link.getAttribute("href") ?? "";
+    expect(href).toContain("https://www.google.com/maps/dir/");
+    expect(href).toContain("destination=34.052200");
+    expect(href).toContain("-118.243700");
     expect(link).toHaveAttribute("target", "_blank");
+
+    expect(screen.getByText("Open in Apple Maps")).toBeInTheDocument();
   });
 
   it("should display verification disclaimer", () => {
@@ -108,7 +112,7 @@ describe("ParkContactSidebar", () => {
     expect(
       container.querySelector('a[href="tel:5551234567"]'),
     ).toBeInTheDocument();
-    expect(screen.getByText("Get Directions")).toBeInTheDocument();
+    expect(screen.getByText("Get Directions (Google Maps)")).toBeInTheDocument();
   });
 
   it("should render icons", () => {
@@ -140,7 +144,7 @@ describe("ParkContactSidebar", () => {
     render(<ParkContactSidebar park={minimalPark} />);
 
     expect(screen.getByText("Contact & Links")).toBeInTheDocument();
-    expect(screen.getByText("Get Directions")).toBeInTheDocument();
+    expect(screen.getByText("Get Directions (Google Maps)")).toBeInTheDocument();
     expect(screen.queryByText("Official Website")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What & why

The route builder already builds multi-stop trips, but there was no way to hand a route off for turn-by-turn navigation. This adds a **route-export / external-navigation** feature — entirely client-side, no API keys and no metered calls.

### Route builder — "Navigate & Export"
A new panel on the route builder (shown for any visitor, since export needs no account — it sits above the Save & Share gate):

- **Open in Google Maps** — multi-stop deep link (`origin`/`destination`/`waypoints`). Caps at Google's 9 intermediate-waypoint limit and tells the user when extra stops were dropped.
- **Open in Apple Maps** — start → end deep link. Apple's URL scheme has no reliable multi-stop support, so intermediate stops are carried by the GPX export instead (stated in the UI).
- **Download GPX** — GPX 1.1 with named `<wpt>` stops + a road-following `<trk>` (from the stored Mapbox route geometry, straight-line fallback otherwise). This is the offline handoff off-roaders actually use — Gaia GPS, onX Offroad, Avenza, Garmin — where there's no cell signal.

### Per-park "Get Directions" — now platform-aware
The park detail sidebar link leads with the viewer's native maps app (Apple Maps on iOS/macOS, Google Maps elsewhere) and offers the other as a secondary option. Uses `useSyncExternalStore` so the client/server choice doesn't cause a hydration mismatch.

## Design note
The base map stays **Leaflet + OSM** — Google/Apple are deep-link navigation *targets*, not renderers. No basemap migration, no new metered map loads.

## Files
- `src/features/map/utils/export.ts` — pure URL/GPX builders + helpers (25 assertions verified)
- `src/features/map/components/RouteExportControls.tsx` — the export panel
- `src/features/parks/detail/components/DirectionsLinks.tsx` — platform-aware directions
- wired into `RouteList.tsx` and `ParkContactSidebar.tsx`

## Testing
- Full suite green: **2388 passed, 2 skipped**.
- Updated `ParkContactSidebar` tests for the new platform-aware link.
- Verified the pure export logic (URL construction, waypoint capping/truncation, GPX structure + XML escaping, lat/lng swap, filename slugify) via a standalone script.

## Follow-ups (not in this PR)
Satellite/topo basemap switcher, marker clustering, and a "you are here" map pin — next on the map-expansion roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)