### PR TITLE
feat(nav): clearer navigation — Saved Routes, category split, mobile bottom tab bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,3 +173,12 @@
   --animate-collapse: collapse 200ms ease-out;
   --animate-expand: expand 200ms ease-out;
 }
+
+/* Clear the fixed mobile bottom tab bar (MobileTabBar). Below lg the bar is
+   ~56px tall plus the iOS home-indicator safe area; pad the page so trailing
+   content and the footer aren't hidden behind it. */
+@media (max-width: 1023px) {
+  body {
+    padding-bottom: calc(3.5rem + env(safe-area-inset-bottom));
+  }
+}

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -28,7 +28,7 @@ const EMAIL_LOGIN_ENABLED = false;
  * Auth.js "resend" provider, which sends the link through our shared sender
  * with a dev fallback that logs it).
  */
-export function LoginDialog() {
+export function LoginDialog({ trigger }: { trigger?: React.ReactNode } = {}) {
   const [email, setEmail] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [sent, setSent] = useState(false);
@@ -60,10 +60,17 @@ export function LoginDialog() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2" aria-label="Sign In">
-          <LogIn className="w-4 h-4" />
-          <span className="hidden sm:inline">Sign In</span>
-        </Button>
+        {trigger ?? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            aria-label="Sign In"
+          >
+            <LogIn className="w-4 h-4" />
+            <span className="hidden sm:inline">Sign In</span>
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent className="max-w-sm">
         <DialogHeader>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
 import {
   ArrowLeft,
   Building2,
@@ -18,8 +9,8 @@ import {
   Info,
   Mail,
   MessageSquare,
-  Menu,
   PlusCircle,
+  Route,
 } from "lucide-react";
 import Link from "next/link";
 import {
@@ -29,6 +20,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { UserMenu } from "./UserMenu";
+import { MobileTabBar } from "./MobileTabBar";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { LoginDialog } from "@/components/auth/LoginDialog";
 import { signOut } from "next-auth/react";
@@ -45,25 +37,13 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ user, showBackButton }: AppHeaderProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  // Close the mobile menu if the viewport grows to desktop, where its trigger
-  // is hidden and the links render inline.
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 1024px)");
-    const closeIfDesktop = () => {
-      if (mq.matches) setMenuOpen(false);
-    };
-    mq.addEventListener("change", closeIfDesktop);
-    return () => mq.removeEventListener("change", closeIfDesktop);
-  }, []);
-
   const handleSignOut = async () => {
     await signOut({ callbackUrl: "/" });
   };
 
   return (
-    <header className="bg-card/95 backdrop-blur-sm border-b border-border shadow-sm z-20">
+    <>
+      <header className="bg-card/95 backdrop-blur-sm border-b border-border shadow-sm z-20">
       <div className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-4 sm:px-6 py-3 flex items-center gap-2 sm:gap-3">
         {showBackButton && (
           <Button asChild variant="ghost" size="sm" className="mr-1 sm:mr-2">
@@ -82,8 +62,11 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
         <span className="ml-1 hidden sm:inline-flex items-center text-[10px] px-2 py-0.5 rounded-md bg-primary/15 text-primary border border-primary/25 font-bold uppercase tracking-wider">
           beta
         </span>
-        {/* Desktop nav — hidden on mobile, moved into the sheet below */}
+        {/* Desktop nav — hidden on mobile, moved into the sheet below.
+            Product destinations sit directly on the bar; the "More" menu holds
+            only company/marketing pages. */}
         <nav className="ml-auto hidden items-center gap-3 lg:flex">
+          {/* Product nav — always available */}
           <Button asChild variant="ghost" size="sm">
             <Link href="/reviews" className="flex items-center gap-2">
               <MessageSquare className="w-4 h-4" />
@@ -98,15 +81,26 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
             </Link>
           </Button>
 
+          {/* Personal nav — signed-in destinations */}
           {user && (
-            <Button asChild variant="ghost" size="sm">
-              <Link href="/profile" className="flex items-center gap-2">
-                <CircleUser className="w-4 h-4" />
-                My Profile
-              </Link>
-            </Button>
+            <>
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/routes" className="flex items-center gap-2">
+                  <Route className="w-4 h-4" />
+                  Saved Routes
+                </Link>
+              </Button>
+
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/profile" className="flex items-center gap-2">
+                  <CircleUser className="w-4 h-4" />
+                  My Profile
+                </Link>
+              </Button>
+            </>
           )}
 
+          {/* Company / marketing — overflow only */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="sm" className="gap-1">
@@ -137,91 +131,43 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
           </DropdownMenu>
         </nav>
 
-        {/* Right-side controls: theme + auth stay visible at every size. On
-            mobile the ml-auto lives here since the desktop nav is hidden. */}
+        {/* Right-side controls: theme stays visible at every size. On mobile
+            the ml-auto lives here since the desktop nav is hidden. */}
         <div className="ml-auto flex items-center gap-2 lg:ml-4">
-          <ThemeToggle />
-
-          {user ? (
-            <UserMenu user={user} onSignOut={handleSignOut} />
-          ) : (
-            <LoginDialog />
+          {/* Submit is an occasional action — a compact icon button on mobile
+              rather than a bottom-nav tab (signed-in only; the page is gated). */}
+          {user && (
+            <Button
+              asChild
+              variant="ghost"
+              size="icon-sm"
+              className="lg:hidden"
+            >
+              <Link href="/submit" aria-label="Submit a park">
+                <PlusCircle className="w-5 h-5" />
+              </Link>
+            </Button>
           )}
 
-          {/* Mobile menu — surfaces the nav links hidden above */}
-          <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
-            <SheetTrigger asChild className="lg:hidden">
-              <Button variant="ghost" size="icon-sm" aria-label="Open menu">
-                <Menu className="h-5 w-5" />
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="right" className="w-72">
-              <SheetHeader>
-                <SheetTitle>Menu</SheetTitle>
-              </SheetHeader>
-              <nav className="flex flex-col gap-1 px-2">
-                <SheetClose asChild>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/reviews" className="flex items-center gap-2">
-                      <MessageSquare className="w-4 h-4" />
-                      Park Reviews
-                    </Link>
-                  </Button>
-                </SheetClose>
+          <ThemeToggle />
 
-                <SheetClose asChild>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/submit" className="flex items-center gap-2">
-                      <PlusCircle className="w-4 h-4" />
-                      Submit Park
-                    </Link>
-                  </Button>
-                </SheetClose>
-
-                {user && (
-                  <SheetClose asChild>
-                    <Button asChild variant="ghost" className="justify-start">
-                      <Link href="/profile" className="flex items-center gap-2">
-                        <CircleUser className="w-4 h-4" />
-                        My Profile
-                      </Link>
-                    </Button>
-                  </SheetClose>
-                )}
-
-                <div className="my-1 border-t border-border" />
-
-                <SheetClose asChild>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/for-operators" className="flex items-center gap-2">
-                      <Building2 className="w-4 h-4" />
-                      For Operators
-                    </Link>
-                  </Button>
-                </SheetClose>
-
-                <SheetClose asChild>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/about" className="flex items-center gap-2">
-                      <Info className="w-4 h-4" />
-                      About
-                    </Link>
-                  </Button>
-                </SheetClose>
-
-                <SheetClose asChild>
-                  <Button asChild variant="ghost" className="justify-start">
-                    <Link href="/contact" className="flex items-center gap-2">
-                      <Mail className="w-4 h-4" />
-                      Contact
-                    </Link>
-                  </Button>
-                </SheetClose>
-              </nav>
-            </SheetContent>
-          </Sheet>
+          {/* Auth entry points move into the bottom tab bar on mobile (Account
+              sheet when signed in, Sign in tab when signed out), so both are
+              hidden below lg here. */}
+          {user ? (
+            <div className="hidden lg:block">
+              <UserMenu user={user} onSignOut={handleSignOut} />
+            </div>
+          ) : (
+            <div className="hidden lg:block">
+              <LoginDialog />
+            </div>
+          )}
         </div>
       </div>
-    </header>
+      </header>
+
+      <MobileTabBar user={user} onSignOut={handleSignOut} />
+    </>
   );
 }

--- a/src/components/layout/FooterRoutesLink.tsx
+++ b/src/components/layout/FooterRoutesLink.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import { SessionProvider, useSession } from "next-auth/react";
+
+/**
+ * Saved Routes is a signed-in-only destination — `/routes` redirects anonymous
+ * visitors straight to sign-in. Rendering it as a client island lets the footer
+ * stay a static server component (so the legal/marketing pages keep their static
+ * rendering) while still hiding the link from logged-out users.
+ */
+function FooterRoutesLinkInner() {
+  const { data: session } = useSession();
+
+  if (!session?.user) return null;
+
+  return (
+    <li>
+      <Link href="/routes" className="hover:text-foreground transition-colors">
+        Saved routes
+      </Link>
+    </li>
+  );
+}
+
+export function FooterRoutesLink() {
+  return (
+    <SessionProvider>
+      <FooterRoutesLinkInner />
+    </SessionProvider>
+  );
+}

--- a/src/components/layout/MobileTabBar.tsx
+++ b/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Building2,
+  CircleUser,
+  Info,
+  type LucideIcon,
+  LogOut,
+  LogIn,
+  Mail,
+  MapPin,
+  MessageSquare,
+  Route,
+  Settings,
+  User,
+} from "lucide-react";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { LoginDialog } from "@/components/auth/LoginDialog";
+import { cn } from "@/lib/utils";
+
+interface MobileTabBarProps {
+  user?: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    role?: string | null;
+  } | null;
+  onSignOut: () => void;
+}
+
+/**
+ * Mobile primary navigation. A fixed bottom tab bar that replaces the hamburger
+ * sheet below the `lg` breakpoint (where the desktop inline nav takes over).
+ *
+ * All tabs carry equal weight — they're the destinations users move between,
+ * so Submit (an occasional, sign-in-gated contribution action) is not a tab;
+ * it lives as a compact button in the header instead. Saved and Account are
+ * signed-in only; signed-out users get a Sign in CTA in that space, since it
+ * unlocks everything gated. Account opens a bottom sheet carrying the
+ * personal/account links that don't warrant their own tab.
+ */
+export function MobileTabBar({ user, onSignOut }: MobileTabBarProps) {
+  const pathname = usePathname();
+  const [accountOpen, setAccountOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
+
+  // Account has no route of its own — highlight it while on any of the
+  // destinations reachable from its sheet.
+  const accountActive = ["/profile", "/admin", "/operator"].some((p) =>
+    pathname.startsWith(p),
+  );
+
+  // Role gating copied from UserMenu so the sheet surfaces the same links.
+  const isAdmin = user?.role === "ADMIN" || user?.role === "SUPER_ADMIN";
+  const canViewAdmin = isAdmin || user?.role === "BETA_TESTER";
+  const showManageParks =
+    (canViewAdmin || user?.role === "OPERATOR") && user?.role !== "BETA_TESTER";
+
+  const columns = user ? 4 : 3;
+
+  return (
+    <>
+      <nav
+        aria-label="Primary"
+        className="lg:hidden fixed inset-x-0 bottom-0 z-40 border-t border-border bg-card/95 backdrop-blur-sm pb-[env(safe-area-inset-bottom)]"
+      >
+        <div
+          className="grid items-stretch"
+          style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        >
+          <TabLink
+            href="/"
+            label="Browse"
+            icon={MapPin}
+            active={isActive("/")}
+          />
+
+          <TabLink
+            href="/reviews"
+            label="Reviews"
+            icon={MessageSquare}
+            active={isActive("/reviews")}
+          />
+
+          {user ? (
+            <>
+              <TabLink
+                href="/routes"
+                label="Saved"
+                icon={Route}
+                active={isActive("/routes")}
+              />
+
+              <button
+                type="button"
+                onClick={() => setAccountOpen(true)}
+                aria-label="Account menu"
+                aria-haspopup="dialog"
+                className={cn(
+                  "flex flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-medium transition-colors",
+                  accountActive
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <User className="h-5 w-5" />
+                <span>Account</span>
+              </button>
+            </>
+          ) : (
+            <LoginDialog
+              trigger={
+                <button
+                  type="button"
+                  aria-label="Sign in"
+                  className="flex flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-medium text-primary transition-colors"
+                >
+                  <LogIn className="h-5 w-5" />
+                  <span>Sign in</span>
+                </button>
+              }
+            />
+          )}
+        </div>
+      </nav>
+
+      {user && (
+        <Sheet open={accountOpen} onOpenChange={setAccountOpen}>
+          <SheetContent side="bottom" className="rounded-t-2xl">
+            <SheetHeader className="text-left">
+              <SheetTitle>{user.name || "Account"}</SheetTitle>
+              {user.email && (
+                <p className="text-xs text-muted-foreground">{user.email}</p>
+              )}
+            </SheetHeader>
+
+            <nav className="flex flex-col gap-1 px-2 pb-[env(safe-area-inset-bottom)]">
+              <SheetClose asChild>
+                <Button asChild variant="ghost" className="justify-start">
+                  <Link href="/profile" className="flex items-center gap-2">
+                    <CircleUser className="h-4 w-4" />
+                    My Profile
+                  </Link>
+                </Button>
+              </SheetClose>
+
+              {canViewAdmin && (
+                <SheetClose asChild>
+                  <Button asChild variant="ghost" className="justify-start">
+                    <Link href="/admin" className="flex items-center gap-2">
+                      <Settings className="h-4 w-4" />
+                      Admin Panel
+                    </Link>
+                  </Button>
+                </SheetClose>
+              )}
+
+              {showManageParks && (
+                <SheetClose asChild>
+                  <Button asChild variant="ghost" className="justify-start">
+                    <Link href="/operator" className="flex items-center gap-2">
+                      <Building2 className="h-4 w-4" />
+                      Manage Parks
+                    </Link>
+                  </Button>
+                </SheetClose>
+              )}
+
+              <div className="my-1 border-t border-border" />
+
+              <SheetClose asChild>
+                <Button asChild variant="ghost" className="justify-start">
+                  <Link href="/for-operators" className="flex items-center gap-2">
+                    <Building2 className="h-4 w-4" />
+                    For Operators
+                  </Link>
+                </Button>
+              </SheetClose>
+
+              <SheetClose asChild>
+                <Button asChild variant="ghost" className="justify-start">
+                  <Link href="/about" className="flex items-center gap-2">
+                    <Info className="h-4 w-4" />
+                    About
+                  </Link>
+                </Button>
+              </SheetClose>
+
+              <SheetClose asChild>
+                <Button asChild variant="ghost" className="justify-start">
+                  <Link href="/contact" className="flex items-center gap-2">
+                    <Mail className="h-4 w-4" />
+                    Contact
+                  </Link>
+                </Button>
+              </SheetClose>
+
+              <div className="my-1 border-t border-border" />
+
+              <Button
+                variant="ghost"
+                className="justify-start"
+                onClick={() => {
+                  setAccountOpen(false);
+                  onSignOut();
+                }}
+              >
+                <LogOut className="h-4 w-4" />
+                Sign Out
+              </Button>
+            </nav>
+          </SheetContent>
+        </Sheet>
+      )}
+    </>
+  );
+}
+
+function TabLink({
+  href,
+  label,
+  icon: Icon,
+  active,
+}: {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "flex flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-medium transition-colors",
+        active ? "text-primary" : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="h-5 w-5" />
+      <span>{label}</span>
+    </Link>
+  );
+}

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { WelcomeFooterLink } from "@/components/welcome/WelcomeFooterLink";
+import { FooterRoutesLink } from "./FooterRoutesLink";
 
 /**
  * Global site footer. Provides always-available links to the legal pages
@@ -15,7 +16,6 @@ const FOOTER_SECTIONS: {
     links: [
       { href: "/", label: "Browse parks" },
       { href: "/reviews", label: "Reviews" },
-      { href: "/routes", label: "Routes" },
       { href: "/submit", label: "Submit a park" },
     ],
   },
@@ -70,6 +70,7 @@ export function SiteFooter() {
                   </Link>
                 </li>
               ))}
+              {section.heading === "Explore" && <FooterRoutesLink />}
             </ul>
           </nav>
         ))}

--- a/test/app/operator/page.test.tsx
+++ b/test/app/operator/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+  usePathname: () => "/operator",
 }));
 
 vi.mock("next/link", () => ({

--- a/test/app/submit/page.test.tsx
+++ b/test/app/submit/page.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
+  usePathname: () => "/submit",
 }));
 
 vi.mock("@/app/submit/SubmitSignInGate", () => ({

--- a/test/components/layout/AppHeader.test.tsx
+++ b/test/components/layout/AppHeader.test.tsx
@@ -70,7 +70,10 @@ describe("AppHeader", () => {
   it("should show sign in button when user is not authenticated", () => {
     render(<AppHeader user={null} />);
 
-    expect(screen.getByText("Sign In")).toBeInTheDocument();
+    // Two responsive entry points render for signed-out users: the desktop
+    // header dialog and the mobile bottom-bar tab (each hidden at the other's
+    // breakpoint via CSS). Assert at least one is present.
+    expect(screen.getAllByText("Sign In").length).toBeGreaterThan(0);
   });
 
   it("should show UserMenu when user is authenticated", () => {


### PR DESCRIPTION
## What & why

Reworks primary navigation for clarity and discoverability. Nav options that were buried in dropdowns/footer are now visible, and mobile gets a proper bottom tab bar.

### Changes
- **Surface Saved Routes** — previously only reachable from the footer; now a navbar destination for signed-in users (desktop bar + mobile tab bar). The footer `Routes` link is gated too, since `/routes` redirects anonymous users to sign-in. A small client island (`FooterRoutesLink`) keeps `SiteFooter` a static server component (so the static legal/marketing pages stay static).
- **Split desktop nav categories** — product destinations sit directly on the bar; the "More" menu holds only company/marketing pages (For Operators, About, Contact).
- **Mobile bottom tab bar** (new `MobileTabBar`), replacing the hamburger sheet below `lg`:
  - Signed in: **Browse · Reviews · Saved · Account** (Account opens a bottom sheet with profile/admin/operator/company links + sign out).
  - Signed out: **Browse · Reviews · Sign in** (accent CTA that opens the existing Google sign-in dialog).
  - **Submit** is an occasional, sign-in-gated action, so it's a compact header button rather than a tab.
  - `body` gets bottom padding (+ `env(safe-area-inset-bottom)`) so content clears the fixed bar.
- **`LoginDialog`** accepts an optional custom `trigger` so the bottom-bar Sign in tab reuses the same branded dialog.

### Tests
- Added `usePathname` to `next/navigation` mocks in the submit/operator page tests (`MobileTabBar` consumes it via `AppHeader`).
- `AppHeader` sign-in test now asserts ≥1 sign-in trigger (desktop + mobile are both in the DOM at their respective breakpoints).
- Full suite: 2378 pass. (Pre-existing unrelated failure: `test/app/admin/dashboard` — `recharts` is in `package.json` but missing from the lockfile/`node_modules` in this env.)

### Verification
Signed-out mobile bar verified in-browser (light + dark): Browse · Reviews · Sign in, no Submit tab, Sign in opens the dialog, bar fixed to viewport bottom with content clearing it. Signed-in states (Saved/Account bar, header Submit button) were confirmed in code/type-check but not exercised live (this env's dev server lacks DB/auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)