### PR TITLE
fix(route-planner): stop mobile route card overlapping the footer

### DIFF
--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -564,7 +564,7 @@ function OffroadParksAppInner({
                       onRemoveWaypoint={removeWaypoint}
                     />
                   </div>
-                  <div className="lg:col-span-1 lg:self-start">
+                  <div className="lg:col-span-1 self-start">
                     {session?.user && (
                       <MyRoutesOverlayPanel
                         onSelectRoute={setPreviewRoute}

--- a/src/features/route-planner/RouteList.tsx
+++ b/src/features/route-planner/RouteList.tsx
@@ -256,7 +256,7 @@ export function RouteList({
   const hasWaypoints = waypoints.length > 0;
 
   return (
-    <Card className="h-full">
+    <Card className="lg:h-full">
       {hasWaypoints ? (
         <RouteListHeader
           onClearRoute={handleClearRoute}

--- a/test/features/route-planner/RouteList.test.tsx
+++ b/test/features/route-planner/RouteList.test.tsx
@@ -272,7 +272,7 @@ describe("RouteList", () => {
 
   it("should render card container", () => {
     const { container } = render(<RouteList {...defaultProps} />);
-    const card = container.querySelector(".h-full");
+    const card = container.querySelector(".lg\\:h-full");
     expect(card).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Problem

On the mobile **map view**, the Route Planner card overlapped the site footer at the bottom of the page (see the reported screenshot — the empty card's bottom border sits on top of the "OFFROAD PARKS" footer heading).

## Root cause

In the map tab, the map and the route-planner column live in a `grid grid-cols-1 lg:grid-cols-3`. The route column was top-aligned only on desktop (`lg:self-start`), so on mobile it fell back to the grid's default `align-items: stretch`. The route card's unconditional `h-full` then resolved its height against the stretched row track, inflating the (otherwise short, empty-state) card until its bottom edge collided with the footer.

I reproduced this with the project's real compiled Tailwind CSS at a 390px viewport: the empty card rendered **278px** tall and overlapped the footer by **46px**.

## Fix

- `OffroadParksApp.tsx`: top-align the route column at every breakpoint — `lg:self-start` → `self-start`.
- `RouteList.tsx`: scope the card's full-height intent to desktop — `h-full` → `lg:h-full`.

Together these keep the card sized to its content on mobile so it sits cleanly above the footer. After the fix the same reproduction renders the card at content height (**168px**) with a **64px** gap to the footer — no overlap.

**Desktop is unchanged:** the column was already `lg:self-start`, so the card was content-height there before and after.

## Testing

- Reproduced before/after with the project's real Tailwind build at mobile width (measurements above).
- `RouteList` card-container test updated to match the new responsive class.
- Full suite green via the pre-commit hook: **2476 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKgxkWWr3Ze5vLkHAYfDo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKgxkWWr3Ze5vLkHAYfDo7)_