### PR TITLE
fix(map): allow Esri/OpenTopoMap basemap tiles in CSP img-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,12 @@ const isDev = process.env.NODE_ENV !== "production";
  * Content-Security-Policy (OP-99).
  *
  * Scoped to the app's real client-side resource usage:
- *  - Leaflet loads OSM map tiles (*.tile.openstreetmap.org) and default marker
- *    icons (unpkg.com) directly in the browser.
+ *  - Leaflet loads basemap tiles directly in the browser: OSM streets
+ *    (*.tile.openstreetmap.org), Esri World Imagery satellite
+ *    (server.arcgisonline.com), and OpenTopoMap topo (*.tile.opentopomap.org).
+ *    See src/features/map/basemaps.ts — new tile hosts must be added to
+ *    img-src below (a test guards this coverage).
+ *  - Leaflet default marker icons load from unpkg.com.
  *  - The route planner fetches Mapbox directions/geocoding (api.mapbox.com).
  *  - next/image proxies blob + Mapbox images through /_next/image (same-origin).
  *  - Vercel Analytics + the preview toolbar (vercel.live) inject scripts.
@@ -38,6 +42,8 @@ function contentSecurityPolicy(): string {
       "https://*.public.blob.vercel-storage.com",
       "https://api.mapbox.com",
       "https://*.tile.openstreetmap.org",
+      "https://server.arcgisonline.com",
+      "https://*.tile.opentopomap.org",
       "https://unpkg.com",
       "https://lh3.googleusercontent.com",
       "https://vercel.live",

--- a/test/features/map/basemap-csp.test.ts
+++ b/test/features/map/basemap-csp.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { BASEMAPS } from "@/features/map/basemaps";
+
+/**
+ * Guards against the regression where a basemap tile host isn't allowed by the
+ * Content-Security-Policy `img-src` in next.config.ts — which renders as a gray
+ * map in production (dev has no CSP, and direct fetches bypass it, so this only
+ * surfaces in prod). Adding a basemap with a new host must also update the CSP.
+ */
+function cspHostFor(url: string): string {
+  // Leaflet substitutes {s} with a subdomain, so a `{s}.host` template maps to
+  // the `*.host` CSP wildcard; strip it before parsing the host.
+  const host = new URL(url.replace("{s}.", "")).host;
+  return url.includes("{s}.") ? `*.${host}` : host;
+}
+
+const nextConfigSource = readFileSync(
+  resolve(__dirname, "../../../next.config.ts"),
+  "utf8",
+);
+
+describe("basemap CSP coverage", () => {
+  it("allows every basemap tile host in the next.config img-src", () => {
+    for (const base of BASEMAPS) {
+      const host = cspHostFor(base.url);
+      expect(
+        nextConfigSource,
+        `${base.name} tile host "${host}" must be allow-listed in next.config.ts img-src`,
+      ).toContain(host);
+    }
+  });
+});


### PR DESCRIPTION
## Bug
In production, switching the basemap to **Satellite** or **Topo** renders a gray map — the browser blocks the tile requests (visible as arcgis/opentopomap failures in the Network tab).

## Root cause
The basemap switcher (#200) added Esri World Imagery and OpenTopoMap tile sources, but the app's Content-Security-Policy (`next.config.ts`, OP-99) `img-src` only allow-listed `*.tile.openstreetmap.org`. The new hosts were blocked.

This didn't surface earlier because **dev has no CSP** and the direct `curl` checks during the basemap PR bypassed CSP entirely — CSP only applies to browser subresource loads in prod.

## Fix
- Add `https://server.arcgisonline.com` and `https://*.tile.opentopomap.org` to `img-src`.
- Add a **regression test** that derives each basemap's host from `BASEMAPS` and asserts it's allow-listed in `next.config.ts` — so adding a basemap can never silently drift from the CSP again.

## Verification
- New test fails without the fix, passes with it; full suite green (**2456 passed**).
- End-to-end: I'll confirm the deployed Vercel preview serves a CSP header containing both new hosts and that Satellite/Topo tiles load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)