### PR TITLE
fix(nav): stop signed-out navbar flash during client navigation

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { Home, RotateCw } from "lucide-react";
-import { AppHeader } from "@/components/layout/AppHeader";
+import { SessionAppHeader } from "@/components/layout/SessionAppHeader";
 import { BrokenTruck } from "@/components/BrokenTruck";
 import { Button } from "@/components/ui/button";
 
@@ -21,7 +21,7 @@ export default function Error({
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <AppHeader />
+      <SessionAppHeader />
       <main className="flex-1 flex items-center justify-center px-6 py-16">
         <div className="w-full max-w-md text-center flex flex-col items-center">
           <BrokenTruck className="w-64 sm:w-80 mb-8" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/globals.css";
 import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { AuthProvider } from "@/components/auth/AuthProvider";
 import { SignInPromptProvider } from "@/components/auth/SignInPromptProvider";
 import { WelcomeProvider } from "@/components/welcome/WelcomeProvider";
 import { CookieConsent } from "@/components/CookieConsent";
@@ -38,15 +39,17 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-background">
-        <ThemeProvider>
-          <WelcomeProvider>
-            <SignInPromptProvider>
-              {children}
-              <SiteFooter />
-              <CookieConsent />
-            </SignInPromptProvider>
-          </WelcomeProvider>
-        </ThemeProvider>
+        <AuthProvider>
+          <ThemeProvider>
+            <WelcomeProvider>
+              <SignInPromptProvider>
+                {children}
+                <SiteFooter />
+                <CookieConsent />
+              </SignInPromptProvider>
+            </WelcomeProvider>
+          </ThemeProvider>
+        </AuthProvider>
         <Analytics />
       </body>
     </html>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,10 +1,10 @@
-import { AppHeader } from "@/components/layout/AppHeader";
+import { SessionAppHeader } from "@/components/layout/SessionAppHeader";
 import { LoadingMessage } from "@/components/LoadingMessage";
 
 export default function Loading() {
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <AppHeader />
+      <SessionAppHeader />
       <main className="flex-1 flex items-center justify-center px-6 py-16">
         <LoadingMessage />
       </main>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { MapPinned } from "lucide-react";
-import { AppHeader } from "@/components/layout/AppHeader";
+import { SessionAppHeader } from "@/components/layout/SessionAppHeader";
 import { BrokenTruck } from "@/components/BrokenTruck";
 import { Button } from "@/components/ui/button";
 import type { Metadata } from "next";
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default function NotFound() {
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <AppHeader />
+      <SessionAppHeader />
       <main className="flex-1 flex items-center justify-center px-6 py-16">
         <div className="w-full max-w-md text-center flex flex-col items-center">
           <BrokenTruck className="w-64 sm:w-80 mb-8" />

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+/**
+ * App-wide client session context. Mounted once in the root layout so the
+ * signed-in state persists across client-side navigations — without it, the
+ * `loading.tsx` fallback (and error/not-found pages) render a header with no
+ * server `user` prop and briefly flash the signed-out navbar mid-navigation.
+ *
+ * Intentionally unseeded: not passing a server session keeps the root layout
+ * statically renderable (no `auth()` call), and the session is fetched once
+ * client-side then cached for the session's lifetime.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/components/layout/SessionAppHeader.tsx
+++ b/src/components/layout/SessionAppHeader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { AppHeader } from "./AppHeader";
+
+/**
+ * AppHeader for the auth-less fallbacks (loading.tsx / error.tsx /
+ * not-found.tsx) that have no server-fetched `user` to pass. It reads the
+ * cached client session instead, so the header keeps its signed-in state
+ * during navigation rather than flashing the signed-out navbar.
+ *
+ * Regular pages should keep passing the server `user` prop to AppHeader
+ * directly — that renders correctly on the first paint with no client fetch.
+ */
+export function SessionAppHeader({
+  showBackButton,
+}: {
+  showBackButton?: boolean;
+}) {
+  const { data: session } = useSession();
+  const user = session?.user
+    ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        role: session.user.role,
+      }
+    : null;
+
+  return <AppHeader user={user} showBackButton={showBackButton} />;
+}


### PR DESCRIPTION
## Problem
When signed in, navigating to a new page briefly flashed the **signed-out** navbar while the page loaded.

## Cause
The root `src/app/loading.tsx` — the Suspense fallback shown on every client-side navigation — rendered `<AppHeader />` with no server-fetched `user` prop, so mid-navigation the header fell back to its signed-out layout. `error.tsx` and `not-found.tsx` had the same gap. `loading.tsx` is a synchronous fallback, so it can't fetch the session itself.

## Fix
- Mount a global **`SessionProvider`** (`AuthProvider`) once in the root layout, so the signed-in state persists client-side across navigations.
- Give the three auth-less fallbacks a small **`SessionAppHeader`** that resolves the user from the cached client session (`useSession`) instead of a server prop.

The header now stays signed-in through navigation. Regular pages are unchanged — they keep passing the server `user` prop to `AppHeader`, so first paint is correct with no client fetch.

### Notes
- `AuthProvider` is intentionally **unseeded** (no `auth()` call) so the root layout stays statically renderable; the session is fetched once client-side then cached.
- `AppHeader` and its tests are untouched — only the three fallbacks and the layout change.

### Verification
`tsc` + lint clean; full suite 2413 pass (the only failures are pre-existing missing-dep suites — `leaflet.markercluster`, `recharts` — unrelated to this change). The signed-in flash can't be reproduced in the local worktree (no auth/DB env), so **best verified on this PR's Vercel preview**: sign in, then navigate between pages and confirm the navbar no longer flashes signed-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)