### PR TITLE
fix(nav): resolve header user on the server for /reviews and /profile

### DIFF
--- a/src/app/reviews/RecentReviews.tsx
+++ b/src/app/reviews/RecentReviews.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useRecentReviews } from "@/hooks/useReviews";
+import { ReviewList } from "@/components/reviews";
+import { AppHeader } from "@/components/layout/AppHeader";
+import { SlidersHorizontal, X } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { US_STATES } from "@/lib/constants";
+
+const VEHICLE_TYPE_OPTIONS = [
+  { value: "motorcycle", label: "Motorcycle" },
+  { value: "atv", label: "ATV" },
+  { value: "sxs", label: "SxS / UTV" },
+  { value: "fullSize", label: "Full Size 4x4" },
+];
+
+const RATING_OPTIONS = [
+  { value: "4", label: "4+ Stars" },
+  { value: "3", label: "3+ Stars" },
+  { value: "2", label: "2+ Stars" },
+];
+
+interface RecentReviewsProps {
+  /**
+   * Header user resolved on the server, so the navbar renders signed-in on the
+   * first paint — deriving it from useSession here flashed the signed-out
+   * navbar while the client session loaded.
+   */
+  user: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    role?: string | null;
+  } | null;
+}
+
+export function RecentReviews({ user }: RecentReviewsProps) {
+  const [showFilters, setShowFilters] = useState(false);
+  const { reviews, isLoading, pagination, setPage, filters, setFilters, clearFilters } =
+    useRecentReviews({ limit: 10 });
+
+  const hasActiveFilters = !!(filters.minRating || filters.vehicleType || filters.state);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="sticky top-0 z-20">
+        <AppHeader user={user} showBackButton />
+      </div>
+
+      <main className="max-w-4xl mx-auto px-6 py-8">
+        <div className="flex items-center justify-between mb-2">
+          <h1 className="text-3xl font-bold">Recent Reviews</h1>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowFilters((v) => !v)}
+            className="flex items-center gap-2"
+          >
+            <SlidersHorizontal className="w-4 h-4" />
+            Filters
+            {hasActiveFilters && (
+              <span className="ml-1 w-2 h-2 rounded-full bg-primary inline-block" />
+            )}
+          </Button>
+        </div>
+        <p className="text-muted-foreground mb-6">
+          See what riders are saying about parks across the country
+        </p>
+
+        {/* Filter panel */}
+        {showFilters && (
+          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Filter Reviews</span>
+              {hasActiveFilters && (
+                <button
+                  onClick={clearFilters}
+                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                >
+                  <X className="w-3 h-3" />
+                  Clear all
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              {/* Min rating */}
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Minimum Rating
+                </label>
+                <select
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  value={filters.minRating ?? ""}
+                  onChange={(e) =>
+                    setFilters({ ...filters, minRating: e.target.value || undefined })
+                  }
+                >
+                  <option value="">Any rating</option>
+                  {RATING_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Vehicle type */}
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  Vehicle Type
+                </label>
+                <select
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  value={filters.vehicleType ?? ""}
+                  onChange={(e) =>
+                    setFilters({ ...filters, vehicleType: e.target.value || undefined })
+                  }
+                >
+                  <option value="">All vehicles</option>
+                  {VEHICLE_TYPE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* State */}
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">
+                  State
+                </label>
+                <select
+                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
+                  value={filters.state ?? ""}
+                  onChange={(e) =>
+                    setFilters({ ...filters, state: e.target.value || undefined })
+                  }
+                >
+                  <option value="">All states</option>
+                  {US_STATES.map((state) => (
+                    <option key={state} value={state}>
+                      {state}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <ReviewList
+          reviews={reviews}
+          isLoading={isLoading}
+          pagination={pagination}
+          onPageChange={setPage}
+          showParkLink
+          emptyMessage={
+            hasActiveFilters
+              ? "No reviews match your filters. Try adjusting your criteria."
+              : "No reviews have been posted yet. Be the first to share your experience!"
+          }
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,32 +1,11 @@
-"use client";
+import { auth } from "@/lib/auth";
+import { RecentReviews } from "./RecentReviews";
 
-import { SessionProvider, useSession } from "next-auth/react";
-import { useRecentReviews } from "@/hooks/useReviews";
-import { ReviewList } from "@/components/reviews";
-import { AppHeader } from "@/components/layout/AppHeader";
-import { SlidersHorizontal, X } from "lucide-react";
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { US_STATES } from "@/lib/constants";
-
-const VEHICLE_TYPE_OPTIONS = [
-  { value: "motorcycle", label: "Motorcycle" },
-  { value: "atv", label: "ATV" },
-  { value: "sxs", label: "SxS / UTV" },
-  { value: "fullSize", label: "Full Size 4x4" },
-];
-
-const RATING_OPTIONS = [
-  { value: "4", label: "4+ Stars" },
-  { value: "3", label: "3+ Stars" },
-  { value: "2", label: "2+ Stars" },
-];
-
-function RecentReviewsContent() {
-  const { data: session } = useSession();
-  const [showFilters, setShowFilters] = useState(false);
-  const { reviews, isLoading, pagination, setPage, filters, setFilters, clearFilters } =
-    useRecentReviews({ limit: 10 });
+// Resolve the header user on the server so the navbar renders signed-in on the
+// first paint. As a fully client page it previously derived the user from
+// useSession, which flashed the signed-out navbar during navigation.
+export default async function RecentReviewsPage() {
+  const session = await auth();
 
   const user = session?.user
     ? {
@@ -37,137 +16,5 @@ function RecentReviewsContent() {
       }
     : null;
 
-  const hasActiveFilters = !!(filters.minRating || filters.vehicleType || filters.state);
-
-  return (
-    <div className="min-h-screen bg-background">
-      <div className="sticky top-0 z-20">
-        <AppHeader user={user} showBackButton />
-      </div>
-
-      <main className="max-w-4xl mx-auto px-6 py-8">
-        <div className="flex items-center justify-between mb-2">
-          <h1 className="text-3xl font-bold">Recent Reviews</h1>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowFilters((v) => !v)}
-            className="flex items-center gap-2"
-          >
-            <SlidersHorizontal className="w-4 h-4" />
-            Filters
-            {hasActiveFilters && (
-              <span className="ml-1 w-2 h-2 rounded-full bg-primary inline-block" />
-            )}
-          </Button>
-        </div>
-        <p className="text-muted-foreground mb-6">
-          See what riders are saying about parks across the country
-        </p>
-
-        {/* Filter panel */}
-        {showFilters && (
-          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-4">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">Filter Reviews</span>
-              {hasActiveFilters && (
-                <button
-                  onClick={clearFilters}
-                  className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  <X className="w-3 h-3" />
-                  Clear all
-                </button>
-              )}
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-              {/* Min rating */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">
-                  Minimum Rating
-                </label>
-                <select
-                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                  value={filters.minRating ?? ""}
-                  onChange={(e) =>
-                    setFilters({ ...filters, minRating: e.target.value || undefined })
-                  }
-                >
-                  <option value="">Any rating</option>
-                  {RATING_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Vehicle type */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">
-                  Vehicle Type
-                </label>
-                <select
-                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                  value={filters.vehicleType ?? ""}
-                  onChange={(e) =>
-                    setFilters({ ...filters, vehicleType: e.target.value || undefined })
-                  }
-                >
-                  <option value="">All vehicles</option>
-                  {VEHICLE_TYPE_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              {/* State */}
-              <div>
-                <label className="text-xs text-muted-foreground block mb-1">
-                  State
-                </label>
-                <select
-                  className="w-full text-sm border border-border rounded-md px-3 py-2 bg-background"
-                  value={filters.state ?? ""}
-                  onChange={(e) =>
-                    setFilters({ ...filters, state: e.target.value || undefined })
-                  }
-                >
-                  <option value="">All states</option>
-                  {US_STATES.map((state) => (
-                    <option key={state} value={state}>
-                      {state}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <ReviewList
-          reviews={reviews}
-          isLoading={isLoading}
-          pagination={pagination}
-          onPageChange={setPage}
-          showParkLink
-          emptyMessage={
-            hasActiveFilters
-              ? "No reviews match your filters. Try adjusting your criteria."
-              : "No reviews have been posted yet. Be the first to share your experience!"
-          }
-        />
-      </main>
-    </div>
-  );
-}
-
-export default function RecentReviewsPage() {
-  return (
-    <SessionProvider>
-      <RecentReviewsContent />
-    </SessionProvider>
-  );
+  return <RecentReviews user={user} />;
 }

--- a/src/components/profile/UserProfileClient.tsx
+++ b/src/components/profile/UserProfileClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SessionProvider, useSession } from "next-auth/react";
+import { SessionProvider } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import type { Park, Review } from "@/lib/types";
 import { ParkCard } from "@/components/parks/ParkCard";
@@ -18,22 +18,13 @@ interface UserProfileClientProps {
     name?: string | null;
     email?: string | null;
     image?: string | null;
+    role?: string | null;
   };
 }
 
 function UserProfileInner({ parks, reviews, user }: UserProfileClientProps) {
   const router = useRouter();
-  const { data: session } = useSession();
   const { toggleFavorite, isFavorite } = useFavorites();
-
-  const headerUser = session?.user
-    ? {
-        name: session.user.name,
-        email: session.user.email,
-        image: session.user.image,
-        role: session.user.role,
-      }
-    : null;
 
   const handleToggleFavorite = async (parkId: string) => {
     await toggleFavorite(parkId);
@@ -57,7 +48,7 @@ function UserProfileInner({ parks, reviews, user }: UserProfileClientProps) {
   return (
     <div className="min-h-screen bg-background">
       <div className="sticky top-0 z-20">
-        <AppHeader user={headerUser} showBackButton />
+        <AppHeader user={user} showBackButton />
       </div>
 
       <main className="max-w-7xl mx-auto px-6 py-8">


### PR DESCRIPTION
## Problem
After #204, the navbar no longer flashed signed-out during navigation — **except** when navigating to `/reviews` or `/profile`, which still flashed.

## Why only those two
Pages that don't flash reach `AppHeader` through a **server component that suspends** on data fetching, so the root `loading.tsx` fallback (session-aware since #204) covers the transition. `/reviews` and `/profile` instead rendered the header from a client `useSession()` — `null` on the first paint — so the signed-out navbar showed for a beat:

- **`/reviews`** was a fully `"use client"` page. No server work → no suspense → no `loading.tsx` to mask the client `useSession` null-frame.
- **`/profile`** already received the real `user` from its server page but **ignored it**, deriving the header from `useSession` instead.

## Fix
Resolve the header user on the **server** so the navbar is signed-in on the first paint:

- **`/reviews`**: split into a server `page.tsx` (calls `auth()`, passes `user`) + a new client `RecentReviews` component. The header no longer depends on `useSession`.
- **`/profile`**: use the `user` prop the server already passes (widened to include `role`) for the header, and drop the `useSession` call. `useFavorites`' own `useSession` is covered by the global `AuthProvider` from #204.

## Verification
`tsc` + lint clean on changed files; profile/reviews tests pass (45); full suite 2413 pass (only pre-existing missing-dep suites fail — `leaflet.markercluster`, `recharts` — unrelated). The signed-in behavior can't be reproduced in the local worktree (no auth/DB env), so **please confirm on this PR's Vercel preview**: signed in, navigate into Park Reviews and My Profile and confirm the navbar stays signed-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)