### PR TITLE
fix(parks): make scroll recall actually work (deterministic replay)

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import {
   ArrowLeft,
@@ -45,35 +44,13 @@ export function AppHeader({ user, showBackButton }: AppHeaderProps) {
     await signOut({ callbackUrl: "/" });
   };
 
-  // Did we arrive here straight from the browse list/map? OffroadParksApp sets
-  // this hint on a park-link click; consume it on mount (into a ref, so no
-  // extra render) so it reflects *this* page's arrival and can't go stale.
-  const cameFromBrowseListRef = useRef(false);
-  useEffect(() => {
-    try {
-      if (window.sessionStorage.getItem("parks:backHint")) {
-        cameFromBrowseListRef.current = true;
-        window.sessionStorage.removeItem("parks:backHint");
-      }
-    } catch {
-      /* sessionStorage unavailable — treat as a normal navigation */
-    }
-  }, []);
-
-  // "Back to Parks":
-  //   • Came straight from the browse list/map → router.back(), so the router
-  //     cache restores scroll + loaded pages + view exactly as they were.
-  //   • Otherwise → restore the last browse view fresh (filters + map/list) from
-  //     the URL OffroadParksApp stashed in sessionStorage.
-  // The href="/" stays as the fallback and for modified clicks (cmd/ctrl/middle
-  // → open the bare list in a new tab).
+  // "Back to Parks" returns to the browse view the user last had open (filters
+  // + map/list mode), which OffroadParksApp stashes in sessionStorage. Read at
+  // click time (SSR-safe, always fresh); href="/" stays as the fallback and for
+  // modified clicks (cmd/ctrl/middle → open the bare list in a new tab). Scroll
+  // + pagination are restored by OffroadParksApp on arrival.
   const handleBackToParks = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
-    if (cameFromBrowseListRef.current) {
-      e.preventDefault();
-      router.back();
-      return;
-    }
     try {
       const stored = window.sessionStorage.getItem("parks:returnUrl");
       if (stored && stored !== "/") {

--- a/src/components/ui/OffroadParksApp.tsx
+++ b/src/components/ui/OffroadParksApp.tsx
@@ -242,22 +242,84 @@ function OffroadParksAppInner({
     }
   }, [queryString, activeView]);
 
-  // Flag navigations that start from a park card or map popup in this browse
-  // view. "Back to parks" on the detail page reads this and router.back()s, so
-  // the router cache restores scroll + loaded pages exactly (see AppHeader).
+  // --- Scroll + pagination recall ---
+  // Home is force-dynamic, so returning via the URL remounts the list at page 0
+  // and Next's scroll restoration lands on a too-short list. Instead we snapshot
+  // what was loaded when a park was opened and rebuild it on return.
+  const scrollRestoreRef = useRef<{
+    url: string;
+    count: number;
+    href: string | null;
+  } | null>(null);
+  const restoreAttemptsRef = useRef(0);
+
+  // On a park-link click in the LIST view, snapshot the browse URL (to confirm
+  // we return to the same view), how many parks were loaded (to replay the
+  // infinite-scroll pages), and which park link was clicked (to scroll to).
   const handleBrowseParkClickCapture = (
     e: React.MouseEvent<HTMLDivElement>,
   ) => {
+    if (activeView !== "list") return;
     const link = (e.target as HTMLElement | null)?.closest?.(
       'a[href^="/parks/"]',
     );
     if (!link) return;
     try {
-      window.sessionStorage.setItem("parks:backHint", "1");
+      window.sessionStorage.setItem(
+        "parks:scrollSnap",
+        JSON.stringify({
+          url: window.location.pathname + window.location.search,
+          count: listParks.length,
+          href: link.getAttribute("href"),
+        }),
+      );
     } catch {
-      /* sessionStorage unavailable — back just falls back to a fresh view */
+      /* sessionStorage unavailable — scroll recall just no-ops */
     }
   };
+
+  // Mount: adopt a snapshot only if we're back on the exact same browse view
+  // (one-shot; declared before the replay effect so the ref is set first).
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem("parks:scrollSnap");
+      if (!raw) return;
+      window.sessionStorage.removeItem("parks:scrollSnap");
+      const snap = JSON.parse(raw);
+      if (snap?.url === window.location.pathname + window.location.search) {
+        scrollRestoreRef.current = snap;
+      }
+    } catch {
+      /* ignore malformed / unavailable snapshot */
+    }
+  }, []);
+
+  // Replay loaded pages up to the snapshot count, then scroll the clicked park
+  // into view. Runs on every list update; ref-guarded and attempt-capped so it
+  // always terminates (even if a page fetch fails and can't make progress).
+  useEffect(() => {
+    const target = scrollRestoreRef.current;
+    if (!target) return;
+    if (listParks.length >= target.count || !hasMore) {
+      scrollRestoreRef.current = null;
+      const href = target.href;
+      requestAnimationFrame(() => {
+        if (!href) return;
+        document.querySelectorAll('a[href^="/parks/"]').forEach((card) => {
+          if (card.getAttribute("href") === href) {
+            card.scrollIntoView({ block: "center" });
+          }
+        });
+      });
+    } else if (!isLoading && !isLoadingMore) {
+      if (restoreAttemptsRef.current >= 40) {
+        scrollRestoreRef.current = null; // safety cap — stop replaying
+        return;
+      }
+      restoreAttemptsRef.current += 1;
+      loadMore();
+    }
+  }, [listParks.length, hasMore, isLoading, isLoadingMore, loadMore]);
 
   const {
     presets,

--- a/test/components/layout/AppHeader.test.tsx
+++ b/test/components/layout/AppHeader.test.tsx
@@ -9,16 +9,13 @@ vi.mock("next-auth/react", () => ({
   signOut: vi.fn(),
 }));
 
-// Local next/navigation mock exposing stable push/back spies (the global setup
-// mock returns fresh fns each call, which can't be asserted on).
-const { mockPush, mockBack } = vi.hoisted(() => ({
-  mockPush: vi.fn(),
-  mockBack: vi.fn(),
-}));
+// Local next/navigation mock exposing a stable push spy (the global setup mock
+// returns a fresh push each call, which can't be asserted on).
+const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
-    back: mockBack,
+    back: vi.fn(),
     replace: vi.fn(),
     refresh: vi.fn(),
     forward: vi.fn(),
@@ -220,23 +217,5 @@ describe("AppHeader", () => {
 
     // No stored view → the plain href="/" navigation is used, not router.push.
     expect(mockPush).not.toHaveBeenCalled();
-  });
-
-  it("Back to Parks uses history back when arriving from the browse list", () => {
-    // The hint is set by OffroadParksApp on a park-link click; a filtered
-    // return URL is also present, but arriving from the list takes precedence
-    // so the router cache can restore scroll + loaded pages.
-    window.sessionStorage.setItem("parks:backHint", "1");
-    window.sessionStorage.setItem("parks:returnUrl", "/?state=Arkansas");
-
-    const { container } = render(<AppHeader showBackButton />);
-    fireEvent.click(
-      container.querySelector('a[aria-label="Back to Parks"]') as HTMLElement,
-    );
-
-    expect(mockBack).toHaveBeenCalled();
-    expect(mockPush).not.toHaveBeenCalled();
-    // The hint is consumed on mount so it can't leak to a later page.
-    expect(window.sessionStorage.getItem("parks:backHint")).toBeNull();
   });
 });


