### PR TITLE
feat(parks): shareable filtered URLs + scroll/pagination recall on back

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
   ArrowLeft,
@@ -44,12 +45,35 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
     await signOut({ callbackUrl: "/" });
   };
 
-  // "Back to Parks" returns to the browse view the user last had open (filters
-  // + map/list mode), which OffroadParksApp stashes in sessionStorage. Read at
-  // click time (SSR-safe, always fresh); the href="/" stays as the fallback and
-  // for modified clicks (cmd/ctrl/middle → open the bare list in a new tab).
+  // Did we arrive here straight from the browse list/map? OffroadParksApp sets
+  // this hint on a park-link click; consume it on mount (into a ref, so no
+  // extra render) so it reflects *this* page's arrival and can't go stale.
+  const cameFromBrowseListRef = useRef(false);
+  useEffect(() => {
+    try {
+      if (window.sessionStorage.getItem("parks:backHint")) {
+        cameFromBrowseListRef.current = true;
+        window.sessionStorage.removeItem("parks:backHint");
+      }
+    } catch {
+      /* sessionStorage unavailable — treat as a normal navigation */
+    }
+  }, []);
+
+  // "Back to Parks":
+  //   • Came straight from the browse list/map → router.back(), so the router
+  //     cache restores scroll + loaded pages + view exactly as they were.
+  //   • Otherwise → restore the last browse view fresh (filters + map/list) from
+  //     the URL OffroadParksApp stashed in sessionStorage.
+  // The href="/" stays as the fallback and for modified clicks (cmd/ctrl/middle
+  // → open the bare list in a new tab).
   const handleBackToParks = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+    if (cameFromBrowseListRef.current) {
+      e.preventDefault();
+      router.back();
+      return;
+    }
     try {
       const stored = window.sessionStorage.getItem("parks:returnUrl");
       if (stored && stored !== "/") {

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -218,20 +218,46 @@ function OffroadParksAppInner({
     enabled: activeView === "map",
   });
 
-  // Remember the current browse view (filters + map/list mode) so "Back to
-  // parks" from a detail page restores exactly what the user was looking at,
-  // instead of dropping them on an unfiltered list. The mount-time URL seed
-  // (parseParkFilterParams + ?view=) reconstructs it on return.
+  // Keep the address bar and the "Back to parks" return target in sync with the
+  // current browse view (filters + map/list mode).
+  //   • sessionStorage["parks:returnUrl"] lets the header restore the view on
+  //     return (see AppHeader).
+  //   • history.replaceState mirrors it into the URL so filtered/searched views
+  //     are shareable and survive a refresh. It uses the History API (not the
+  //     Next router), so it never triggers a navigation / server refetch, and it
+  //     preserves Next's own history state. Skipped while the route-planner owns
+  //     the URL via ?routeId.
   useEffect(() => {
     try {
       const params = new URLSearchParams(queryString);
       if (activeView === "map") params.set("view", "map");
       const qs = params.toString();
-      window.sessionStorage.setItem("parks:returnUrl", qs ? `/?${qs}` : "/");
+      const url = qs ? `/?${qs}` : "/";
+      window.sessionStorage.setItem("parks:returnUrl", url);
+      if (!new URLSearchParams(window.location.search).get("routeId")) {
+        window.history.replaceState(window.history.state, "", url);
+      }
     } catch {
-      /* sessionStorage unavailable (e.g. privacy mode) — recall just no-ops */
+      /* sessionStorage / history unavailable — recall & mirroring just no-op */
     }
   }, [queryString, activeView]);
+
+  // Flag navigations that start from a park card or map popup in this browse
+  // view. "Back to parks" on the detail page reads this and router.back()s, so
+  // the router cache restores scroll + loaded pages exactly (see AppHeader).
+  const handleBrowseParkClickCapture = (
+    e: React.MouseEvent<HTMLDivElement>,
+  ) => {
+    const link = (e.target as HTMLElement | null)?.closest?.(
+      'a[href^="/parks/"]',
+    );
+    if (!link) return;
+    try {
+      window.sessionStorage.setItem("parks:backHint", "1");
+    } catch {
+      /* sessionStorage unavailable — back just falls back to a fresh view */
+    }
+  };
 
   const {
     presets,
@@ -508,7 +534,10 @@ function OffroadParksAppInner({
             {filtersPanel}
           </div>
 
-          <div className="flex-1 min-w-0 w-full">
+          <div
+            className="flex-1 min-w-0 w-full"
+            onClickCapture={handleBrowseParkClickCapture}
+          >
             <Tabs
               value={activeView}
               onValueChange={(v) => setActiveView(v as "list" | "map")}

--- a/test/components/layout/AppHeader.test.tsx
+++ b/test/components/layout/AppHeader.test.tsx
@@ -9,15 +9,18 @@ vi.mock("next-auth/react", () => ({
   signOut: vi.fn(),
 }));
 
-// Local next/navigation mock exposing a stable push spy (the global setup mock
-// returns a fresh push each call, which can't be asserted on).
-const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }));
+// Local next/navigation mock exposing stable push/back spies (the global setup
+// mock returns fresh fns each call, which can't be asserted on).
+const { mockPush, mockBack } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockBack: vi.fn(),
+}));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
+    back: mockBack,
     replace: vi.fn(),
     refresh: vi.fn(),
