### PR TITLE
Add location autocomplete to the home search bar

### DIFF
--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -3,16 +3,29 @@ import { NextResponse } from "next/server";
 // Depends on the request query string, so it must never be statically cached.
 export const dynamic = "force-dynamic";
 
+interface MapboxFeature {
+  center?: [number, number];
+  place_name?: string;
+}
+
 /**
- * GET /api/geocode?q=…
+ * GET /api/geocode?q=…[&limit=N]
  *
  * Server-side forward geocoding via Mapbox. Lets the home page turn a typed
  * location ("Denver, CO", "90210") into coordinates that feed the existing
  * "distance-nearest" coords channel — without the client hitting Mapbox
  * directly.
  *
- * Returns `{ lat, lng, placeName }` on a hit, 404 when nothing matches, 400
- * for an empty query, and 500 when the token is missing / Mapbox errors.
+ * Two modes, keyed off `limit`:
+ *  - Default (single match): returns `{ lat, lng, placeName }` on a hit,
+ *    404 when nothing matches.
+ *  - Suggestions (`limit` > 1): returns `{ suggestions: [{ lat, lng,
+ *    placeName }, …] }` for as-you-type autocomplete. Degrades to an empty
+ *    list rather than erroring on an upstream miss, so the dropdown just
+ *    shows "no results".
+ *
+ * Both modes return 400 for an empty query and 500 when the token is missing
+ * / Mapbox throws.
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -20,6 +33,12 @@ export async function GET(request: Request) {
   if (!q) {
     return NextResponse.json({ error: "Missing query" }, { status: 400 });
   }
+
+  // `limit` > 1 switches into suggestions mode (an array of matches). Cap it so
+  // a caller can't ask Mapbox for an unbounded list.
+  const rawLimit = Number(searchParams.get("limit"));
+  const suggestMode = Number.isFinite(rawLimit) && rawLimit > 1;
+  const limit = suggestMode ? Math.min(Math.floor(rawLimit), 10) : 1;
 
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   if (!token) {
@@ -30,25 +49,38 @@ export async function GET(request: Request) {
   }
 
   const encoded = encodeURIComponent(q);
-  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encoded}.json?access_token=${token}&country=us&limit=1`;
+  const autocomplete = suggestMode ? "&autocomplete=true" : "";
+  const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encoded}.json?access_token=${token}&country=us&limit=${limit}${autocomplete}`;
 
   try {
     const res = await fetch(url);
     if (!res.ok) {
-      return NextResponse.json(
-        { error: "Location not found" },
-        { status: 404 },
-      );
+      // In suggestions mode an upstream miss is just "no matches yet" — degrade
+      // to an empty list so the dropdown stays quiet instead of erroring.
+      return suggestMode
+        ? NextResponse.json({ suggestions: [] })
+        : NextResponse.json({ error: "Location not found" }, { status: 404 });
     }
     const data = await res.json();
-    const feature = data?.features?.[0];
-    if (!feature || !Array.isArray(feature.center)) {
-      return NextResponse.json(
-        { error: "Location not found" },
-        { status: 404 },
-      );
+    const features: MapboxFeature[] = Array.isArray(data?.features)
+      ? data.features
+      : [];
+
+    if (suggestMode) {
+      const suggestions = features
+        .filter((f) => Array.isArray(f.center))
+        .map((f) => {
+          const [lng, lat] = f.center as [number, number];
+          return { lat, lng, placeName: f.place_name ?? q };
+        });
+      return NextResponse.json({ suggestions });
     }
-    const [lng, lat] = feature.center as [number, number];
+
+    const feature = features[0];
+    if (!feature || !Array.isArray(feature.center)) {
+      return NextResponse.json({ error: "Location not found" }, { status: 404 });
+    }
+    const [lng, lat] = feature.center;
     return NextResponse.json({
       lat,
       lng,

--- a/src/components/layout/SearchHeader.tsx
+++ b/src/components/layout/SearchHeader.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { Filter, Locate, LocateFixed, MapPin, Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Filter, Loader2, Locate, LocateFixed, MapPin, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import type { GeocodeResult } from "@/lib/geocode-client";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -25,8 +26,14 @@ interface SearchHeaderProps {
   locationLoading?: boolean;
   onUseMyLocation?: () => void;
   onClearLocation?: () => void;
-  /** Resolve a typed location (city/zip) to coords via /api/geocode. */
+  /** Resolve a typed location (city/zip) to coords via /api/geocode. Used as
+      the free-text fallback when the user submits without picking a suggestion. */
   onLocationSearch?: (query: string) => void;
