### PR TITLE
fix(nav): server-resolve header user on home + park detail (flash + sign-in staleness)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import UtvParksApp from "@/components/ui/OffroadParksApp";
+import { auth } from "@/lib/auth";
 import {
   parseParkFilterParams,
   searchParamsToURLSearchParams,
@@ -23,14 +24,28 @@ export default async function Page({ searchParams }: PageProps) {
   const resolved = (await searchParams) ?? {};
   const params = parseParkFilterParams(searchParamsToURLSearchParams(resolved));
 
-  const [initialPage, initialMarkers, facets] = await Promise.all([
+  const [session, initialPage, initialMarkers, facets] = await Promise.all([
+    auth(),
     getParkPage(params, 0),
     getParkMarkers(params),
     getParkFacets(),
   ]);
 
+  // Resolve the header user on the server so the navbar renders signed-in on
+  // the first paint. Deriving it from useSession in the client app flashed the
+  // signed-out navbar on navigation and left it stale right after sign-in.
+  const user = session?.user
+    ? {
+        name: session.user.name,
+        email: session.user.email,
+        image: session.user.image,
+        role: session.user.role,
+      }
+    : null;
+
   return (
     <UtvParksApp
+      user={user}
       initialData={initialPage}
       initialMarkers={initialMarkers}
       facets={facets}

--- a/src/app/parks/[id]/page.tsx
+++ b/src/app/parks/[id]/page.tsx
@@ -319,6 +319,16 @@ export default async function ParkPage({ params }: ParkPageProps) {
     <ParkDetailPage
       park={park}
       photos={photos}
+      user={
+        session?.user
+          ? {
+              name: session.user.name,
+              email: session.user.email,
+              image: session.user.image,
+              role: session.user.role,
+            }
+          : null
+      }
       currentUserId={session?.user?.id}
       isAdmin={isAdmin}
       parkDbId={dbPark.id}

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -47,12 +47,24 @@ interface OffroadParksAppProps {
   initialMarkers: Park[];
   /** Static filter facets (states + slider bounds) over all approved parks. */
   facets: ParkFacets;
+  /**
+   * Header user resolved on the server, so the navbar renders signed-in on the
+   * first paint. Deriving it from useSession here flashed the signed-out navbar
+   * on navigation and after sign-in.
+   */
+  user: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    role?: string | null;
+  } | null;
 }
 
 function OffroadParksAppInner({
   initialData,
   initialMarkers,
   facets,
+  user,
 }: OffroadParksAppProps) {
   const { data: session } = useSession();
   const searchParams = useSearchParams();
@@ -322,14 +334,8 @@ function OffroadParksAppInner({
     })();
   }, [routeIdParam, loadRouteById]);
 
-  const user = session?.user
-    ? {
-        name: session.user.name,
-        email: session.user.email,
-        image: session.user.image,
-        role: session.user.role,
-      }
-    : null;
+  // `user` (header identity) comes from the server prop above; `session` is
+  // still used for client-reactive, non-header bits below.
 
   // Mobile filters live in a slide-in sheet; on desktop the sidebar is inline.
   // Close the sheet if the viewport grows to desktop so it can't linger open

--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -62,6 +62,18 @@ interface Photo {
 interface ParkDetailPageProps {
   park: Park;
   photos: Photo[];
+  /**
+   * Header user resolved on the server, so the navbar renders signed-in on the
+   * first paint. Deriving it from useSession here flashed the signed-out navbar
+   * on navigation and after sign-in. Optional only so tests can omit it; the
+   * real page always passes it.
+   */
+  user?: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+    role?: string | null;
+  } | null;
   currentUserId?: string;
   isAdmin?: boolean;
   /** DB id of the park — used to build the admin edit link. */
@@ -81,6 +93,7 @@ interface ParkDetailPageProps {
 function ParkDetailPageInner({
   park,
   photos,
+  user,
   currentUserId,
   isAdmin,
   parkDbId,
@@ -152,14 +165,8 @@ function ParkDetailPageInner({
   const activeTrailOverlay =
     dbTrailGeometry ?? (overlayUrl ? fetchedOverlay : null);
 
-  const user = session?.user
-    ? {
-        name: session.user.name,
-        email: session.user.email,
-        image: session.user.image,
-        role: session.user.role,
-      }
-    : null;
+  // `user` (header identity) comes from the server prop above; `session` is
+  // still used for the client-reactive, non-header review UI below.
 
   // Review hooks
   const { reviews, pagination, isLoading: reviewsLoading, setPage, refresh: refreshReviews } = useReviews({ parkSlug: park.id });

--- a/test/app/page.test.tsx
+++ b/test/app/page.test.tsx
@@ -12,6 +12,12 @@ vi.mock("@/lib/park-query", () => ({
   getParkFacets: vi.fn(),
 }));
 
+// The page now resolves the header user server-side via auth(); stub it so the
+// test doesn't pull in next-auth (which fails to resolve next/server here).
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(() => Promise.resolve(null)),
+}));
+
 // Mock the main app component so we can assert the props the page passes.
 vi.mock("@/components/ui/OffroadParksApp", () => ({
   default: ({ initialData, initialMarkers, facets }: any) => (


### PR DESCRIPTION
## Problems
1. **Navbar still flashed signed-out** when navigating to home ("Back to parks") and to park detail pages.
2. **Sign-in looked stale**: after signing into an already-authorized Google account (instant, no account picker), the navbar flashed and showed "Sign in" again — until you navigated or refreshed.

## One root cause
Both are the same issue #205 fixed for `/reviews` and `/profile`: these pages derived the header `user` from client `useSession()` (`null` on the first paint) instead of the server.

- **Home** (`OffroadParksApp`) rendered `AppHeader` from `useSession`, and its `page.tsx` never called `auth()`. So "Back to parks" flashed, and — because the server render of `/` carried no user — after the Google redirect landed on `/`, the header stayed signed-out until a later navigation/refresh forced a fresh session read.
- **Park detail** (`ParkDetailPage`) had the session on its server page but ignored it, using `useSession` for the header.

## Fix
Resolve the header user on the **server** and pass it as a prop, so the navbar is correct on the first paint (and correct immediately after the sign-in redirect lands on `/`):

- `app/page.tsx` → `auth()` → `user` → `OffroadParksApp`; header uses the prop.
- `app/parks/[id]/page.tsx` already had the session → now passes a `user` prop `ParkDetailPage` uses for the header.

`useSession` stays on both pages for the non-header, client-reactive UI (review controls, etc.).

## Audit
Checked **every** `AppHeader` call site. All now receive a server-resolved user, except `SessionAppHeader` — the intentional loading/error/not-found fallback that reads the cached session from #204. `PublicSharedRoute` already passed a server user, so no change needed.

## Verification
`tsc`/lint clean on changed files; affected tests pass; full suite 2409 pass (only the pre-existing `leaflet.markercluster` / `recharts` missing-dep suites fail — unrelated). The signed-in behavior can't be reproduced in the local worktree (no auth/DB env), so **please confirm on this PR's Vercel preview**: signed in, use "Back to parks" and open a park page (no flash); and sign in with an already-authorized Google account (navbar shows signed-in immediately, no refresh needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)