### PR TITLE
Move weather + trail conditions to top of the Overview column

### DIFF
--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -354,9 +354,21 @@ function ParkDetailPageInner({
 
               {/* Overview Tab */}
               <TabsContent value="overview" className="space-y-6">
+                {/* Live, glanceable info kept above the fold at the top of the
+                    main column — weather + latest trail conditions, side by
+                    side. Each self-hides when it has no data (WeatherCard for
+                    parks without coords / NWS coverage). */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+                  <WeatherCard
+                    current={weatherCurrent ?? null}
+                    forecast={weatherForecast ?? []}
+                  />
+                  <TrailConditionsDisplay parkSlug={park.id} />
+                </div>
                 <ParkOverviewCard park={park} />
                 <ParkAttributesCards park={park} />
                 <ParkOperationalCard park={park} />
+                <CampingInfoCard park={park} />
               </TabsContent>
 
               {/* Photos Tab */}
@@ -641,21 +653,6 @@ function ParkDetailPageInner({
               />
             </div>
           </div>
-        </div>
-
-        {/* "More about this park" — full-width band below the two-column grid.
-            Glanceable info (trail conditions, weather, camping) reads across
-            the page instead of stacking the right rail too tall. Each card
-            self-hides when it has no data, so the row collapses gracefully. */}
-        <div className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6 items-start">
-          <TrailConditionsDisplay parkSlug={park.id} />
-          {/* OP-53: NWS forecast + current. Renders nothing when both are
-              empty (parks without coords or outside NWS coverage). */}
-          <WeatherCard
-            current={weatherCurrent ?? null}
-            forecast={weatherForecast ?? []}
-          />
-          <CampingInfoCard park={park} />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary

Fixes the layout regression from #202: the "More about this park" band sat **below** the two-column grid, so it only started after the taller column. On a data-light park (short main column, tall right rail) the band dropped to the bottom of the rail — leaving a big empty gap in the main column and pushing **Weather below the fold**.

**Option A:** put **Weather + Trail Conditions** as a 2-up row at the **top of the Overview tab's main column** (visible without scrolling), move **Camping** into that column too, and remove the below-grid band. The right rail keeps hero → Contact → the contribution card.

- Fixes both problems: Weather is above the fold, and the live cards fill the otherwise-sparse main column so there's no gap.
- Trade-off (accepted): Weather / Trail Conditions render on the Overview tab only — the default, decision-making tab.

## Testing
- Full suite **2472 passing** (2 skipped), `tsc --noEmit` clean, `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McL16nM82aQydjmDWW73zq)_