+  /** Fetch as-you-type location suggestions for the autocomplete dropdown.
+      When omitted, the location input stays a plain submit-to-search box. */
+  onLocationSuggest?: (query: string) => Promise<GeocodeResult[]>;
+  /** User picked a suggestion — coords are already known, so no re-geocode. */
+  onLocationSelect?: (result: GeocodeResult) => void;
   /** Current distance cutoff in miles (undefined = no cutoff). */
   radiusMiles?: number;
   onRadiusChange?: (miles: number | undefined) => void;
@@ -44,22 +51,105 @@ export function SearchHeader({
   onUseMyLocation,
   onClearLocation,
   onLocationSearch,
+  onLocationSuggest,
+  onLocationSelect,
   radiusMiles,
   onRadiusChange,
   onOpenFilters,
 }: SearchHeaderProps) {
   const [locationQuery, setLocationQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<GeocodeResult[]>([]);
+  const [activeSuggestion, setActiveSuggestion] = useState(-1);
+  const [isSuggesting, setIsSuggesting] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const locationBoxRef = useRef<HTMLFormElement | null>(null);
 
   const handleSortChange = (value: string) => {
     onSortChange(value as SortOption);
   };
 
+  const clearSuggestions = () => {
+    setSuggestions([]);
+    setActiveSuggestion(-1);
+    setShowSuggestions(false);
+  };
+
+  // Debounced suggestion fetch — mirrors the map route planner's custom-stop
+  // search (350ms, min 2 chars). No-ops when no suggest handler is wired.
+  const handleLocationChange = (value: string) => {
+    setLocationQuery(value);
+    setActiveSuggestion(-1);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!onLocationSuggest || value.trim().length < 2) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      setIsSuggesting(false);
+      return;
+    }
+    setIsSuggesting(true);
+    setShowSuggestions(true);
+    debounceRef.current = setTimeout(async () => {
+      const results = await onLocationSuggest(value.trim());
+      setSuggestions(results);
+      setIsSuggesting(false);
+    }, 350);
+  };
+
+  const selectSuggestion = (result: GeocodeResult) => {
+    setLocationQuery(result.placeName);
+    clearSuggestions();
+    onLocationSelect?.(result);
+  };
+
   const handleLocationSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // Enter with a highlighted suggestion picks it; otherwise fall back to a
+    // free-text geocode of whatever was typed.
+    if (activeSuggestion >= 0 && suggestions[activeSuggestion]) {
+      selectSuggestion(suggestions[activeSuggestion]);
+      return;
+    }
     const q = locationQuery.trim();
     if (!q) return;
+    clearSuggestions();
     onLocationSearch?.(q);
   };
