### PR TITLE
Separate park attribute rows with dividers and spacing

### DIFF
--- a/src/features/parks/detail/components/ParkAttributesCards.tsx
+++ b/src/features/parks/detail/components/ParkAttributesCards.tsx
@@ -110,7 +110,7 @@ function AttrRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 sm:flex-row sm:items-baseline sm:gap-3">
+    <div className="flex flex-col gap-1.5 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-baseline sm:gap-3">
       <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground sm:w-20 sm:shrink-0 sm:pt-0.5">
         {label}
       </span>
@@ -135,7 +135,7 @@ export function ParkAttributesCards({ park }: ParkAttributesCardsProps) {
 
   return (
     <Card>
-      <CardContent className="space-y-3 py-4">
+      <CardContent className="divide-y divide-border/60 py-4">
         {park.terrain.length > 0 && (
           <AttrRow label="Terrain">
             {park.terrain.map((terrain) => (


### PR DESCRIPTION
## Summary

The terrain / vehicles / amenities chip strip in the park detail "at a glance" card (`ParkAttributesCards`) read as one dense block. This adds visual separation between the three rows.

- Hairline dividers (`divide-y divide-border/60`) between the Terrain, Vehicles, and Amenities rows.
- Per-row vertical padding (`py-3`) for breathing room, with `first:pt-0 last:pb-0` so the card's own padding stays balanced and it degrades gracefully when a park has only one or two of the groups.

## Verification
- `tsc --noEmit` and eslint clean; the `ParkAttributesCards` tests pass.
- Rendered in the running app in light and dark to confirm the dividers read well on both backgrounds.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6goDXmdR6LHSC7KHrf6CN)_