### PR TITLE
Rebalance park detail layout, merge contribute/claim cards, hours in corrections

### DIFF
--- a/src/app/api/parks/[slug]/corrections/route.ts
+++ b/src/app/api/parks/[slug]/corrections/route.ts
@@ -9,6 +9,7 @@ import {
   correctableFieldType,
   OWNERSHIP_OPTIONS,
 } from "@/lib/ai/park-fields";
+import { weeklyHoursSchema } from "@/lib/hours";
 
 export const runtime = "nodejs";
 
@@ -65,6 +66,19 @@ function coerceFieldValue(
         };
       }
       return { value: raw };
+    }
+    case "hours": {
+      // Structured weekly schedule: validate the full {mon..sun} object with
+      // the same Zod schema the editor/display use (enforces HH:MM + open<close).
+      const result = weeklyHoursSchema.safeParse(raw);
+      if (!result.success) {
+        return {
+          error:
+            result.error.issues[0]?.message ??
+            "Enter a valid weekly schedule.",
+        };
+      }
+      return { value: result.data };
     }
     case "string":
     default: {

--- a/src/components/admin/FieldExtractionReview.tsx
+++ b/src/components/admin/FieldExtractionReview.tsx
@@ -13,6 +13,7 @@ import {
   EXTRACTABLE_FIELDS,
   humanizeOption,
 } from "@/lib/ai/park-fields";
+import { formatWeeklyHours } from "@/lib/hours";
 
 type EditorKind = "array" | "ownership" | "boolean" | "number" | "string";
 
@@ -347,7 +348,15 @@ export function FieldExtractionReview({ extractions }: Props) {
                       <div>
                         <p className="text-muted-foreground text-xs mb-1">Current Value</p>
                         <p className="text-foreground font-mono bg-muted rounded px-2 py-1 break-all">
-                          {extraction.currentValue ? formatValue(extraction.currentValue) : <span className="italic text-muted-foreground">empty</span>}
+                          {extraction.currentValue ? (
+                            extraction.fieldName === "hours" ? (
+                              <HoursValue json={extraction.currentValue} />
+                            ) : (
+                              formatValue(extraction.currentValue)
+                            )
+                          ) : (
+                            <span className="italic text-muted-foreground">empty</span>
+                          )}
                         </p>
                       </div>
                       <div>
@@ -355,7 +364,15 @@ export function FieldExtractionReview({ extractions }: Props) {
                           {isArrayField(extraction.fieldName) ? "New values to add" : "Extracted Value"}
                         </p>
                         <p className={`text-foreground font-mono rounded px-2 py-1 break-all ${isArrayField(extraction.fieldName) ? "bg-green-50 dark:bg-green-900/20" : "bg-blue-50 dark:bg-blue-900/20"}`}>
-                          {extraction.extractedValue ? formatValue(extraction.extractedValue) : <span className="italic text-muted-foreground">null</span>}
+                          {extraction.extractedValue ? (
+                            extraction.fieldName === "hours" ? (
+                              <HoursValue json={extraction.extractedValue} />
+                            ) : (
+                              formatValue(extraction.extractedValue)
+                            )
+                          ) : (
+                            <span className="italic text-muted-foreground">null</span>
+                          )}
                         </p>
                       </div>
                     </div>
@@ -486,6 +503,32 @@ function ConfidenceBadge({ score }: { score: number | null }) {
 const ARRAY_FIELDS = new Set(["terrain", "amenities", "camping", "vehicleTypes"]);
 function isArrayField(fieldName: string): boolean {
   return ARRAY_FIELDS.has(fieldName);
+}
+
+/**
+ * Render a structured weekly-hours JSON value as a readable schedule
+ * (grouped day ranges). Falls back to the raw string if it can't be parsed
+ * into a valid schedule.
+ */
+function HoursValue({ json }: { json: string }) {
+  let groups: ReturnType<typeof formatWeeklyHours>;
+  try {
+    groups = formatWeeklyHours(JSON.parse(json));
+  } catch {
+    return <>{json}</>;
+  }
+  if (groups.length === 0) {
+    return <span className="italic text-muted-foreground">No hours set</span>;
+  }
+  return (
+    <span className="block space-y-0.5">
+      {groups.map((g) => (
+        <span key={g.label} className="block">
+          {g.label}: {g.hours}
+        </span>
+      ))}
+    </span>
+  );
 }
 
 function formatValue(jsonStr: string): string {

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -13,7 +13,6 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ParkAttributesCards } from "./components/ParkAttributesCards";
-import { ParkClaimCTA } from "./components/ParkClaimCTA";
 import { ParkContactSidebar } from "./components/ParkContactSidebar";
 import { ParkOperationalCard } from "./components/ParkOperationalCard";
 import { ParkOverviewCard } from "./components/ParkOverviewCard";
@@ -624,37 +623,39 @@ function ParkDetailPageInner({
                   </div>
                 )
               )}
-              {/* Consolidated, always-visible contribution card. Keeps the
-                  correction dialog + photo prompt near the top of the sidebar
-                  instead of buried at the bottom of the page. */}
+              {/* Contact / directions — kept as a primary sidebar box. */}
+              <ParkContactSidebar park={park} />
+              {/* Consolidated contribution card: suggest a correction, add
+                  photos, and claim. The claim flow is embedded here as a
+                  section rather than living in a separate box this card links
+                  to. */}
               <ContributeCard
                 parkSlug={park.id}
                 parkName={park.name}
                 onAddPhotos={() => setActiveTab("photos")}
+                isLoggedIn={!!session?.user}
+                hasOperator={park.hasOperator}
+                existingClaim={existingClaim}
+                isOperatorOfPark={isOperatorOfPark}
+                operatorName={operatorName}
               />
-              <TrailConditionsDisplay parkSlug={park.id} />
-              {/* OP-53: NWS forecast + current. Renders nothing when both
-                  are empty (parks without coords or outside NWS coverage). */}
-              <WeatherCard
-                current={weatherCurrent ?? null}
-                forecast={weatherForecast ?? []}
-              />
-              <ParkContactSidebar park={park} />
-              <CampingInfoCard park={park} />
-              {/* Full claim flow. The ContributeCard's "Claim it" pointer
-                  links to this `#claim` anchor so the form lives in one place. */}
-              <div id="claim" className="scroll-mt-24">
-                <ParkClaimCTA
-                  parkSlug={park.id}
-                  isLoggedIn={!!session?.user}
-                  hasOperator={park.hasOperator}
-                  existingClaim={existingClaim}
-                  isOperatorOfPark={isOperatorOfPark}
-                  operatorName={operatorName}
-                />
-              </div>
             </div>
           </div>
+        </div>
+
+        {/* "More about this park" — full-width band below the two-column grid.
+            Glanceable info (trail conditions, weather, camping) reads across
+            the page instead of stacking the right rail too tall. Each card
+            self-hides when it has no data, so the row collapses gracefully. */}
+        <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6 items-start">
+          <TrailConditionsDisplay parkSlug={park.id} />
+          {/* OP-53: NWS forecast + current. Renders nothing when both are
+              empty (parks without coords or outside NWS coverage). */}
+          <WeatherCard
+            current={weatherCurrent ?? null}
+            forecast={weatherForecast ?? []}
+          />
+          <CampingInfoCard park={park} />
         </div>
       </main>
     </div>

--- a/src/features/parks/detail/components/ContributeCard.tsx
+++ b/src/features/parks/detail/components/ContributeCard.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import Link from "next/link";
 import { Camera, ClipboardCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SuggestCorrectionDialog } from "./SuggestCorrectionDialog";
+import { ParkClaimCTA } from "./ParkClaimCTA";
 
 interface ContributeCardProps {
-  /** Slug of the park (park.id) — passed through to the correction dialog. */
+  /** Slug of the park (park.id) — passed through to the correction dialog + claim flow. */
   parkSlug: string;
   /** Park name, shown in the correction dialog copy. */
   parkName: string;
@@ -17,21 +17,30 @@ interface ContributeCardProps {
    * the uploader here.
    */
   onAddPhotos: () => void;
+  /** Claim-flow props, threaded straight through to the embedded ParkClaimCTA. */
+  isLoggedIn: boolean;
+  hasOperator?: boolean;
+  existingClaim?: { status: string; reviewNotes: string | null } | null;
+  isOperatorOfPark?: boolean;
+  operatorName?: string | null;
 }
 
 /**
- * A single, understated "accuracy" card for the park-detail sidebar. Gathers
- * the crowd-sourced contribution affordances that were previously scattered
- * down the page — suggest a correction, add photos, and claim the listing —
- * into one calm, always-available spot (Wikipedia-style: edit is invited, never
- * shouty). The claim affordance is a short pointer to the full `ParkClaimCTA`
- * (mounted lower in the sidebar under `#claim`), so the claim form is not
- * duplicated.
+ * A single, understated card for the park-detail sidebar gathering every
+ * crowd-sourced contribution affordance — suggest a correction, add photos, and
+ * claim the listing — into one calm, always-available spot (Wikipedia-style:
+ * edit is invited, never shouty). The claim flow is embedded directly here as a
+ * second section rather than living in a separate box the card merely links to.
  */
 export function ContributeCard({
   parkSlug,
   parkName,
   onAddPhotos,
+  isLoggedIn,
+  hasOperator,
+  existingClaim,
+  isOperatorOfPark,
+  operatorName,
 }: ContributeCardProps) {
   return (
     <Card>
@@ -41,32 +50,36 @@ export function ContributeCard({
           Help keep this listing accurate
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-sm text-muted-foreground">
-          This is a community directory. Spot something off, or been here
-          yourself? Lend a hand.
-        </p>
-        <div className="flex flex-col gap-2">
-          <SuggestCorrectionDialog parkSlug={parkSlug} parkName={parkName} />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onAddPhotos}
-            className="justify-center"
-          >
-            <Camera className="w-4 h-4 mr-1.5" />
-            Add photos
-          </Button>
+      <CardContent className="space-y-4">
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            This is a community directory. Spot something off, or been here
+            yourself? Lend a hand.
+          </p>
+          <div className="flex flex-col gap-2">
+            <SuggestCorrectionDialog parkSlug={parkSlug} parkName={parkName} />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onAddPhotos}
+              className="justify-center"
+            >
+              <Camera className="w-4 h-4 mr-1.5" />
+              Add photos
+            </Button>
+          </div>
         </div>
-        <p className="text-xs text-muted-foreground">
-          Own or manage this park?{" "}
-          <Link
-            href="#claim"
-            className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
-          >
-            Claim it
-          </Link>
-        </p>
+        <div className="border-t border-border pt-4">
+          <ParkClaimCTA
+            embedded
+            parkSlug={parkSlug}
+            isLoggedIn={isLoggedIn}
+            hasOperator={hasOperator}
+            existingClaim={existingClaim}
+            isOperatorOfPark={isOperatorOfPark}
+            operatorName={operatorName}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/features/parks/detail/components/ParkClaimCTA.tsx
+++ b/src/features/parks/detail/components/ParkClaimCTA.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
+import { cn } from "@/lib/utils";
 
 interface ParkClaimCTAProps {
   parkSlug: string;
@@ -18,6 +19,12 @@ interface ParkClaimCTAProps {
   isOperatorOfPark?: boolean;
   /** Display name of the operator org, if the park is claimed */
   operatorName?: string | null;
+  /**
+   * Render without the outer Card chrome so this can sit as a section inside
+   * another card (the sidebar "Help keep this listing accurate" card). Colored
+   * status states become inset panels instead of standalone cards.
+   */
+  embedded?: boolean;
 }
 
 interface ClaimFormData {
@@ -28,7 +35,7 @@ interface ClaimFormData {
   message: string;
 }
 
-export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim, isOperatorOfPark, operatorName }: ParkClaimCTAProps) {
+export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim, isOperatorOfPark, operatorName, embedded = false }: ParkClaimCTAProps) {
   const { promptSignIn } = useSignInPrompt();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -44,72 +51,85 @@ export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim,
     message: "",
   });
 
-  if (isOperatorOfPark) {
-    return (
-      <Card className="border-blue-200 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-800">
-        <CardContent className="pt-4 pb-4 space-y-3">
-          <div className="flex items-center gap-2 text-blue-700 dark:text-blue-400">
-            <Building2 className="w-4 h-4 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-medium">You manage this park</p>
-              <p className="text-xs text-blue-600 dark:text-blue-500 mt-0.5">
-                You&apos;re registered as an operator of this park.
-              </p>
-            </div>
-          </div>
-          <Link
-            href={`/operator/${parkSlug}/dashboard?from=park`}
-            className="flex items-center justify-center gap-2 w-full text-sm font-medium px-3 py-2 rounded-md border border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
-          >
-            Go to Operator Portal
-            <ArrowRight className="w-4 h-4" />
-          </Link>
-        </CardContent>
+  /**
+   * Wraps a status state's content in either a colored Card (standalone) or a
+   * colored inset panel (embedded), keeping the palette identical across both.
+   */
+  const statusFrame = (
+    toneClass: string,
+    content: React.ReactNode,
+    contentClass?: string,
+  ) =>
+    embedded ? (
+      <div className={cn("rounded-lg border p-4", toneClass, contentClass)}>
+        {content}
+      </div>
+    ) : (
+      <Card className={toneClass}>
+        <CardContent className={cn("pt-4 pb-4", contentClass)}>{content}</CardContent>
       </Card>
+    );
+
+  if (isOperatorOfPark) {
+    return statusFrame(
+      "border-blue-200 bg-blue-50 dark:bg-blue-950/20 dark:border-blue-800",
+      <>
+        <div className="flex items-center gap-2 text-blue-700 dark:text-blue-400">
+          <Building2 className="w-4 h-4 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium">You manage this park</p>
+            <p className="text-xs text-blue-600 dark:text-blue-500 mt-0.5">
+              You&apos;re registered as an operator of this park.
+            </p>
+          </div>
+        </div>
+        <Link
+          href={`/operator/${parkSlug}/dashboard?from=park`}
+          className="flex items-center justify-center gap-2 w-full text-sm font-medium px-3 py-2 rounded-md border border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+        >
+          Go to Operator Portal
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </>,
+      "space-y-3",
     );
   }
 
   if (hasOperator) {
-    return (
-      <Card className="border-gray-200 bg-gray-50 dark:bg-gray-900/40 dark:border-gray-700">
-        <CardContent className="pt-4 pb-4">
-          <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-            <Building2 className="w-4 h-4 flex-shrink-0" />
-            <p className="text-xs">
-              This listing is managed by{" "}
-              <span className="font-medium text-gray-800 dark:text-gray-200">
-                {operatorName ?? "a verified operator"}
-              </span>
-              {" "}— details are kept up to date directly by the operator.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+    return statusFrame(
+      "border-gray-200 bg-gray-50 dark:bg-gray-900/40 dark:border-gray-700",
+      <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+        <Building2 className="w-4 h-4 flex-shrink-0" />
+        <p className="text-xs">
+          This listing is managed by{" "}
+          <span className="font-medium text-gray-800 dark:text-gray-200">
+            {operatorName ?? "a verified operator"}
+          </span>
+          {" "}— details are kept up to date directly by the operator.
+        </p>
+      </div>,
     );
   }
 
   // Rejected state — shown server-side and cannot re-submit
   if (existingClaim?.status === "REJECTED") {
-    return (
-      <Card className="border-red-200 bg-red-50 dark:bg-red-950/20 dark:border-red-800">
-        <CardContent className="pt-4 pb-4">
-          <div className="flex items-start gap-2 text-red-700 dark:text-red-400">
-            <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-            <div>
-              <p className="text-sm font-medium">Claim not approved</p>
-              <p className="text-xs text-red-600 dark:text-red-500 mt-0.5">
-                Your claim request for this park was not approved.
-              </p>
-              {existingClaim.reviewNotes && (
-                <p className="text-xs text-red-700 dark:text-red-400 mt-1.5 border-t border-red-200 dark:border-red-800 pt-1.5">
-                  <span className="font-medium">Note: </span>
-                  {existingClaim.reviewNotes}
-                </p>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+    return statusFrame(
+      "border-red-200 bg-red-50 dark:bg-red-950/20 dark:border-red-800",
+      <div className="flex items-start gap-2 text-red-700 dark:text-red-400">
+        <XCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+        <div>
+          <p className="text-sm font-medium">Claim not approved</p>
+          <p className="text-xs text-red-600 dark:text-red-500 mt-0.5">
+            Your claim request for this park was not approved.
+          </p>
+          {existingClaim.reviewNotes && (
+            <p className="text-xs text-red-700 dark:text-red-400 mt-1.5 border-t border-red-200 dark:border-red-800 pt-1.5">
+              <span className="font-medium">Note: </span>
+              {existingClaim.reviewNotes}
+            </p>
+          )}
+        </div>
+      </div>,
     );
   }
 
@@ -148,20 +168,149 @@ export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim,
   };
 
   if (isSuccess) {
+    return statusFrame(
+      "border-green-200 bg-green-50 dark:bg-green-950/20 dark:border-green-800",
+      <div className="flex items-center gap-2 text-green-700 dark:text-green-400">
+        <CheckCircle className="w-4 h-4 flex-shrink-0" />
+        <div>
+          <p className="text-sm font-medium">Claim submitted!</p>
+          <p className="text-xs text-green-600 dark:text-green-500 mt-0.5">
+            We&apos;ll review your request and get back to you by email.
+          </p>
+        </div>
+      </div>,
+    );
+  }
+
+  const body = (
+    <>
+      <p className="text-sm text-muted-foreground">
+        Claim your listing to manage your park&apos;s profile, post trail conditions, and respond to visitors.
+      </p>
+
+      {!isLoggedIn ? (
+        <p className="text-xs text-muted-foreground">
+          <button
+            type="button"
+            onClick={() =>
+              promptSignIn({
+                description: "Sign in to claim and manage this park.",
+              })
+            }
+            className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
+          >
+            Sign in
+          </button>{" "}
+          to claim this park.
+        </p>
+      ) : (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => setIsExpanded((v) => !v)}
+          >
+            Claim this park
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4 ml-2" />
+            ) : (
+              <ChevronDown className="w-4 h-4 ml-2" />
+            )}
+          </Button>
+
+          {isExpanded && (
+            <form onSubmit={handleSubmit} className="space-y-3 pt-1" data-testid="claim-form">
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Organization or business name <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={form.businessName}
+                  onChange={(e) => setForm((f) => ({ ...f, businessName: e.target.value }))}
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  placeholder="Iowa DNR, Desert Riders Association…"
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Your name <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={form.claimantName}
+                  onChange={(e) => setForm((f) => ({ ...f, claimantName: e.target.value }))}
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  placeholder="Jane Smith"
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Contact email <span className="text-destructive">*</span>
+                </label>
+                <input
+                  type="email"
+                  required
+                  value={form.claimantEmail}
+                  onChange={(e) => setForm((f) => ({ ...f, claimantEmail: e.target.value }))}
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  placeholder="jane@example.com"
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Phone (optional)
+                </label>
+                <input
+                  type="tel"
+                  value={form.claimantPhone}
+                  onChange={(e) => setForm((f) => ({ ...f, claimantPhone: e.target.value }))}
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  placeholder="(555) 555-5555"
+                />
+              </div>
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Why are you claiming this park? (optional)
+                </label>
+                <textarea
+                  value={form.message}
+                  onChange={(e) => setForm((f) => ({ ...f, message: e.target.value }))}
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  rows={3}
+                  placeholder="I am the owner/manager of this park..."
+                />
+              </div>
+              {error && (
+                <p className="text-xs text-destructive">{error}</p>
+              )}
+              <Button
+                type="submit"
+                size="sm"
+                className="w-full"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? "Submitting…" : "Submit claim"}
+              </Button>
+            </form>
+          )}
+        </>
+      )}
+    </>
+  );
+
+  if (embedded) {
     return (
-      <Card className="border-green-200 bg-green-50 dark:bg-green-950/20 dark:border-green-800">
-        <CardContent className="pt-4 pb-4">
-          <div className="flex items-center gap-2 text-green-700 dark:text-green-400">
-            <CheckCircle className="w-4 h-4 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-medium">Claim submitted!</p>
-              <p className="text-xs text-green-600 dark:text-green-500 mt-0.5">
-                We&apos;ll review your request and get back to you by email.
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-base font-semibold">
+          <Building2 className="w-4 h-4" />
+          Own or manage this park?
+        </div>
+        {body}
+      </div>
     );
   }
 
@@ -173,123 +322,7 @@ export function ParkClaimCTA({ parkSlug, isLoggedIn, hasOperator, existingClaim,
           Own or manage this park?
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-sm text-muted-foreground">
-          Claim your listing to manage your park&apos;s profile, post trail conditions, and respond to visitors.
-        </p>
-
-        {!isLoggedIn ? (
-          <p className="text-xs text-muted-foreground">
-            <button
-              type="button"
-              onClick={() =>
-                promptSignIn({
-                  description: "Sign in to claim and manage this park.",
-                })
-              }
-              className="text-primary underline underline-offset-2 font-medium hover:opacity-80"
-            >
-              Sign in
-            </button>{" "}
-            to claim this park.
-          </p>
-        ) : (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full"
-              onClick={() => setIsExpanded((v) => !v)}
-            >
-              Claim this park
-              {isExpanded ? (
-                <ChevronUp className="w-4 h-4 ml-2" />
-              ) : (
-                <ChevronDown className="w-4 h-4 ml-2" />
-              )}
-            </Button>
-
-            {isExpanded && (
-              <form onSubmit={handleSubmit} className="space-y-3 pt-1" data-testid="claim-form">
-                <div>
-                  <label className="text-xs text-muted-foreground block mb-1">
-                    Organization or business name <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={form.businessName}
-                    onChange={(e) => setForm((f) => ({ ...f, businessName: e.target.value }))}
-                    className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                    placeholder="Iowa DNR, Desert Riders Association…"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground block mb-1">
-                    Your name <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={form.claimantName}
-                    onChange={(e) => setForm((f) => ({ ...f, claimantName: e.target.value }))}
-                    className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                    placeholder="Jane Smith"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground block mb-1">
-                    Contact email <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    type="email"
-                    required
-                    value={form.claimantEmail}
-                    onChange={(e) => setForm((f) => ({ ...f, claimantEmail: e.target.value }))}
-                    className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                    placeholder="jane@example.com"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground block mb-1">
-                    Phone (optional)
-                  </label>
-                  <input
-                    type="tel"
-                    value={form.claimantPhone}
-                    onChange={(e) => setForm((f) => ({ ...f, claimantPhone: e.target.value }))}
-                    className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                    placeholder="(555) 555-5555"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-muted-foreground block mb-1">
-                    Why are you claiming this park? (optional)
-                  </label>
-                  <textarea
-                    value={form.message}
-                    onChange={(e) => setForm((f) => ({ ...f, message: e.target.value }))}
-                    className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                    rows={3}
-                    placeholder="I am the owner/manager of this park..."
-                  />
-                </div>
-                {error && (
-                  <p className="text-xs text-destructive">{error}</p>
-                )}
-                <Button
-                  type="submit"
-                  size="sm"
-                  className="w-full"
-                  disabled={isSubmitting}
-                >
-                  {isSubmitting ? "Submitting…" : "Submit claim"}
-                </Button>
-              </form>
-            )}
-          </>
-        )}
-      </CardContent>
+      <CardContent className="space-y-3">{body}</CardContent>
     </Card>
   );
 }

--- a/src/features/parks/detail/components/SuggestCorrectionDialog.tsx
+++ b/src/features/parks/detail/components/SuggestCorrectionDialog.tsx
@@ -30,6 +30,13 @@ import {
   humanizeOption,
   OWNERSHIP_OPTIONS,
 } from "@/lib/ai/park-fields";
+import { WeeklyHoursEditor } from "@/components/forms/park-fields/WeeklyHoursEditor";
+import {
+  emptyWeeklyHours,
+  hasAnyHours,
+  weeklyHoursSchema,
+  type WeeklyHours,
+} from "@/lib/hours";
 
 type Mode = "field" | "text";
 
@@ -65,6 +72,7 @@ export function SuggestCorrectionDialog({
   const [fieldName, setFieldName] = useState<string>("");
   const [stringValue, setStringValue] = useState<string>("");
   const [boolValue, setBoolValue] = useState<boolean>(false);
+  const [hoursValue, setHoursValue] = useState<WeeklyHours>(emptyWeeklyHours());
   const [note, setNote] = useState<string>("");
   const [textNote, setTextNote] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
@@ -80,6 +88,7 @@ export function SuggestCorrectionDialog({
     setFieldName("");
     setStringValue("");
     setBoolValue(false);
+    setHoursValue(emptyWeeklyHours());
     setNote("");
     setTextNote("");
     setError(null);
@@ -105,6 +114,20 @@ export function SuggestCorrectionDialog({
 
   const buildFieldValue = (): { value: unknown } | { error: string } => {
     if (valueType === "boolean") return { value: boolValue };
+    if (valueType === "hours") {
+      if (!hasAnyHours(hoursValue)) {
+        return { error: "Set hours for at least one day." };
+      }
+      const parsed = weeklyHoursSchema.safeParse(hoursValue);
+      if (!parsed.success) {
+        return {
+          error:
+            parsed.error.issues[0]?.message ??
+            "Check the hours — opening time must be before closing time.",
+        };
+      }
+      return { value: parsed.data };
+    }
     if (valueType === "number") {
       const trimmed = stringValue.trim();
       if (trimmed === "") return { error: "Enter a number." };
@@ -252,6 +275,7 @@ export function SuggestCorrectionDialog({
                       setFieldName(v);
                       setStringValue("");
                       setBoolValue(false);
+                      setHoursValue(emptyWeeklyHours());
                       setError(null);
                     }}
                   >
@@ -282,7 +306,12 @@ export function SuggestCorrectionDialog({
                       Correct value
                     </label>
 
-                    {valueType === "boolean" ? (
+                    {valueType === "hours" ? (
+                      <WeeklyHoursEditor
+                        value={hoursValue}
+                        onChange={setHoursValue}
+                      />
+                    ) : valueType === "boolean" ? (
                       <label className="inline-flex items-center gap-2 cursor-pointer">
                         <input
                           id="correction-value"

--- a/src/lib/ai/park-fields.ts
+++ b/src/lib/ai/park-fields.ts
@@ -104,7 +104,6 @@ export const EXTRACTABLE_FIELDS: Record<string, string> = {
   sparkArrestorRequired: "boolean",
   helmetsRequired: "boolean",
   noiseLimitDBA: "number",
-  hours: "hours",
   "address.streetAddress": "string",
   "address.city": "string",
   "address.zipCode": "string",
@@ -116,12 +115,18 @@ export const EXTRACTABLE_FIELDS: Record<string, string> = {
 };
 
 /**
- * Curated subset of {@link EXTRACTABLE_FIELDS} that end users are allowed to
- * correct via the "Suggest a correction" dialog. Kept intentionally narrow to
- * user-verifiable facts (contact info, fees, access rules, address) — the full
- * extractable set includes fields like latitude/notes that we don't expose to
- * public field-level correction. The POST /api/parks/[slug]/corrections route
- * validates `fieldName` against this list; the dialog builds its picker from it.
+ * Fields end users are allowed to correct via the "Suggest a correction" dialog.
+ * Mostly a curated subset of {@link EXTRACTABLE_FIELDS} — user-verifiable facts
+ * (contact info, fees, access rules, address); the full extractable set includes
+ * fields like latitude/notes we don't expose to public correction.
+ *
+ * `hours` is the one member that is correctable but deliberately NOT in
+ * EXTRACTABLE_FIELDS: structured weekly hours are display-only and human-entered
+ * (submit/operator/admin forms + this correction dialog), never AI-researched or
+ * scored for completeness. See {@link correctableFieldType}.
+ *
+ * The POST /api/parks/[slug]/corrections route validates `fieldName` against this
+ * list; the dialog builds its picker from it.
  */
 export const CORRECTABLE_FIELDS = [
   "website",
@@ -170,6 +175,9 @@ export function isCorrectableField(field: string): field is CorrectableField {
  * - "string"  → text input
  */
 export function correctableFieldType(field: CorrectableField): string {
+  // `hours` is correctable but not an AI-extractable field, so it has no
+  // EXTRACTABLE_FIELDS entry — its structured-editor type is defined here.
+  if (field === "hours") return "hours";
   return EXTRACTABLE_FIELDS[field];
 }
 

--- a/src/lib/ai/park-fields.ts
+++ b/src/lib/ai/park-fields.ts
@@ -104,6 +104,7 @@ export const EXTRACTABLE_FIELDS: Record<string, string> = {
   sparkArrestorRequired: "boolean",
   helmetsRequired: "boolean",
   noiseLimitDBA: "number",
+  hours: "hours",
   "address.streetAddress": "string",
   "address.city": "string",
   "address.zipCode": "string",
@@ -143,6 +144,7 @@ export const CORRECTABLE_FIELDS = [
   "flagsRequired",
   "sparkArrestorRequired",
   "helmetsRequired",
+  "hours",
   "address.streetAddress",
   "address.city",
   "address.zipCode",
@@ -164,6 +166,7 @@ export function isCorrectableField(field: string): field is CorrectableField {
  * - "boolean" → toggle
  * - "number"  → number input
  * - "Ownership" → enum select (see OWNERSHIP_OPTIONS)
+ * - "hours"    → structured weekly-hours editor (see WeeklyHoursEditor)
  * - "string"  → text input
  */
 export function correctableFieldType(field: CorrectableField): string {
@@ -192,6 +195,7 @@ const FIELD_LABEL_OVERRIDES: Record<string, string> = {
   flagsRequired: "Flags required",
   sparkArrestorRequired: "Spark arrestor required",
   helmetsRequired: "Helmets required",
+  hours: "Hours",
   "address.streetAddress": "Street address",
   "address.city": "City",
   "address.zipCode": "ZIP code",

--- a/test/app/api/admin/ai-research/extractions/[id]/approve/route.test.ts
+++ b/test/app/api/admin/ai-research/extractions/[id]/approve/route.test.ts
@@ -1,0 +1,112 @@
+import { POST } from "@/app/api/admin/ai-research/extractions/[id]/approve/route";
+import { requireAdmin } from "@/lib/api-helpers";
+import { prisma } from "@/lib/prisma";
+import { vi } from "vitest";
+
+vi.mock("@/lib/api-helpers", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// Transaction client shared by the mock so tests can assert on its calls.
+const tx = {
+  park: {
+    update: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  address: { updateMany: vi.fn() },
+  fieldExtraction: {
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    findMany: vi.fn(),
+  },
+  parkEditLog: { create: vi.fn() },
+  parkTerrain: { findMany: vi.fn(), create: vi.fn() },
+  parkAmenity: { findMany: vi.fn(), create: vi.fn() },
+  parkCamping: { findMany: vi.fn(), create: vi.fn() },
+  parkVehicleType: { findMany: vi.fn(), create: vi.fn() },
+};
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    fieldExtraction: { findUnique: vi.fn() },
+    $transaction: vi.fn(async (cb: (client: typeof tx) => unknown) => cb(tx)),
+  },
+}));
+
+vi.mock("@/lib/ai/research-lifecycle", () => ({
+  calculateCompleteness: vi.fn(() => 42),
+  getCurrentFieldValue: vi.fn(() => null),
+}));
+
+const emptyParkRelations = {
+  terrain: [],
+  amenities: [],
+  camping: [],
+  vehicleTypes: [],
+  address: null,
+};
+
+function makeReq(body?: unknown) {
+  return new Request(
+    "http://localhost/api/admin/ai-research/extractions/ext-1/approve",
+    {
+      method: "POST",
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    },
+  );
+}
+
+const params = { params: Promise.resolve({ id: "ext-1" }) };
+
+describe("POST /api/admin/ai-research/extractions/[id]/approve — hours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      user: { id: "admin-1" },
+    } as never);
+    tx.park.findUnique.mockResolvedValue({
+      id: "park-1",
+      ...emptyParkRelations,
+    });
+  });
+
+  it("applies a structured hours object to Park.hours unchanged", async () => {
+    const hours = {
+      mon: { open: "08:00", close: "18:00" },
+      tue: { open: "08:00", close: "18:00" },
+      wed: null,
+      thu: null,
+      fri: null,
+      sat: { closed: true },
+      sun: null,
+    };
+
+    vi.mocked(prisma.fieldExtraction.findUnique).mockResolvedValue({
+      id: "ext-1",
+      parkId: "park-1",
+      fieldName: "hours",
+      extractedValue: JSON.stringify(hours),
+      status: "PENDING_REVIEW",
+      dataSourceId: null,
+      park: { id: "park-1", ...emptyParkRelations },
+    } as never);
+
+    const res = await POST(makeReq(), params);
+    expect(res.status).toBe(200);
+
+    // Scalar path: the parsed object is written straight to Park.hours.
+    expect(tx.park.update).toHaveBeenCalledWith({
+      where: { id: "park-1" },
+      data: { hours },
+    });
+
+    // Extraction is marked approved.
+    expect(tx.fieldExtraction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "ext-1" },
+        data: expect.objectContaining({ status: "APPROVED" }),
+      }),
+    );
+  });
+});

--- a/test/app/api/parks/[slug]/corrections/route.test.ts
+++ b/test/app/api/parks/[slug]/corrections/route.test.ts
@@ -215,6 +215,89 @@ describe("POST /api/parks/[slug]/corrections", () => {
       expect(res.status).toBe(400);
       expect(prisma.fieldExtraction.create).not.toHaveBeenCalled();
     });
+
+    it("accepts and stringifies a valid weekly-hours object", async () => {
+      vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as any);
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(mockPark as any);
+      vi.mocked(prisma.fieldExtraction.create).mockResolvedValue({ id: "fx" } as any);
+
+      const hours = {
+        mon: { open: "08:00", close: "18:00" },
+        tue: { open: "08:00", close: "18:00" },
+        wed: null,
+        thu: null,
+        fri: null,
+        sat: { closed: true },
+        sun: null,
+      };
+      const res = await POST(
+        makeReq({ kind: "field", fieldName: "hours", value: hours }),
+        params,
+      );
+      expect(res.status).toBe(201);
+      const call = vi.mocked(prisma.fieldExtraction.create).mock.calls[0][0];
+      expect(call.data.fieldName).toBe("hours");
+      expect(call.data.extractedValue).toBe(JSON.stringify(hours));
+      // The stored value round-trips back into a proper object for the approve route.
+      expect(JSON.parse(call.data.extractedValue as string)).toEqual(hours);
+    });
+
+    it("rejects a malformed weekly-hours object (open >= close)", async () => {
+      vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as any);
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(mockPark as any);
+      const res = await POST(
+        makeReq({
+          kind: "field",
+          fieldName: "hours",
+          value: {
+            mon: { open: "18:00", close: "08:00" },
+            tue: null,
+            wed: null,
+            thu: null,
+            fri: null,
+            sat: null,
+            sun: null,
+          },
+        }),
+        params,
+      );
+      expect(res.status).toBe(400);
+      expect(prisma.fieldExtraction.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a weekly-hours value with a bad time format", async () => {
+      vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as any);
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(mockPark as any);
+      const res = await POST(
+        makeReq({
+          kind: "field",
+          fieldName: "hours",
+          value: {
+            mon: { open: "8am", close: "6pm" },
+            tue: null,
+            wed: null,
+            thu: null,
+            fri: null,
+            sat: null,
+            sun: null,
+          },
+        }),
+        params,
+      );
+      expect(res.status).toBe(400);
+      expect(prisma.fieldExtraction.create).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-object hours value", async () => {
+      vi.mocked(auth).mockResolvedValue({ user: { id: "user-1" } } as any);
+      vi.mocked(prisma.park.findUnique).mockResolvedValue(mockPark as any);
+      const res = await POST(
+        makeReq({ kind: "field", fieldName: "hours", value: "9-5" }),
+        params,
+      );
+      expect(res.status).toBe(400);
+      expect(prisma.fieldExtraction.create).not.toHaveBeenCalled();
+    });
   });
 
   it("rate-limits after the configured number of submissions", async () => {

--- a/test/components/admin/FieldExtractionReview.test.tsx
+++ b/test/components/admin/FieldExtractionReview.test.tsx
@@ -214,6 +214,50 @@ describe("FieldExtractionReview", () => {
     expect(container.textContent).not.toMatch(/%/);
   });
 
+  it("renders a formatted schedule for a hours extraction", () => {
+    const hours = {
+      mon: { open: "08:00", close: "18:00" },
+      tue: { open: "08:00", close: "18:00" },
+      wed: { open: "08:00", close: "18:00" },
+      thu: { open: "08:00", close: "18:00" },
+      fri: { open: "08:00", close: "18:00" },
+      sat: { closed: true },
+      sun: { closed: true },
+    };
+    render(
+      <FieldExtractionReview
+        extractions={[
+          makeExtraction({
+            fieldName: "hours",
+            extractedValue: JSON.stringify(hours),
+            currentValue: null,
+          }),
+        ]}
+      />
+    );
+    // Grouped, human-readable schedule instead of the raw JSON blob.
+    expect(
+      screen.getByText(/Mon.*Fri.*8:00 AM.*6:00 PM/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Sat.*Sun.*Closed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"open"/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to raw text when a hours value can't be parsed", () => {
+    render(
+      <FieldExtractionReview
+        extractions={[
+          makeExtraction({
+            fieldName: "hours",
+            extractedValue: "not-json",
+            currentValue: null,
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText("not-json")).toBeInTheDocument();
+  });
+
   it("falls back to raw JSON string when parsing fails", () => {
     render(
       <FieldExtractionReview

--- a/test/components/parks/SuggestCorrectionDialog.test.tsx
+++ b/test/components/parks/SuggestCorrectionDialog.test.tsx
@@ -46,6 +46,18 @@ vi.mock("@/components/ui/dialog", async () => {
   };
 });
 
+// Radix Checkbox (used by the embedded WeeklyHoursEditor) → native checkbox.
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({ checked, onCheckedChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+      {...props}
+    />
+  ),
+}));
+
 // Mock the radix Select as a native <select> (radix Select doesn't work in jsdom).
 vi.mock("@/components/ui/select", () => ({
   Select: ({ value, onValueChange, children }: any) => (
@@ -203,6 +215,77 @@ describe("SuggestCorrectionDialog", () => {
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
     expect(body.value).toBe(1200);
+  });
+
+  it("renders the weekly-hours editor for the hours field", () => {
+    signedIn();
+    render(<SuggestCorrectionDialog parkSlug="test-park" />);
+    openDialog();
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "hours" },
+    });
+    expect(screen.getByTestId("weekly-hours-editor")).toBeInTheDocument();
+    expect(screen.getByLabelText("Monday opening time")).toBeInTheDocument();
+  });
+
+  it("submits a weekly-hours correction as a structured object", async () => {
+    signedIn();
+    render(<SuggestCorrectionDialog parkSlug="test-park" />);
+    openDialog();
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "hours" },
+    });
+    fireEvent.change(screen.getByLabelText("Monday opening time"), {
+      target: { value: "08:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Monday closing time"), {
+      target: { value: "18:00" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.kind).toBe("field");
+    expect(body.fieldName).toBe("hours");
+    expect(body.value).toEqual({
+      mon: { open: "08:00", close: "18:00" },
+      tue: null,
+      wed: null,
+      thu: null,
+      fri: null,
+      sat: null,
+      sun: null,
+    });
+  });
+
+  it("blocks submit when no hours are set", () => {
+    signedIn();
+    render(<SuggestCorrectionDialog parkSlug="test-park" />);
+    openDialog();
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "hours" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(/at least one day/i);
+  });
+
+  it("blocks submit and surfaces an error for invalid hours (open after close)", () => {
+    signedIn();
+    render(<SuggestCorrectionDialog parkSlug="test-park" />);
+    openDialog();
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "hours" },
+    });
+    fireEvent.change(screen.getByLabelText("Monday opening time"), {
+      target: { value: "18:00" },
+    });
+    fireEvent.change(screen.getByLabelText("Monday closing time"), {
+      target: { value: "08:00" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^submit$/i }));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("submits a free-text report", async () => {

--- a/test/features/parks/detail/ParkDetailPage.test.tsx
+++ b/test/features/parks/detail/ParkDetailPage.test.tsx
@@ -695,11 +695,18 @@ describe("ParkDetailPage", () => {
       ).toBeInTheDocument();
     });
 
-    it("points to the claim flow via the #claim anchor", () => {
-      render(<ParkDetailPage park={mockPark} photos={[]} />);
+    it("embeds the claim flow inside the accuracy card (no separate #claim box)", () => {
+      const { container } = render(
+        <ParkDetailPage park={mockPark} photos={[]} />,
+      );
 
-      const link = screen.getByRole("link", { name: /claim it/i });
-      expect(link).toHaveAttribute("href", "#claim");
+      // The claim prompt now lives inside the sidebar accuracy card...
+      const sidebar = container.querySelector(".lg\\:col-span-1");
+      const claimHeading = screen.getByText(/own or manage this park/i);
+      expect(sidebar).toContainElement(claimHeading);
+      // ...and the old cross-page pointer + #claim anchor are gone.
+      expect(screen.queryByRole("link", { name: /claim it/i })).toBeNull();
+      expect(container.querySelector("#claim")).toBeNull();
     });
 
     it("no longer renders the old inline correction prompt in the Overview tab", () => {

--- a/test/features/parks/detail/components/ContributeCard.test.tsx
+++ b/test/features/parks/detail/components/ContributeCard.test.tsx
@@ -16,13 +16,32 @@ vi.mock(
   }),
 );
 
+// Stub the claim flow — we assert it's embedded inside the card with the right
+// props, not its internal states (those are covered in ParkClaimCTA's tests).
+vi.mock("@/features/parks/detail/components/ParkClaimCTA", () => ({
+  ParkClaimCTA: (props: any) => (
+    <div
+      data-testid="claim-cta"
+      data-embedded={String(props.embedded)}
+      data-slug={props.parkSlug}
+      data-loggedin={String(props.isLoggedIn)}
+      data-operatorname={props.operatorName ?? ""}
+    >
+      claim
+    </div>
+  ),
+}));
+
 describe("ContributeCard", () => {
-  const noop = () => {};
+  const defaultProps = {
+    parkSlug: "test-park",
+    parkName: "Test Park",
+    onAddPhotos: () => {},
+    isLoggedIn: true,
+  };
 
   it("renders the 'Help keep this listing accurate' title", () => {
-    render(
-      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
-    );
+    render(<ContributeCard {...defaultProps} />);
 
     expect(
       screen.getByText(/help keep this listing accurate/i),
@@ -30,9 +49,7 @@ describe("ContributeCard", () => {
   });
 
   it("mounts the correction dialog with the park slug and name", () => {
-    render(
-      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
-    );
+    render(<ContributeCard {...defaultProps} />);
 
     const dialog = screen.getByTestId("suggest-correction-dialog");
     expect(dialog).toHaveTextContent("correction:test-park:Test Park");
@@ -41,26 +58,30 @@ describe("ContributeCard", () => {
   it("renders an 'Add photos' button that calls onAddPhotos when clicked", async () => {
     const onAddPhotos = vi.fn();
     const user = userEvent.setup();
-    render(
-      <ContributeCard
-        parkSlug="test-park"
-        parkName="Test Park"
-        onAddPhotos={onAddPhotos}
-      />,
-    );
+    render(<ContributeCard {...defaultProps} onAddPhotos={onAddPhotos} />);
 
     await user.click(screen.getByRole("button", { name: /add photos/i }));
 
     expect(onAddPhotos).toHaveBeenCalledOnce();
   });
 
-  it("renders a subtle claim pointer linking to the #claim anchor", () => {
+  it("embeds the claim flow inside the card (no separate box) with claim props threaded through", () => {
     render(
-      <ContributeCard parkSlug="test-park" parkName="Test Park" onAddPhotos={noop} />,
+      <ContributeCard
+        {...defaultProps}
+        isLoggedIn={false}
+        operatorName="Desert Riders"
+      />,
     );
 
-    expect(screen.getByText(/own or manage this park/i)).toBeInTheDocument();
-    const link = screen.getByRole("link", { name: /claim it/i });
-    expect(link).toHaveAttribute("href", "#claim");
+    const claim = screen.getByTestId("claim-cta");
+    expect(claim).toBeInTheDocument();
+    // Rendered inline (embedded), not as a standalone card the user is pointed to.
+    expect(claim).toHaveAttribute("data-embedded", "true");
+    expect(claim).toHaveAttribute("data-slug", "test-park");
+    expect(claim).toHaveAttribute("data-loggedin", "false");
+    expect(claim).toHaveAttribute("data-operatorname", "Desert Riders");
+    // The old cross-page pointer link is gone.
+    expect(screen.queryByRole("link", { name: /claim it/i })).toBeNull();
   });
 });

--- a/test/features/parks/detail/components/ParkClaimCTA.test.tsx
+++ b/test/features/parks/detail/components/ParkClaimCTA.test.tsx
@@ -245,4 +245,43 @@ describe("ParkClaimCTA", () => {
       );
     });
   });
+
+  describe("embedded mode (inside the accuracy card)", () => {
+    it("renders the claim prompt inline when logged in", () => {
+      render(<ParkClaimCTA parkSlug="test-park" isLoggedIn={true} embedded />);
+
+      expect(screen.getByText("Own or manage this park?")).toBeInTheDocument();
+      expect(screen.getByText("Claim this park")).toBeInTheDocument();
+    });
+
+    it("renders the operator status inline when isOperatorOfPark", () => {
+      render(
+        <ParkClaimCTA
+          parkSlug="test-park"
+          isLoggedIn={true}
+          isOperatorOfPark={true}
+          embedded
+        />,
+      );
+
+      expect(screen.getByText("You manage this park")).toBeInTheDocument();
+    });
+
+    it("renders the managed-by notice inline when the park has an operator", () => {
+      render(
+        <ParkClaimCTA
+          parkSlug="test-park"
+          isLoggedIn={false}
+          hasOperator={true}
+          operatorName="Desert Riders LLC"
+          embedded
+        />,
+      );
+
+      expect(
+        screen.getByText(/this listing is managed by/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Desert Riders LLC")).toBeInTheDocument();
+    });
+  });
 });

--- a/test/lib/ai/correctable-fields.test.ts
+++ b/test/lib/ai/correctable-fields.test.ts
@@ -32,9 +32,16 @@ describe("correctable fields registry", () => {
     expect(correctableFieldType("ownership")).toBe("Ownership");
   });
 
+  it("registers hours as a correctable field with the 'hours' type", () => {
+    expect(isCorrectableField("hours")).toBe(true);
+    expect(correctableFieldType("hours")).toBe("hours");
+    expect(EXTRACTABLE_FIELDS["hours"]).toBe("hours");
+  });
+
   it("humanizeFieldName produces readable labels incl. address fields", () => {
     expect(humanizeFieldName("website")).toBe("Website");
     expect(humanizeFieldName("address.streetAddress")).toBe("Street address");
     expect(humanizeFieldName("contactEmail")).toBe("Contact email");
+    expect(humanizeFieldName("hours")).toBe("Hours");
   });
 });

--- a/test/lib/ai/correctable-fields.test.ts
+++ b/test/lib/ai/correctable-fields.test.ts
@@ -8,10 +8,17 @@ import {
 } from "@/lib/ai/park-fields";
 
 describe("correctable fields registry", () => {
-  it("every correctable field exists in EXTRACTABLE_FIELDS", () => {
+  it("every correctable field exists in EXTRACTABLE_FIELDS (except display-only hours)", () => {
     for (const f of CORRECTABLE_FIELDS) {
+      // `hours` is correctable but intentionally not AI-extractable, so it has
+      // no EXTRACTABLE_FIELDS entry (kept out of research + completeness).
+      if (f === "hours") continue;
       expect(EXTRACTABLE_FIELDS[f]).toBeDefined();
     }
+  });
+
+  it("keeps hours out of EXTRACTABLE_FIELDS so it is never AI-researched or scored", () => {
+    expect(EXTRACTABLE_FIELDS["hours"]).toBeUndefined();
   });
 
   it("isCorrectableField gates the curated subset", () => {
@@ -35,7 +42,6 @@ describe("correctable fields registry", () => {
   it("registers hours as a correctable field with the 'hours' type", () => {
     expect(isCorrectableField("hours")).toBe(true);
     expect(correctableFieldType("hours")).toBe("hours");
-    expect(EXTRACTABLE_FIELDS["hours"]).toBe("hours");
   });
 
   it("humanizeFieldName produces readable labels incl. address fields", () => {


### PR DESCRIPTION
## Summary

Follow-ups to the detail-page work: shorten the over-long right rail, remove a card-links-to-card smell, and let riders suggest weekly hours.

### Layout — rebalance the right rail (Option 2)
- Moved **Trail Conditions, Weather, and Camping** out of the sidebar into a full-width **"More about this park"** band below the two-column grid, so glanceable info reads horizontally instead of stacking the rail too tall. Each card self-hides when it has no data, so the row collapses gracefully.
- **Contact / Directions stays as a primary box in the right rail** (per request); the rail is now hero → Contact → contribution card.

### Merge the "accuracy" card with the claim box
- `ParkClaimCTA` gains an `embedded` mode — renders without its own Card chrome, and its colored status states (you-manage / managed-by / rejected / submitted) become inset panels.
- It's now composed as a section **inside** the "Help keep this listing accurate" card rather than a separate box the card merely linked to via `#claim`. The old pointer link and anchor are removed.

### Weekly hours in "Suggest a correction"
- `hours` registered as a correctable field; the correction dialog renders the structured `WeeklyHoursEditor`, the route validates with `weeklyHoursSchema`, the admin review shows a readable schedule, and approve applies it to `Park.hours` through the existing pipeline.
- **Decoupled `hours` from `EXTRACTABLE_FIELDS`**: it is user-correctable and display-only, so it is deliberately kept out of AI research and completeness scoring (`correctableFieldType` special-cases it). This corrects a regression the full suite caught where hours would otherwise have been enrolled into the research pipeline.

## Testing
- Every change covered by tests, including `embedded` ParkClaimCTA states and the hours-decoupling invariants. Full suite **2462 passing** (2 skipped), `tsc --noEmit` clean, `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McL16nM82aQydjmDWW73zq)_