+
+  const handleLocationKeyDown = (e: React.KeyboardEvent) => {
+    if (!showSuggestions || suggestions.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveSuggestion((i) => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveSuggestion((i) => Math.max(i - 1, -1));
+    } else if (e.key === "Escape") {
+      clearSuggestions();
+    }
+  };
+
+  // Clear the pending debounce on unmount.
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  // Close the dropdown on an outside click.
+  useEffect(() => {
+    if (!showSuggestions) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        locationBoxRef.current &&
+        !locationBoxRef.current.contains(e.target as Node)
+      ) {
+        clearSuggestions();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showSuggestions]);
 
   const handleRadiusChange = (value: string) => {
     onRadiusChange?.(value === "__any" ? undefined : Number(value));
@@ -78,19 +168,68 @@ export function SearchHeader({
           />
         </div>
         <div className="flex items-center gap-2">
-          {/* Manual location entry — resolves a typed city/zip to coords. */}
+          {/* Manual location entry — as-you-type suggestions resolve to coords,
+              matching the map route planner's custom-stop search. */}
           <form
             onSubmit={handleLocationSubmit}
             className="relative hidden md:block"
+            ref={locationBoxRef}
           >
             <MapPin className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
             <Input
               placeholder="City or ZIP…"
               aria-label="Search by location"
               value={locationQuery}
-              onChange={(e) => setLocationQuery(e.target.value)}
+              onChange={(e) => handleLocationChange(e.target.value)}
+              onKeyDown={handleLocationKeyDown}
+              onFocus={() => {
+                if (suggestions.length > 0) setShowSuggestions(true);
+              }}
+              autoComplete="off"
+              role="combobox"
+              aria-expanded={showSuggestions && suggestions.length > 0}
+              aria-autocomplete="list"
               className="pl-8 h-9 w-32 lg:w-40"
             />
+            {isSuggesting && (
+              <Loader2 className="absolute right-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 animate-spin text-muted-foreground" />
+            )}
+            {showSuggestions && suggestions.length > 0 && (
+              <ul className="absolute z-50 left-0 mt-1 w-64 max-w-[calc(100vw-3rem)] bg-popover border border-border rounded-md shadow-md overflow-hidden text-sm">
+                {suggestions.map((s, i) => (
+                  <li key={`${s.lat}-${s.lng}`}>
+                    <button
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        selectSuggestion(s);
+                      }}
+                      className={`w-full text-left px-3 py-2 hover:bg-accent hover:text-accent-foreground transition ${
+                        activeSuggestion === i
+                          ? "bg-accent text-accent-foreground"
+                          : ""
+                      }`}
+                    >
+                      <span className="font-medium truncate block">
+                        {s.placeName.split(",")[0]}
+                      </span>
+                      <span className="text-xs text-muted-foreground truncate block">
+                        {s.placeName.split(",").slice(1).join(",").trim()}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {showSuggestions &&
+              !isSuggesting &&
+              onLocationSuggest &&
+              locationQuery.trim().length >= 2 &&
+              suggestions.length === 0 && (
+                <div className="absolute z-50 left-0 mt-1 w-64 max-w-[calc(100vw-3rem)] bg-popover border border-border rounded-md shadow-md px-3 py-2 text-xs text-muted-foreground">
+                  No results found
+                </div>
+              )}
           </form>
           {locationActive ? (
             <Button

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -11,7 +11,11 @@ import { useSearchPresets } from "@/hooks/useSearchPresets";
 import { useSignInPrompt } from "@/components/auth/SignInPromptProvider";
 import { useParkList, useParkMarkers } from "@/hooks/useServerParks";
 import { haversineDistance } from "@/lib/geo";
-import { geocodeQuery } from "@/lib/geocode-client";
+import {
+  geocodeQuery,
+  geocodeSuggestions,
+  type GeocodeResult,
+} from "@/lib/geocode-client";
 import {
   buildParkQueryString,
   parkFilterParamsToState,
@@ -251,17 +255,21 @@ function OffroadParksAppInner({
     );
   };
 
-  // Resolve a typed location via the /api/geocode route, then drive the exact
-  // same coords path "Near Me" uses (set coords + switch to distance sort).
+  // Drive the exact same coords path "Near Me" uses: set coords + switch to
+  // distance sort. Shared by the free-text search and suggestion-pick flows.
+  const applyLocationResult = (result: GeocodeResult) => {
+    setUserCoords({ lat: result.lat, lng: result.lng });
+    setSortOption("distance-nearest");
+  };
+
+  // Free-text fallback: resolve a typed location via the /api/geocode route
+  // when the user submits without picking an autocomplete suggestion.
   const handleLocationSearch = async (query: string) => {
     if (!query.trim()) return;
     setLocationLoading(true);
     const result = await geocodeQuery(query);
     setLocationLoading(false);
-    if (result) {
-      setUserCoords({ lat: result.lat, lng: result.lng });
-      setSortOption("distance-nearest");
-    }
+    if (result) applyLocationResult(result);
   };
 
   const handleClearLocation = () => {
@@ -444,6 +452,8 @@ function OffroadParksAppInner({
           onUseMyLocation={handleUseMyLocation}
           onClearLocation={handleClearLocation}
           onLocationSearch={handleLocationSearch}
+          onLocationSuggest={geocodeSuggestions}
+          onLocationSelect={applyLocationResult}
           radiusMiles={radiusMiles}
           onRadiusChange={setRadiusMiles}
           onOpenFilters={() => setFiltersOpen(true)}

--- a/src/lib/geocode-client.ts
+++ b/src/lib/geocode-client.ts
@@ -34,3 +34,39 @@ export async function geocodeQuery(
     return null;
   }
 }
+
+/**
+ * Fetch as-you-type location suggestions from the `/api/geocode` route in its
+ * suggestions mode. Returns an empty array for a too-short query, a miss, or
+ * any network/parse failure so the autocomplete dropdown degrades gracefully.
+ * Requires at least 2 characters to avoid noisy single-letter lookups.
+ */
+export async function geocodeSuggestions(
+  query: string,
+  limit = 5,
+): Promise<GeocodeResult[]> {
+  const q = query.trim();
+  if (q.length < 2) return [];
+
+  try {
+    const res = await fetch(
+      `/api/geocode?q=${encodeURIComponent(q)}&limit=${limit}`,
+    );
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data?.suggestions)) return [];
+    return data.suggestions
+      .filter(
+        (s: unknown) =>
+          typeof (s as GeocodeResult)?.lat === "number" &&
+          typeof (s as GeocodeResult)?.lng === "number",
+      )
+      .map((s: GeocodeResult) => ({
+        lat: s.lat,
+        lng: s.lng,
+        placeName: typeof s.placeName === "string" ? s.placeName : q,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/test/app/api/geocode/route.test.ts
+++ b/test/app/api/geocode/route.test.ts
@@ -80,4 +80,97 @@ describe("GET /api/geocode", () => {
     expect(res.status).toBe(500);
     expect(consoleSpy).toHaveBeenCalled();
   });
+
+  describe("suggestions mode (limit > 1)", () => {
+    it("returns an array of suggestions and asks Mapbox for autocomplete", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          features: [
+            { center: [-104.9903, 39.7392], place_name: "Denver, Colorado" },
+            { center: [-105.0, 40.0], place_name: "Denver Metro, Colorado" },
+          ],
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await GET(req("?q=Denver&limit=5"));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.suggestions).toEqual([
+        { lat: 39.7392, lng: -104.9903, placeName: "Denver, Colorado" },
+        { lat: 40.0, lng: -105.0, placeName: "Denver Metro, Colorado" },
+      ]);
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("limit=5");
+      expect(calledUrl).toContain("autocomplete=true");
+    });
+
+    it("caps the upstream limit at 10", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ features: [] }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await GET(req("?q=Denver&limit=50"));
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("limit=10");
+    });
+
+    it("degrades to an empty list on an upstream miss instead of 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+
+      const res = await GET(req("?q=nowhere&limit=5"));
+      const data = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(data.suggestions).toEqual([]);
+    });
+
+    it("skips features without coordinates", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            features: [
+              { center: [-104.9903, 39.7392], place_name: "Denver, Colorado" },
+              { place_name: "No coords" },
+            ],
+          }),
+        }),
+      );
+
+      const res = await GET(req("?q=Denver&limit=5"));
+      const data = await res.json();
+      expect(data.suggestions).toEqual([
+        { lat: 39.7392, lng: -104.9903, placeName: "Denver, Colorado" },
+      ]);
+    });
+
+    it("stays in single-result mode for limit=1", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            features: [
+              { center: [-104.9903, 39.7392], place_name: "Denver, Colorado" },
+            ],
+          }),
+        }),
+      );
+
+      const res = await GET(req("?q=Denver&limit=1"));
+      const data = await res.json();
+      expect(data).toEqual({
+        lat: 39.7392,
+        lng: -104.9903,
+        placeName: "Denver, Colorado",
+      });
+      expect(data.suggestions).toBeUndefined();
+    });
+  });
 });

