### PR TITLE
Compact spec chips + a prominent trail-status bar

### DIFF
--- a/src/features/parks/detail/ParkDetailPage.tsx
+++ b/src/features/parks/detail/ParkDetailPage.tsx
@@ -29,6 +29,7 @@ import type {
 } from "@/lib/weather/types";
 import { ReviewList, ReviewForm, StarRating, DifficultyRating } from "@/components/reviews";
 import { TrailConditionsDisplay } from "@/features/trail-conditions/TrailConditionsDisplay";
+import { TrailStatusBar } from "@/features/trail-conditions/TrailStatusBar";
 import { useReviews } from "@/hooks/useReviews";
 import { useParkReview } from "@/hooks/useParkReview";
 import { AppHeader } from "@/components/layout/AppHeader";
@@ -373,6 +374,9 @@ function ParkDetailPageInner({
                   (weather, trail conditions, contact, claim) lives in the
                   sidebar rail. */}
               <TabsContent value="overview" className="space-y-6">
+                {/* Prominent, color-coded trail status. Links to the full
+                    report list + form in the rail (#trail-conditions). */}
+                <TrailStatusBar parkSlug={park.id} />
                 <ParkOverviewCard park={park} />
                 <ParkAttributesCards park={park} />
                 <ParkOperationalCard park={park} />
@@ -653,7 +657,9 @@ function ParkDetailPageInner({
               <ParkContactSidebar park={park} />
               {/* Trail conditions: compact, community-reported, usually empty —
                   fine low in the rail rather than taking prime content space. */}
-              <TrailConditionsDisplay parkSlug={park.id} />
+              <div id="trail-conditions" className="scroll-mt-24">
+                <TrailConditionsDisplay parkSlug={park.id} />
+              </div>
               {/* Operator claim flow as its own slim card. */}
               <ParkClaimCTA
                 parkSlug={park.id}

--- a/src/features/parks/detail/components/ParkAttributesCards.tsx
+++ b/src/features/parks/detail/components/ParkAttributesCards.tsx
@@ -1,78 +1,174 @@
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { formatAmenity, formatTerrain } from "@/lib/formatting";
-import type { Amenity, Park, Terrain } from "@/lib/types";
+import type { Amenity, Park, Terrain, VehicleType } from "@/lib/types";
+import {
+  Anchor,
+  Baby,
+  Bike,
+  Car,
+  CarFront,
+  CircleCheck,
+  Droplets,
+  Fish,
+  Flag,
+  Flame,
+  Fuel,
+  Gauge,
+  GraduationCap,
+  Map,
+  Mountain,
+  MountainSnow,
+  Plus,
+  Route,
+  Ship,
+  ShoppingBag,
+  ShowerHead,
+  Store,
+  Toilet,
+  Truck,
+  Umbrella,
+  Utensils,
+  Waves,
+  Wifi,
+  Wrench,
+} from "lucide-react";
+
+type IconComponent = React.ComponentType<{ className?: string }>;
+
+const TERRAIN_ICONS: Record<Terrain, IconComponent> = {
+  sand: Waves,
+  rocks: Mountain,
+  mud: Droplets,
+  trails: Route,
+  hills: MountainSnow,
+  motocrossTrack: Flag,
+};
+
+const VEHICLE_ICONS: Record<VehicleType, IconComponent> = {
+  motorcycle: Bike,
+  atv: Car,
+  sxs: CarFront,
+  fullSize: Truck,
+};
+
+const VEHICLE_LABELS: Record<VehicleType, string> = {
+  motorcycle: "Motorcycle",
+  atv: "ATV",
+  sxs: "SxS",
+  fullSize: "Full-Size",
+};
+
+const AMENITY_ICONS: Record<Amenity, IconComponent> = {
+  restrooms: Toilet,
+  showers: ShowerHead,
+  food: Utensils,
+  fuel: Fuel,
+  repair: Wrench,
+  boatRamp: Anchor,
+  loadingRamp: Ship,
+  picnicTable: CircleCheck,
+  shelter: Umbrella,
+  grill: Flame,
+  playground: Baby,
+  wifi: Wifi,
+  fishing: Fish,
+  airStation: Gauge,
+  trailMaps: Map,
+  rentals: ShoppingBag,
+  training: GraduationCap,
+  firstAid: Plus,
+  store: Store,
+};
 
 interface ParkAttributesCardsProps {
   park: Park;
 }
 
-export function ParkAttributesCards({ park }: ParkAttributesCardsProps) {
+function AttrChip({
+  icon: Icon,
+  label,
+}: {
+  icon: IconComponent;
+  label: string;
+}) {
   return (
-    <>
-      {/* Terrain Card — hidden when the park has no terrain data */}
-      {park.terrain.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Terrain Types</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {park.terrain.map((terrain) => (
-                <Badge
-                  key={terrain}
-                  variant="outline"
-                  className="text-sm"
-                >
-                  {formatTerrain(terrain as Terrain)}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2.5 py-1 text-xs font-medium">
+      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+      {label}
+    </span>
+  );
+}
 
-      {/* Amenities Card — hidden when the park has no amenities */}
-      {park.amenities.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Amenities</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {park.amenities.map((amenity) => (
-                <Badge key={amenity} className="text-sm">
-                  {formatAmenity(amenity as Amenity)}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+function AttrRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 sm:flex-row sm:items-baseline sm:gap-3">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground sm:w-20 sm:shrink-0 sm:pt-0.5">
+        {label}
+      </span>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  );
+}
 
-      {/* Vehicle Types Card */}
-      {park.vehicleTypes.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Allowed Vehicle Types</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {park.vehicleTypes.map((vehicleType) => (
-                <Badge key={vehicleType} variant="outline" className="text-sm">
-                  {vehicleType === "fullSize"
-                    ? "Full-Size"
-                    : vehicleType === "sxs"
-                      ? "SxS"
-                      : vehicleType === "atv"
-                        ? "ATV"
-                        : "Motorcycle"}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-    </>
+/**
+ * Compact "at a glance" strip for a park's terrain, allowed vehicles, and
+ * amenities. Replaces three full-width single-badge cards with one slim card of
+ * labeled icon-chip rows, reclaiming vertical space in the Overview column. Each
+ * row hides when empty; the whole card hides when the park has none of these.
+ */
+export function ParkAttributesCards({ park }: ParkAttributesCardsProps) {
+  const hasAny =
+    park.terrain.length > 0 ||
+    park.vehicleTypes.length > 0 ||
+    park.amenities.length > 0;
+
+  if (!hasAny) return null;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 py-4">
+        {park.terrain.length > 0 && (
+          <AttrRow label="Terrain">
+            {park.terrain.map((terrain) => (
+              <AttrChip
+                key={terrain}
+                icon={TERRAIN_ICONS[terrain as Terrain] ?? CircleCheck}
+                label={formatTerrain(terrain as Terrain)}
+              />
+            ))}
+          </AttrRow>
+        )}
+
+        {park.vehicleTypes.length > 0 && (
+          <AttrRow label="Vehicles">
+            {park.vehicleTypes.map((vehicleType) => (
+              <AttrChip
+                key={vehicleType}
+                icon={VEHICLE_ICONS[vehicleType as VehicleType] ?? CircleCheck}
+                label={VEHICLE_LABELS[vehicleType as VehicleType] ?? vehicleType}
+              />
+            ))}
+          </AttrRow>
+        )}
+
+        {park.amenities.length > 0 && (
+          <AttrRow label="Amenities">
+            {park.amenities.map((amenity) => (
+              <AttrChip
+                key={amenity}
+                icon={AMENITY_ICONS[amenity as Amenity] ?? CircleCheck}
+                label={formatAmenity(amenity as Amenity)}
+              />
+            ))}
+          </AttrRow>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/features/trail-conditions/TrailConditionsDisplay.tsx
+++ b/src/features/trail-conditions/TrailConditionsDisplay.tsx
@@ -10,6 +10,7 @@ import {
   formatConditionAge,
   isConditionFresh,
   isConditionPinned,
+  selectFeaturedCondition,
   CONDITION_LABELS,
 } from "@/lib/trail-conditions";
 import type { TrailConditionReport } from "@/lib/trail-conditions";
@@ -62,9 +63,7 @@ export function TrailConditionsDisplay({ parkSlug }: TrailConditionsDisplayProps
   const freshConditions = conditions.filter(
     (c) => isConditionFresh(c.createdAt) || isConditionPinned(c.pinnedUntil)
   );
-  const activePin = freshConditions.find((c) => isConditionPinned(c.pinnedUntil)) ?? null;
-  const recentOperatorPost = freshConditions.find((c) => c.isOperatorPost) ?? null;
-  const featured = activePin ?? recentOperatorPost ?? freshConditions[0] ?? null;
+  const featured = selectFeaturedCondition(conditions);
   const communityList = freshConditions.filter((c) => c.id !== featured?.id).slice(0, 4);
 
   const handleReportSuccess = () => {

--- a/src/features/trail-conditions/TrailStatusBar.tsx
+++ b/src/features/trail-conditions/TrailStatusBar.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  CONDITION_LABELS,
+  formatConditionAge,
+  isConditionPinned,
+  selectFeaturedCondition,
+} from "@/lib/trail-conditions";
+import type { TrailConditionReport } from "@/lib/trail-conditions";
+
+interface TrailStatusBarProps {
+  parkSlug: string;
+}
+
+/** Subtle border + tint + text per status color, for both themes. */
+const BAR_CLASS: Record<string, string> = {
+  green:
+    "border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-950/25 dark:text-green-300",
+  red: "border-red-200 bg-red-50 text-red-800 dark:border-red-900 dark:bg-red-950/25 dark:text-red-300",
+  yellow:
+    "border-yellow-200 bg-yellow-50 text-yellow-800 dark:border-yellow-900 dark:bg-yellow-950/25 dark:text-yellow-300",
+  amber:
+    "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-950/25 dark:text-amber-300",
+  blue: "border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-900 dark:bg-blue-950/25 dark:text-blue-300",
+  sky: "border-sky-200 bg-sky-50 text-sky-800 dark:border-sky-900 dark:bg-sky-950/25 dark:text-sky-300",
+};
+
+const DOT_CLASS: Record<string, string> = {
+  green: "bg-green-500",
+  red: "bg-red-500",
+  yellow: "bg-yellow-500",
+  amber: "bg-amber-500",
+  blue: "bg-blue-500",
+  sky: "bg-sky-500",
+};
+
+/**
+ * Compact, color-coded trail-status bar for the top of the park detail
+ * Overview. Summarizes the single featured condition (see
+ * `selectFeaturedCondition`) so a rider sees "is it rideable" without
+ * scrolling. Stays quiet (neutral) when there are no recent reports; the full
+ * report list + reporting form live in the rail's `TrailConditionsDisplay`
+ * (anchored at #trail-conditions). Fetches independently of the rail display —
+ * a second GET to the same cached endpoint.
+ */
+export function TrailStatusBar({ parkSlug }: TrailStatusBarProps) {
+  const [conditions, setConditions] = useState<TrailConditionReport[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/parks/${parkSlug}/conditions`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled && data) setConditions(data.conditions ?? []);
+      })
+      .catch(() => {
+        /* non-critical — leave empty */
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [parkSlug]);
+
+  // Avoid a layout flash before the first fetch resolves.
+  if (!loaded) return null;
+
+  const featured = selectFeaturedCondition(conditions);
+
+  if (!featured) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm text-muted-foreground">
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"
+          aria-hidden
+        />
+        <span>No recent trail condition reports.</span>
+        <Link
+          href="#trail-conditions"
+          className="ml-auto shrink-0 text-xs font-medium text-primary hover:underline"
+        >
+          Report condition
+        </Link>
+      </div>
+    );
+  }
+
+  const { label, color } = CONDITION_LABELS[featured.status];
+  const pinned = isConditionPinned(featured.pinnedUntil);
+  const who = featured.isOperatorPost
+    ? " by the operator"
+    : featured.user.name
+      ? ` by ${featured.user.name}`
+      : "";
+
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${BAR_CLASS[color] ?? "border-border bg-card"}`}
+    >
+      <span
+        className={`h-2 w-2 shrink-0 rounded-full ${DOT_CLASS[color] ?? "bg-muted-foreground"}`}
+        aria-hidden
+      />
+      <span className="font-semibold">Trail status: {label}</span>
+      <span className="hidden text-xs opacity-80 sm:inline">
+        · {pinned ? "posted" : "reported"} {formatConditionAge(featured.createdAt)}
+        {who}
+      </span>
+      {featured.note && (
+        <span className="min-w-0 flex-1 truncate text-xs italic opacity-90">
+          &ldquo;{featured.note}&rdquo;
+        </span>
+      )}
+      <Link
+        href="#trail-conditions"
+        className={`shrink-0 text-xs font-medium hover:underline ${featured.note ? "" : "ml-auto"}`}
+      >
+        Report condition
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/trail-conditions.ts
+++ b/src/lib/trail-conditions.ts
@@ -60,6 +60,24 @@ export function formatConditionAge(createdAt: string | Date): string {
   return `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
 }
 
+/**
+ * Pick the single most-relevant condition to feature (used by both the
+ * top-of-page status bar and the rail display): an active operator pin, else
+ * the most recent operator post, else the latest fresh report. Only fresh
+ * (< 72h) or actively-pinned reports are considered. Returns null when none
+ * qualify. Assumes `conditions` is newest-first (as the API returns them).
+ */
+export function selectFeaturedCondition(
+  conditions: TrailConditionReport[],
+): TrailConditionReport | null {
+  const fresh = conditions.filter(
+    (c) => isConditionFresh(c.createdAt) || isConditionPinned(c.pinnedUntil),
+  );
+  const activePin = fresh.find((c) => isConditionPinned(c.pinnedUntil)) ?? null;
+  const recentOperatorPost = fresh.find((c) => c.isOperatorPost) ?? null;
+  return activePin ?? recentOperatorPost ?? fresh[0] ?? null;
+}
+
 /** Display label and color variant per status */
 export const CONDITION_LABELS: Record<
   TrailConditionStatus,

--- a/test/features/parks/detail/ParkDetailPage.test.tsx
+++ b/test/features/parks/detail/ParkDetailPage.test.tsx
@@ -59,6 +59,10 @@ vi.mock("@/features/parks/detail/components/ParkAttributesCards", () => ({
   ),
 }));
 
+vi.mock("@/features/trail-conditions/TrailStatusBar", () => ({
+  TrailStatusBar: () => <div data-testid="trail-status-bar">Trail status</div>,
+}));
+
 vi.mock("@/features/parks/detail/components/ParkContactSidebar", () => ({
   ParkContactSidebar: () => (
     <div data-testid="park-contact-sidebar">Contact Info</div>
@@ -285,6 +289,12 @@ describe("ParkDetailPage", () => {
     render(<ParkDetailPage park={mockPark} photos={[]} />);
 
     expect(screen.getByTestId("park-attributes-cards")).toBeInTheDocument();
+  });
+
+  it("renders the trail status bar at the top of the overview", () => {
+    render(<ParkDetailPage park={mockPark} photos={[]} />);
+
+    expect(screen.getByTestId("trail-status-bar")).toBeInTheDocument();
   });
 
   it("should render park contact sidebar", () => {

--- a/test/features/parks/detail/components/ParkAttributesCards.test.tsx
+++ b/test/features/parks/detail/components/ParkAttributesCards.test.tsx
@@ -1,25 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { ParkAttributesCards } from "@/features/parks/detail/components/ParkAttributesCards";
 import type { Park } from "@/lib/types";
-import { vi } from "vitest";
 
-// Mock UI components
-vi.mock("@/components/ui/card", () => ({
-  Card: ({ children }: any) => <div data-testid="card">{children}</div>,
-  CardHeader: ({ children }: any) => <div>{children}</div>,
-  CardTitle: ({ children }: any) => <h3>{children}</h3>,
-  CardContent: ({ children }: any) => <div>{children}</div>,
-}));
-
-vi.mock("@/components/ui/badge", () => ({
-  Badge: ({ children, variant, className }: any) => (
-    <span data-variant={variant} className={className}>
-      {children}
-    </span>
-  ),
-}));
-
-describe("ParkAttributesCards", () => {
+describe("ParkAttributesCards (chip strip)", () => {
   const mockPark: Park = {
     id: "park-1",
     name: "Test Park",
@@ -28,17 +11,18 @@ describe("ParkAttributesCards", () => {
     terrain: ["sand", "rocks", "mud"],
     amenities: ["restrooms", "showers"],
     camping: [],
-    vehicleTypes: [],
+    vehicleTypes: ["motorcycle", "atv", "sxs", "fullSize"],
   };
 
-  it("should render all two cards", () => {
+  it("renders one labeled row per non-empty attribute group", () => {
     render(<ParkAttributesCards park={mockPark} />);
 
-    expect(screen.getByText("Terrain Types")).toBeInTheDocument();
+    expect(screen.getByText("Terrain")).toBeInTheDocument();
+    expect(screen.getByText("Vehicles")).toBeInTheDocument();
     expect(screen.getByText("Amenities")).toBeInTheDocument();
   });
 
-  it("should render terrain badges with formatted labels", () => {
+  it("renders terrain chips with formatted labels", () => {
     render(<ParkAttributesCards park={mockPark} />);
 
     expect(screen.getByText("Sand")).toBeInTheDocument();
@@ -46,98 +30,72 @@ describe("ParkAttributesCards", () => {
     expect(screen.getByText("Mud")).toBeInTheDocument();
   });
 
-  it("should render terrain badges with outline variant and no capitalize class", () => {
-    render(<ParkAttributesCards park={mockPark} />);
-
-    const sandBadge = screen.getByText("Sand");
-    expect(sandBadge).toHaveAttribute("data-variant", "outline");
-    expect(sandBadge).not.toHaveClass("capitalize");
-  });
-
-  it("should render amenity badges with formatted labels", () => {
+  it("renders amenity chips with formatted labels", () => {
     render(<ParkAttributesCards park={mockPark} />);
 
     expect(screen.getByText("Restrooms")).toBeInTheDocument();
     expect(screen.getByText("Showers")).toBeInTheDocument();
   });
 
-  it("should render amenity badges without capitalize class", () => {
+  it("renders vehicle-type chips with human labels", () => {
     render(<ParkAttributesCards park={mockPark} />);
 
-    const restroomsBadge = screen.getByText("Restrooms");
-    expect(restroomsBadge).not.toHaveClass("capitalize");
+    expect(screen.getByText("Motorcycle")).toBeInTheDocument();
+    expect(screen.getByText("ATV")).toBeInTheDocument();
+    expect(screen.getByText("SxS")).toBeInTheDocument();
+    expect(screen.getByText("Full-Size")).toBeInTheDocument();
   });
 
-  it("should format motocrossTrack terrain as 'Motocross Track'", () => {
-    const parkWithMotocross: Park = {
-      ...mockPark,
-      terrain: ["motocrossTrack"],
-      amenities: [],
-    };
-    render(<ParkAttributesCards park={parkWithMotocross} />);
+  it("formats motocrossTrack terrain as 'Motocross Track'", () => {
+    render(
+      <ParkAttributesCards
+        park={{ ...mockPark, terrain: ["motocrossTrack"], amenities: [], vehicleTypes: [] }}
+      />,
+    );
 
     expect(screen.getByText("Motocross Track")).toBeInTheDocument();
   });
 
-  it("should format picnicTable amenity as 'Picnic Table'", () => {
-    const parkWithPicnic: Park = {
-      ...mockPark,
-      terrain: [],
-      amenities: ["picnicTable"],
-    };
-    render(<ParkAttributesCards park={parkWithPicnic} />);
+  it("formats picnicTable amenity as 'Picnic Table'", () => {
+    render(
+      <ParkAttributesCards
+        park={{ ...mockPark, terrain: [], amenities: ["picnicTable"], vehicleTypes: [] }}
+      />,
+    );
 
     expect(screen.getByText("Picnic Table")).toBeInTheDocument();
   });
 
-  it("hides the Terrain card when terrain is empty", () => {
-    const parkNoTerrain = { ...mockPark, terrain: [] };
-    render(<ParkAttributesCards park={parkNoTerrain} />);
+  it("hides the Terrain row when terrain is empty", () => {
+    render(<ParkAttributesCards park={{ ...mockPark, terrain: [] }} />);
 
-    expect(screen.queryByText("Terrain Types")).not.toBeInTheDocument();
-    // Amenities still has data, so its card remains.
+    expect(screen.queryByText("Terrain")).not.toBeInTheDocument();
     expect(screen.getByText("Amenities")).toBeInTheDocument();
   });
 
-  it("hides the Amenities card when amenities is empty", () => {
-    const parkNoAmenities = { ...mockPark, amenities: [] };
-    render(<ParkAttributesCards park={parkNoAmenities} />);
+  it("hides the Amenities row when amenities is empty", () => {
+    render(<ParkAttributesCards park={{ ...mockPark, amenities: [] }} />);
 
     expect(screen.queryByText("Amenities")).not.toBeInTheDocument();
-    expect(screen.getByText("Terrain Types")).toBeInTheDocument();
+    expect(screen.getByText("Terrain")).toBeInTheDocument();
   });
 
   it("renders nothing when a park has no terrain, amenities, or vehicle types", () => {
-    const minimalPark: Park = {
-      id: "minimal",
-      name: "Minimal Park",
-      address: { state: "Texas" },
-      coords: { lat: 30, lng: -98 },
-      terrain: [],
-      amenities: [],
-      camping: [],
-      vehicleTypes: [],
-    };
+    const { container } = render(
+      <ParkAttributesCards
+        park={{
+          id: "minimal",
+          name: "Minimal Park",
+          address: { state: "Texas" },
+          coords: { lat: 30, lng: -98 },
+          terrain: [],
+          amenities: [],
+          camping: [],
+          vehicleTypes: [],
+        }}
+      />,
+    );
 
-    const { container } = render(<ParkAttributesCards park={minimalPark} />);
-
-    expect(screen.queryByText("Terrain Types")).not.toBeInTheDocument();
-    expect(screen.queryByText("Amenities")).not.toBeInTheDocument();
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it("should render single item in each category with formatted labels", () => {
-    const singleItemPark: Park = {
-      ...mockPark,
-      terrain: ["sand"],
-      amenities: ["restrooms"],
-      camping: [],
-      vehicleTypes: [],
-    };
-
-    render(<ParkAttributesCards park={singleItemPark} />);
-
-    expect(screen.getByText("Sand")).toBeInTheDocument();
-    expect(screen.getByText("Restrooms")).toBeInTheDocument();
   });
 });

--- a/test/features/trail-conditions/TrailStatusBar.test.tsx
+++ b/test/features/trail-conditions/TrailStatusBar.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { TrailStatusBar } from "@/features/trail-conditions/TrailStatusBar";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}));
+
+const freshDate = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+
+function mockConditions(conditions: unknown[]) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ conditions }),
+  }) as unknown as typeof fetch;
+}
+
+describe("TrailStatusBar", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows a neutral 'no reports' state with a Report link when there are none", async () => {
+    mockConditions([]);
+    render(<TrailStatusBar parkSlug="test-park" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no recent trail condition reports/i),
+      ).toBeInTheDocument(),
+    );
+    const link = screen.getByRole("link", { name: /report condition/i });
+    expect(link).toHaveAttribute("href", "#trail-conditions");
+  });
+
+  it("shows a color-coded status with reporter and note for the featured condition", async () => {
+    mockConditions([
+      {
+        id: "c1",
+        parkId: "p1",
+        userId: "u1",
+        status: "MUDDY",
+        note: "Back section is a swamp",
+        reportStatus: "PUBLISHED",
+        isOperatorPost: false,
+        pinnedUntil: null,
+        createdAt: freshDate,
+        user: { id: "u1", name: "Alice", image: null },
+      },
+    ]);
+    render(<TrailStatusBar parkSlug="test-park" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/trail status: muddy/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/by alice/i)).toBeInTheDocument();
+    expect(screen.getByText(/back section is a swamp/i)).toBeInTheDocument();
+  });
+
+  it("credits the operator for an operator post", async () => {
+    mockConditions([
+      {
+        id: "c2",
+        parkId: "p1",
+        userId: "op1",
+        status: "CLOSED",
+        note: null,
+        reportStatus: "PUBLISHED",
+        isOperatorPost: true,
+        pinnedUntil: null,
+        createdAt: freshDate,
+        user: { id: "op1", name: "Park Op", image: null },
+      },
+    ]);
+    render(<TrailStatusBar parkSlug="test-park" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/trail status: closed/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/by the operator/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing on a failed fetch (non-critical)", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("network")) as unknown as typeof fetch;
+    const { container } = render(<TrailStatusBar parkSlug="test-park" />);
+
+    // After the rejected fetch resolves, it falls back to the neutral state.
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no recent trail condition reports/i),
+      ).toBeInTheDocument(),
+    );
+    expect(container).not.toBeEmptyDOMElement();
+  });
+});

--- a/test/lib/trail-conditions.test.ts
+++ b/test/lib/trail-conditions.test.ts
@@ -2,9 +2,11 @@ import { vi } from "vitest";
 import {
   isConditionFresh,
   formatConditionAge,
+  selectFeaturedCondition,
   CONDITION_STALE_AFTER_MS,
   CONDITION_LABELS,
 } from "@/lib/trail-conditions";
+import type { TrailConditionReport } from "@/lib/trail-conditions";
 
 describe("isConditionFresh", () => {
   it("should return true for a condition reported just now", () => {
@@ -94,5 +96,61 @@ describe("CONDITION_LABELS", () => {
       expect(meta.label).toBeTruthy();
       expect(meta.color).toBeTruthy();
     }
+  });
+});
+
+describe("selectFeaturedCondition", () => {
+  const hoursAgo = (h: number) =>
+    new Date(Date.now() - h * 60 * 60 * 1000).toISOString();
+
+  const report = (
+    over: Partial<TrailConditionReport> & Pick<TrailConditionReport, "id">,
+  ): TrailConditionReport => ({
+    parkId: "p1",
+    userId: "u1",
+    status: "OPEN",
+    note: null,
+    reportStatus: "PUBLISHED",
+    isOperatorPost: false,
+    pinnedUntil: null,
+    createdAt: hoursAgo(1),
+    user: { id: "u1", name: "Rider", image: null },
+    ...over,
+  });
+
+  it("returns null for an empty list", () => {
+    expect(selectFeaturedCondition([])).toBeNull();
+  });
+
+  it("returns null when every report is stale and unpinned", () => {
+    const stale = report({ id: "old", createdAt: hoursAgo(100) });
+    expect(selectFeaturedCondition([stale])).toBeNull();
+  });
+
+  it("picks the latest fresh report when none is pinned or operator-posted", () => {
+    // API returns newest-first; the helper takes the first fresh one.
+    const newer = report({ id: "newer", createdAt: hoursAgo(1) });
+    const older = report({ id: "older", createdAt: hoursAgo(5) });
+    expect(selectFeaturedCondition([newer, older])?.id).toBe("newer");
+  });
+
+  it("prefers an actively-pinned report over a newer unpinned one", () => {
+    const newerUnpinned = report({ id: "newer", createdAt: hoursAgo(1) });
+    const pinned = report({
+      id: "pinned",
+      createdAt: hoursAgo(10),
+      pinnedUntil: hoursAgo(-24), // pin active until 24h from now
+    });
+    expect(selectFeaturedCondition([newerUnpinned, pinned])?.id).toBe("pinned");
+  });
+
+  it("prefers an operator post over a newer community report when nothing is pinned", () => {
+    const community = report({ id: "community", createdAt: hoursAgo(1) });
+    const operator = report({
+      id: "operator",
+      createdAt: hoursAgo(4),
+      isOperatorPost: true,
+    });
+    expect(selectFeaturedCondition([community, operator])?.id).toBe("operator");
   });
 });


### PR DESCRIPTION
## Summary

Reclaims the vertical space wasted by the Terrain / Vehicles / Amenities cards and uses it to give Trail Conditions real presence.

- **Spec chips.** Terrain, Allowed Vehicles, and Amenities collapse from three full-width single-badge cards into **one slim card of labeled icon-chip rows** (per-value Lucide icons). Each row hides when empty; the card hides when the park has none.
- **Trail-status bar.** A compact, **color-coded status bar at the top of the Overview** summarizes the single most relevant condition — active operator pin > latest operator post > latest fresh report — with reporter + age, and the note when present. It stays neutral ("No recent trail condition reports") when there's nothing fresh, so it earns attention only when there's news. It links to the full report list + reporting form, which stay in the rail (`#trail-conditions` anchor).
- **Shared logic.** The featured-condition selection is extracted to `selectFeaturedCondition` in `src/lib/trail-conditions.ts` and used by both the status bar and the rail display (removing duplicated logic).

## Notes
- The status bar fetches conditions independently of the rail display — a second GET to the same cached endpoint; both stay in sync via the shared selector.
- Icons are real Lucide glyphs per terrain/vehicle/amenity value, with a safe fallback.

## Testing
- New tests for `selectFeaturedCondition` and `TrailStatusBar`, rewritten `ParkAttributesCards` tests for the chip strip, and a status-bar assertion on the detail page. Full suite **2476 passing** (2 skipped), `tsc --noEmit` clean, `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01McL16nM82aQydjmDWW73zq)_