### PR TITLE
feat(parks): recall filters + map/list view on "Back to parks"

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -13,6 +13,7 @@ import {
   Route,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,8 +38,27 @@ interface AppHeaderProps {
 }
 
 export function AppHeader({ user, showBackButton }: AppHeaderProps) {
+  const router = useRouter();
+
   const handleSignOut = async () => {
     await signOut({ callbackUrl: "/" });
+  };
+
+  // "Back to Parks" returns to the browse view the user last had open (filters
+  // + map/list mode), which OffroadParksApp stashes in sessionStorage. Read at
+  // click time (SSR-safe, always fresh); the href="/" stays as the fallback and
+  // for modified clicks (cmd/ctrl/middle → open the bare list in a new tab).
+  const handleBackToParks = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    try {
+      const stored = window.sessionStorage.getItem("parks:returnUrl");
+      if (stored && stored !== "/") {
+        e.preventDefault();
+        router.push(stored);
+      }
+    } catch {
+      /* sessionStorage unavailable — fall through to the default href="/" */
+    }
   };
 
   return (
@@ -47,7 +67,12 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
       <div className="max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px] mx-auto px-4 sm:px-6 py-3 flex items-center gap-2 sm:gap-3">
         {showBackButton && (
           <Button asChild variant="ghost" size="sm" className="mr-1 sm:mr-2">
-            <Link href="/" className="flex items-center gap-2" aria-label="Back to Parks">
+            <Link
+              href="/"
+              onClick={handleBackToParks}
+              className="flex items-center gap-2"
+              aria-label="Back to Parks"
+            >
               <ArrowLeft className="w-4 h-4" />
               <span className="hidden sm:inline">Back to Parks</span>
             </Link>

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -218,6 +218,21 @@ function OffroadParksAppInner({
     enabled: activeView === "map",
   });
 
+  // Remember the current browse view (filters + map/list mode) so "Back to
+  // parks" from a detail page restores exactly what the user was looking at,
+  // instead of dropping them on an unfiltered list. The mount-time URL seed
+  // (parseParkFilterParams + ?view=) reconstructs it on return.
+  useEffect(() => {
+    try {
+      const params = new URLSearchParams(queryString);
+      if (activeView === "map") params.set("view", "map");
+      const qs = params.toString();
+      window.sessionStorage.setItem("parks:returnUrl", qs ? `/?${qs}` : "/");
+    } catch {
+      /* sessionStorage unavailable (e.g. privacy mode) — recall just no-ops */
+    }
+  }, [queryString, activeView]);
+
   const {
     presets,
     isAuthenticated,

--- a/test/app/operator/page.test.tsx
+++ b/test/app/operator/page.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
   usePathname: () => "/operator",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
 }));
 
 vi.mock("next/link", () => ({

--- a/test/app/submit/page.test.tsx
+++ b/test/app/submit/page.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
   usePathname: () => "/submit",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
 }));
 
 vi.mock("@/app/submit/SubmitSignInGate", () => ({

--- a/test/components/layout/AppHeader.test.tsx
+++ b/test/components/layout/AppHeader.test.tsx
@@ -9,6 +9,21 @@ vi.mock("next-auth/react", () => ({
   signOut: vi.fn(),
 }));
 
+// Local next/navigation mock exposing a stable push spy (the global setup mock
+// returns a fresh push each call, which can't be asserted on).
+const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+}));
+
 // Mock UI components
 vi.mock("@/components/ui/button", () => ({
   Button: ({ children, onClick, variant, size, className, asChild }: any) => (
@@ -173,5 +188,33 @@ describe("AppHeader", () => {
     const backLink = container.querySelector('a[href="/"]');
     expect(backLink).toBeInTheDocument();
     expect(backLink?.textContent).toContain("Back to Parks");
+  });
+
+  it("Back to Parks restores the stored browse view (filters + view)", () => {
+    window.sessionStorage.setItem(
+      "parks:returnUrl",
+      "/?state=Arkansas&view=map",
+    );
+
+    const { container } = render(<AppHeader showBackButton />);
+    fireEvent.click(
+      container.querySelector('a[aria-label="Back to Parks"]') as HTMLElement,
+    );
+
+    expect(mockPush).toHaveBeenCalledWith("/?state=Arkansas&view=map");
+
+    window.sessionStorage.clear();
+  });
+
+  it("Back to Parks falls back to the bare list when nothing is stored", () => {
+    window.sessionStorage.removeItem("parks:returnUrl");
+
+    const { container } = render(<AppHeader showBackButton />);
+    fireEvent.click(
+      container.querySelector('a[aria-label="Back to Parks"]') as HTMLElement,
+    );
+
+    // No stored view → the plain href="/" navigation is used, not router.push.
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What
Selecting a park to view its details, then hitting **Back to parks**, used to drop you on a bare, unfiltered list — you had to reapply filters and re-pick map/list every time. Now it returns you to the exact browse view you left (filters, search, sort, location, and map/list mode).

## How
The home browse UI already reconstructs its full state from the URL on mount (`parseParkFilterParams` + `?view=`); it just never persisted that state when you navigated away. This wires that up:

- **`OffroadParksApp`** stashes the current browse URL — the full filter query (`buildParkQueryString`) plus `view=map` when the map is active — in `sessionStorage` (`parks:returnUrl`) whenever filters or view change.
- **`AppHeader`'s "Back to parks"** reads that at click time and `router.push()`es to it, so the mount-time seed restores everything. Falls back to `/` when there's nothing stored; modified clicks (cmd/ctrl/middle) keep the plain new-tab behavior on `href="/"`.

Because `buildParkQueryString` and `parseParkFilterParams` use identical param names, the round-trip is exact.

## Scope / notes
- **No URL mirroring while browsing** — the address bar stays a clean `/` during browsing (unchanged behavior); the filters only appear in the URL once you return via Back.
- **No scroll/pagination restoration yet** — you land at the top of the restored list. Both URL mirroring (shareable filtered links) and scroll recall are natural follow-ups if you want them.
- Opening a park in a **new tab** starts a fresh `sessionStorage`, so Back there goes to the bare list — expected.

## Tests
Two new `AppHeader` cases (restores the stored view / falls back to bare list). Added `useRouter` to the `next/navigation` mocks in the submit + operator page tests, since `AppHeader` now calls `useRouter`. Full suite 2434 pass (only the pre-existing `leaflet.markercluster` / `recharts` missing-dep suites fail — unrelated).

## Verify on the preview
Apply some filters (and/or switch to map view) → open a park → **Back to parks**: your filters and view should be exactly as you left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)