--- a/test/components/layout/SearchHeader.test.tsx
+++ b/test/components/layout/SearchHeader.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SearchHeader } from "@/components/layout/SearchHeader";
 import { vi } from "vitest";
 
@@ -346,6 +346,92 @@ describe("SearchHeader", () => {
 
     const button = screen.getByTitle("Use my location");
     expect(button).toBeDisabled();
+  });
+
+  it("should show autocomplete suggestions as the user types", async () => {
+    const mockOnLocationSuggest = vi.fn().mockResolvedValue([
+      { lat: 39.7392, lng: -104.9903, placeName: "Denver, Colorado" },
+    ]);
+    render(
+      <SearchHeader
+        searchQuery=""
+        onSearchQueryChange={mockOnSearchQueryChange}
+        sortOption="name"
+        onSortChange={mockOnSortChange}
+        onLocationSuggest={mockOnLocationSuggest}
+      />,
+    );
+
+    const input = screen.getByLabelText("Search by location");
+    fireEvent.change(input, { target: { value: "Denv" } });
+
+    await waitFor(() =>
+      expect(mockOnLocationSuggest).toHaveBeenCalledWith("Denv"),
+    );
+    expect(await screen.findByText("Denver")).toBeInTheDocument();
+  });
+
+  it("should not fetch suggestions for queries shorter than 2 chars", () => {
+    const mockOnLocationSuggest = vi.fn().mockResolvedValue([]);
+    render(
+      <SearchHeader
+        searchQuery=""
+        onSearchQueryChange={mockOnSearchQueryChange}
+        sortOption="name"
+        onSortChange={mockOnSortChange}
+        onLocationSuggest={mockOnLocationSuggest}
+      />,
+    );
+
+    const input = screen.getByLabelText("Search by location");
+    fireEvent.change(input, { target: { value: "D" } });
+
+    expect(mockOnLocationSuggest).not.toHaveBeenCalled();
+  });
+
+  it("should call onLocationSelect (not onLocationSearch) when a suggestion is picked", async () => {
+    const result = { lat: 39.7392, lng: -104.9903, placeName: "Denver, Colorado" };
+    const mockOnLocationSuggest = vi.fn().mockResolvedValue([result]);
+    const mockOnLocationSelect = vi.fn();
+    const mockOnLocationSearch = vi.fn();
+    render(
+      <SearchHeader
+        searchQuery=""
+        onSearchQueryChange={mockOnSearchQueryChange}
+        sortOption="name"
+        onSortChange={mockOnSortChange}
+        onLocationSuggest={mockOnLocationSuggest}
+        onLocationSelect={mockOnLocationSelect}
+        onLocationSearch={mockOnLocationSearch}
+      />,
+    );
+
+    const input = screen.getByLabelText("Search by location");
+    fireEvent.change(input, { target: { value: "Denver" } });
+
+    const option = await screen.findByText("Denver");
+    fireEvent.mouseDown(option);
+
+    expect(mockOnLocationSelect).toHaveBeenCalledWith(result);
+    expect(mockOnLocationSearch).not.toHaveBeenCalled();
+  });
+
+  it("should show a no-results message when suggestions come back empty", async () => {
+    const mockOnLocationSuggest = vi.fn().mockResolvedValue([]);
+    render(
+      <SearchHeader
+        searchQuery=""
+        onSearchQueryChange={mockOnSearchQueryChange}
+        sortOption="name"
+        onSortChange={mockOnSortChange}
+        onLocationSuggest={mockOnLocationSuggest}
+      />,
+    );
+
+    const input = screen.getByLabelText("Search by location");
+    fireEvent.change(input, { target: { value: "zzzznowhere" } });
+
+    expect(await screen.findByText("No results found")).toBeInTheDocument();
   });
 
   it("should render filter icon", () => {

--- a/test/lib/geocode-client.test.ts
+++ b/test/lib/geocode-client.test.ts
@@ -1,4 +1,4 @@
-import { geocodeQuery } from "@/lib/geocode-client";
+import { geocodeQuery, geocodeSuggestions } from "@/lib/geocode-client";
 import { vi } from "vitest";
 
 describe("geocodeQuery (location-set flow)", () => {
@@ -51,5 +51,80 @@ describe("geocodeQuery (location-set flow)", () => {
   it("returns null when fetch rejects", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
     expect(await geocodeQuery("Denver")).toBeNull();
+  });
+});
+
+describe("geocodeSuggestions (autocomplete flow)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty array for a <2 char query without hitting the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await geocodeSuggestions("d")).toEqual([]);
+    expect(await geocodeSuggestions("  ")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("maps suggestions from the geocode route and requests a limit", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        suggestions: [
+          { lat: 39.7392, lng: -104.9903, placeName: "Denver, Colorado" },
+          { lat: 40.0, lng: -105.0, placeName: "Denver Metro, Colorado" },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const results = await geocodeSuggestions("  Denver  ");
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      lat: 39.7392,
+      lng: -104.9903,
+      placeName: "Denver, Colorado",
+    });
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toBe("/api/geocode?q=Denver&limit=5");
+  });
+
+  it("drops entries missing numeric coordinates", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          suggestions: [
+            { lat: 39.7, lng: -104.9, placeName: "Good" },
+            { placeName: "Bad — no coords" },
+          ],
+        }),
+      }),
+    );
+
+    const results = await geocodeSuggestions("Denver");
+    expect(results).toEqual([{ lat: 39.7, lng: -104.9, placeName: "Good" }]);
+  });
+
+  it("returns an empty array on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    expect(await geocodeSuggestions("Denver")).toEqual([]);
+  });
+
+  it("returns an empty array when the payload lacks a suggestions array", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+    expect(await geocodeSuggestions("Denver")).toEqual([]);
+  });
+
+  it("returns an empty array when fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    expect(await geocodeSuggestions("Denver")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The home page "City or ZIP" search box previously resolved a location only on **submit**, to a single best-guess match (Mapbox `limit=1`). This meant no feedback while typing and no way to disambiguate ("Portland, OR" vs "Portland, ME") before committing.

This brings it up to match the **map route planner's** custom-stop search: as-you-type suggestions in a dropdown, so the two location inputs in the app now behave consistently.

## What changed

- **`/api/geocode`** gains a suggestions mode: `limit>1` returns `{ suggestions: [{ lat, lng, placeName }, …] }` with Mapbox `autocomplete=true`. The existing single-result mode (`{ lat, lng, placeName }`) is unchanged for backward compatibility. Upstream misses degrade to an empty list rather than a 404, and the requested limit is capped at 10.
- **`geocodeSuggestions`** client helper in `geocode-client.ts` fetches suggestions **server-side** through `/api/geocode`, so the browser-exposed Mapbox token isn't a dependency and both entry points stay symmetric. Requires ≥2 chars; degrades to `[]` on any miss/error.
- **`SearchHeader`** renders the autocomplete dropdown — debounced 350ms fetch, keyboard nav (↑/↓/Enter/Esc), click-outside dismiss, loading spinner, and a "No results found" state, mirroring the route planner. Picking a suggestion applies its coords **directly** (no second geocode call); submitting free text keeps the previous geocode fallback.
- **`OffroadParksApp`** wires the new `onLocationSuggest`/`onLocationSelect` props, sharing the existing "set coords + switch to distance sort" path that "Near Me" already uses.

## UX notes

- Suggestion pick → coords applied with no re-geocode round trip.
- Enter with no highlighted suggestion → free-text geocode (unchanged behavior).
- When no `onLocationSuggest` handler is wired, the input silently falls back to the old plain submit-to-search box.

## Testing

- New tests for the API suggestions mode (array shape, autocomplete flag, limit cap, graceful degradation, single-result mode intact).
- New tests for `geocodeSuggestions` (min-length guard, mapping, coord filtering, error handling).
- New `SearchHeader` tests (suggestions render as you type, <2-char guard, suggestion-pick calls `onLocationSelect` not `onLocationSearch`, no-results state).
- Full suite green: 2491 passed / 2 skipped. `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5VP1RS3qtBjHvLHbPuz7A)_