### PR DESCRIPTION
## Why the first attempt failed
#214 tried to restore scroll by having "Back to parks" `router.back()` when you'd come from a park click, relying on Next's router cache. But **home is `force-dynamic`**, so `back()` re-renders it fresh at page 0, and the infinite-scroll pages are client state that resets on remount. Next's scroll restoration then lands on a too-short list and clamps to the bottom. Result: filters recalled (they're in the URL), scroll not.

## The fix — deterministic replay (no router-cache dependency)
- **On a park-link click in list view**, `OffroadParksApp` snapshots into `sessionStorage`: the browse URL, how many parks were loaded, and the clicked park's `href`.
- **On return to the same URL**, it replays `loadMore()` until that many parks are loaded, then `scrollIntoView()`s the clicked park. Anchoring to the **park element** (not a Y offset) is robust to card-height / image-load shifts. The loop is ref-guarded, one-shot, and attempt-capped (≤40 pages) so it always terminates — even if a page fetch fails.

`AppHeader` reverts to the plain filters+view push from #212 (the `router.back()` hint machinery is removed); scroll/pagination restore now lives entirely in `OffroadParksApp`. URL mirroring (shareable filtered URLs, which you confirmed works) is untouched.

### Trade-off
Returning replays the pages you'd scrolled through, so you'll briefly see the list rebuild (a second or two of loading for deep scrolls) before it jumps to your park. That's the cost of not being able to preserve client state across a dynamic route — it beats losing your place.

## Tests
`AppHeader` recall tests updated (back to push-only); full suite 2434 pass (only the pre-existing `leaflet.markercluster` / `recharts` missing-dep suites fail — unrelated).

## Please verify on the preview (I can't run this env live)
Scroll a good way down the list → open a park → **Back to parks** → the list should rebuild and land you on the park you clicked. (Map view and no-filter cases should behave too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)