-    back: vi.fn(),
     forward: vi.fn(),
     prefetch: vi.fn(),
   }),
@@ -56,6 +59,7 @@ vi.mock("@/components/auth/LoginDialog", () => ({
 describe("AppHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
   });
 
   it("should render the app title", () => {
@@ -216,5 +220,23 @@ describe("AppHeader", () => {
 
     // No stored view → the plain href="/" navigation is used, not router.push.
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("Back to Parks uses history back when arriving from the browse list", () => {
+    // The hint is set by OffroadParksApp on a park-link click; a filtered
+    // return URL is also present, but arriving from the list takes precedence
+    // so the router cache can restore scroll + loaded pages.
+    window.sessionStorage.setItem("parks:backHint", "1");
+    window.sessionStorage.setItem("parks:returnUrl", "/?state=Arkansas");
+
+    const { container } = render(<AppHeader showBackButton />);
+    fireEvent.click(
+      container.querySelector('a[aria-label="Back to Parks"]') as HTMLElement,
+    );
+
+    expect(mockBack).toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+    // The hint is consumed on mount so it can't leak to a later page.
+    expect(window.sessionStorage.getItem("parks:backHint")).toBeNull();
   });
 });


### PR DESCRIPTION
Two follow-ups to the "Back to parks" view recall (#212).

## 1. Shareable filtered URLs
`OffroadParksApp` now mirrors the current filter + map/list state into the address bar via `window.history.replaceState`, so a filtered/searched view is shareable and survives a refresh. Details:
- Uses the **History API, not the Next router** — so it never triggers a navigation or server refetch, and it preserves Next's own history `state`.
- Skipped while the route-planner owns the URL via `?routeId`.

## 2. Scroll + pagination recall ("land back on the exact park you clicked")
When you open a park **straight from the browse list/map**, "Back to parks" now `router.back()`s instead of pushing a fresh URL — so Next's **router cache restores the exact scroll position and the infinite-scroll pages** you had loaded.
- `OffroadParksApp` flags those navigations with an `onClickCapture` on park links → `sessionStorage["parks:backHint"]`. React event propagation reaches it even for **map-popup** links (react-leaflet portals bubble through the React tree).
- `AppHeader` **consumes the hint on mount** (into a ref, so it reflects *this* page's arrival and can't go stale) and `back()`s when it's set. Otherwise it keeps the existing filters+view push (from #212), then `href="/"`. Modified clicks (cmd/ctrl/middle) still open the bare list in a new tab.

**Graceful degradation:** if the browse page was evicted from the router cache, `back()` re-renders it from the mirrored URL — filters/view preserved, scroll reset.

**Why `back()` is safe here:** the hint is set only inside the browse view's click-capture and consumed by the very next page mount, so pages reached any other way (direct load, profile → park, nav links) fall through to the fresh push — they never wrongly `back()` to a non-browse page.

## Tests
New `AppHeader` case for the `back()` path; the existing recall cases (restore stored view / fall back to bare list) still pass; `sessionStorage` cleared between tests. Full suite 2435 pass (only the pre-existing `leaflet.markercluster` / `recharts` missing-dep suites fail — unrelated).

## Please verify on the preview
- **Shareable URL:** apply filters / switch to map → the address bar reflects it; copy-paste the URL into a new tab → same view.
- **Scroll recall:** scroll down the list, open a park, hit **Back to parks** → you land back at the same scroll position with the same pages loaded (and map/list view).
- **Direct load:** open a park detail URL directly → **Back to parks** goes to the browse list (doesn't leave the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)