### PR TITLE
feat(map): add satellite/topo basemap switcher

### DIFF
--- a/src/features/map/MapView.tsx
+++ b/src/features/map/MapView.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { MapContainer, Polyline, TileLayer, useMapEvents } from "react-leaflet";
+import {
+  LayersControl,
+  MapContainer,
+  Polyline,
+  TileLayer,
+  useMapEvents,
+} from "react-leaflet";
+import { BASEMAPS } from "./basemaps";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import type { Park, RouteWaypoint } from "@/lib/types";
@@ -238,10 +245,25 @@ export function MapView({
         style={{ height: "100%", width: "100%" }}
         scrollWheelZoom={true}
       >
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
+        {/* Basemap switcher — streets / satellite / topo. Satellite and topo
+            suit the off-road audience far better than a road-only street map,
+            and all three sources are keyless. */}
+        <LayersControl position="topright">
+          {BASEMAPS.map((base, index) => (
+            <LayersControl.BaseLayer
+              key={base.name}
+              name={base.name}
+              checked={index === 0}
+            >
+              <TileLayer
+                url={base.url}
+                attribution={base.attribution}
+                maxZoom={base.maxZoom}
+                subdomains={base.subdomains ?? "abc"}
+              />
+            </LayersControl.BaseLayer>
+          ))}
+        </LayersControl>
         {/* POC: OHV trail-network overlay (managed-use styled) */}
         {trailOverlay && <TrailOverlay data={trailOverlay} />}
         {/* Point markers: trailheads, campgrounds/rec areas */}

--- a/src/features/map/basemaps.ts
+++ b/src/features/map/basemaps.ts
@@ -1,0 +1,49 @@
+/**
+ * Basemap tile layers offered by the map's layer switcher.
+ *
+ * All three are keyless and free to use for this scale, so no API key or
+ * metered map SDK is involved. The off-road audience benefits from imagery and
+ * topography, not just the road-only street map.
+ *
+ * The first entry is the default (checked) layer.
+ */
+export interface Basemap {
+  /** Label shown in the layer control. */
+  name: string;
+  /** Leaflet tile URL template. */
+  url: string;
+  /** Attribution HTML shown while this layer is active. */
+  attribution: string;
+  /** Max zoom the tile source serves. */
+  maxZoom: number;
+  /** Tile subdomains, when the URL uses `{s}`. */
+  subdomains?: string;
+}
+
+export const BASEMAPS: readonly Basemap[] = [
+  {
+    name: "Streets",
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    maxZoom: 19,
+    subdomains: "abc",
+  },
+  {
+    name: "Satellite",
+    // Esri World Imagery uses {z}/{y}/{x} ordering (y before x) — not the usual
+    // {z}/{x}/{y}. Swapping them silently returns the wrong tiles.
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    attribution:
+      'Imagery &copy; <a href="https://www.esri.com/">Esri</a>, Maxar, Earthstar Geographics, and the GIS User Community',
+    maxZoom: 19,
+  },
+  {
+    name: "Topo",
+    url: "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+    attribution:
+      'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM | Style: &copy; <a href="https://opentopomap.org/">OpenTopoMap</a> (CC-BY-SA)',
+    maxZoom: 17,
+    subdomains: "abc",
+  },
+] as const;

--- a/test/features/map/MapView.test.tsx
+++ b/test/features/map/MapView.test.tsx
@@ -8,22 +8,42 @@ import type { Park, RouteWaypoint } from "@/lib/types";
 const useMapEventsHandlers: Array<Record<string, (...args: any[]) => void>> = [];
 
 // Mock react-leaflet
-vi.mock("react-leaflet", () => ({
-  MapContainer: ({ children, center, zoom }: any) => (
-    <div
-      data-testid="map-container"
-      data-center={JSON.stringify(center)}
-      data-zoom={zoom}
-    >
-      {children}
-    </div>
-  ),
-  TileLayer: () => <div data-testid="tile-layer" />,
-  useMapEvents: (handlers: Record<string, (...args: any[]) => void>) => {
-    useMapEventsHandlers.push(handlers);
-    return null;
-  },
-}));
+vi.mock("react-leaflet", () => {
+  const LayersControl: any = function LayersControl({ children }: any) {
+    return <div data-testid="layers-control">{children}</div>;
+  };
+  LayersControl.BaseLayer = function BaseLayer({
+    children,
+    name,
+    checked,
+  }: any) {
+    return (
+      <div
+        data-testid={`base-layer-${name}`}
+        data-checked={checked ? "true" : "false"}
+      >
+        {children}
+      </div>
+    );
+  };
+  return {
+    MapContainer: ({ children, center, zoom }: any) => (
+      <div
+        data-testid="map-container"
+        data-center={JSON.stringify(center)}
+        data-zoom={zoom}
+      >
+        {children}
+      </div>
+    ),
+    TileLayer: ({ url }: any) => <div data-testid="tile-layer" data-url={url} />,
+    LayersControl,
+    useMapEvents: (handlers: Record<string, (...args: any[]) => void>) => {
+      useMapEventsHandlers.push(handlers);
+      return null;
+    },
+  };
+});
 
 // Mock child components
 vi.mock("@/features/map/components/MapBoundsHandler", () => ({
@@ -142,9 +162,32 @@ describe("MapView", () => {
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
   });
 
-  it("should render tile layer", () => {
+  it("should render a basemap layer switcher with streets, satellite, and topo", () => {
     render(<MapView parks={[mockPark1]} />);
-    expect(screen.getByTestId("tile-layer")).toBeInTheDocument();
+
+    expect(screen.getByTestId("layers-control")).toBeInTheDocument();
+    expect(screen.getByTestId("base-layer-Streets")).toBeInTheDocument();
+    expect(screen.getByTestId("base-layer-Satellite")).toBeInTheDocument();
+    expect(screen.getByTestId("base-layer-Topo")).toBeInTheDocument();
+    // Three basemaps, each with its own tile layer.
+    expect(screen.getAllByTestId("tile-layer")).toHaveLength(3);
+  });
+
+  it("defaults to the Streets basemap", () => {
+    render(<MapView parks={[mockPark1]} />);
+
+    expect(screen.getByTestId("base-layer-Streets")).toHaveAttribute(
+      "data-checked",
+      "true",
+    );
+    expect(screen.getByTestId("base-layer-Satellite")).toHaveAttribute(
+      "data-checked",
+      "false",
+    );
+    expect(screen.getByTestId("base-layer-Topo")).toHaveAttribute(
+      "data-checked",
+      "false",
+    );
   });
 
   it("should center on first park with coordinates", () => {

--- a/test/features/map/basemaps.test.ts
+++ b/test/features/map/basemaps.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { BASEMAPS } from "@/features/map/basemaps";
+
+describe("BASEMAPS", () => {
+  it("offers streets, satellite, and topo", () => {
+    expect(BASEMAPS.map((b) => b.name)).toEqual([
+      "Streets",
+      "Satellite",
+      "Topo",
+    ]);
+  });
+
+  it("defaults to Streets (first entry)", () => {
+    expect(BASEMAPS[0].name).toBe("Streets");
+  });
+
+  it("uses Esri World Imagery for satellite with {z}/{y}/{x} tile ordering", () => {
+    const satellite = BASEMAPS.find((b) => b.name === "Satellite");
+    expect(satellite).toBeDefined();
+    expect(satellite!.url).toContain("World_Imagery");
+    // Esri serves {z}/{y}/{x}; the usual {z}/{x}/{y} would return wrong tiles.
+    expect(satellite!.url).toContain("{z}/{y}/{x}");
+    expect(satellite!.url).not.toContain("{z}/{x}/{y}");
+  });
+
+  it("gives every basemap an attribution and a maxZoom", () => {
+    for (const base of BASEMAPS) {
+      expect(base.attribution.length).toBeGreaterThan(0);
+      expect(base.maxZoom).toBeGreaterThan(0);
+      expect(base.url).toMatch(/^https:\/\//);
+    }
+  });
+});


### PR DESCRIPTION
## What & why

The map rendered a single road-only OpenStreetMap raster layer. For an off-road audience, terrain and imagery matter more than streets. This adds a Leaflet layer switcher (top-right) with three basemaps:

- **Streets** (OpenStreetMap) — default
- **Satellite** (Esri World Imagery)
- **Topo** (OpenTopoMap)

All three are **keyless and free** at this scale — no API key, no metered map SDK. Google Maps stays out of the render path (it remains a Places-data source and a deep-link nav target only).

## Implementation
- Basemap definitions live in a small `basemaps.ts` module (name, tile URL, attribution, maxZoom, subdomains).
- `MapView` renders them via react-leaflet's `LayersControl` / `BaseLayer`, replacing the single hardcoded `TileLayer`.

## Testing
- Unit test guards the two easy-to-break details: the Esri **{z}/{y}/{x}** tile ordering (the usual {z}/{x}/{y} silently returns wrong tiles) and the default selection.
- MapView tests assert the switcher renders all three layers and defaults to Streets.
- **Verified all three tile endpoints serve valid images** (OSM png, Esri jpeg, OpenTopoMap png).
- Full suite green: **2455 passed, 2 skipped**.

## Note on verification
The dev server can't load parks in this worktree (no `POSTGRES_PRISMA_URL`), so switcher UX wasn't clicked through in-browser here — the tile sources were validated directly and the wiring via tests. The Vercel preview renders against a live DB for visual confirmation.

This completes the map-expansion roadmap items: route export (#198), marker clustering (#199), and basemap switching (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)